### PR TITLE
Fix broken avatar image for users without a custom Discord avatar

### DIFF
--- a/apps/web/components/member/avatar.tsx
+++ b/apps/web/components/member/avatar.tsx
@@ -10,7 +10,7 @@ import Fallback from '@/public/images/fallback_pfp.png'
 
 export default function Avatar({ user, borderRadius = '100%' }: { user?: User, borderRadius?: string }) {
 
-    const [image, setImage] = useState<string | StaticImageData>(user ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}?size=256` : Fallback)
+    const [image, setImage] = useState<string | StaticImageData>(user?.avatarURL || Fallback)
 
     return (
         <Image

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -37,6 +37,12 @@ const nextConfig: NextConfig = {
 
 			{
 				protocol: 'https',
+				hostname: 'cdn.discordapp.com',
+				pathname: '/embed/avatars/**',
+			},
+
+			{
+				protocol: 'https',
 				hostname: '*.asotmilsim.com',
 				pathname: '/api/gallery/fetch/**',
 			},


### PR DESCRIPTION
## Summary

`Avatar.tsx` was reconstructing the Discord CDN URL directly from the raw avatar hash (`.../avatars/{id}/{avatar}?size=256`), which produces a literal `.../avatars/{id}/null` request — and a repeating 404 — whenever a member has no custom avatar set. This was already showing up in logs (`upstream image response failed ... 404`).

- Use `User.avatarURL` instead, which `login/callback` and `init-db.mjs` already compute correctly, including Discord's real default-avatar fallback (`embed/avatars/{(id >> 22) % 6}.png` for users with no custom avatar) — so the fix also makes the site's fallback avatar visually match what Discord itself shows for that user, not a generic placeholder.
- Adds `cdn.discordapp.com`'s `/embed/avatars/**` path to `next.config.ts`'s image `remotePatterns`, which was missing (only `/avatars/**` and `/banners/**` were allowlisted) and would otherwise have made the fallback URL itself get rejected by Next's image optimizer.

## Test plan

- [x] `npx tsc --noEmit` clean in `apps/web`
- [ ] Live test: view a member with no custom Discord avatar set, confirm their Discord default avatar renders (no 404, no broken image), confirm a member with a custom avatar is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)