### PR TITLE
feat(orbat): sync member ranks from the ORBAT spreadsheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 # tracked nowhere, same reasoning as /storage. The dry-run report the importer
 # prints is the audit artifact worth keeping, not the input.
 /ASOT_Member_History_*.csv
+/ASOT - ORBAT*.csv

--- a/apps/web/lib/military/history-match.ts
+++ b/apps/web/lib/military/history-match.ts
@@ -83,9 +83,12 @@ export function buildMemberIndex(members: MatchCandidate[]): Map<string, MatchCa
 }
 
 /** Empty when every override names a member that exists. */
-export function validateOverrides(members: MatchCandidate[]): string[] {
+export function validateOverrides(
+    members: MatchCandidate[],
+    overrides: Record<string, string> = MEMBER_OVERRIDES,
+): string[] {
     const usernames = new Set(members.map(m => m.username))
-    return Object.entries(MEMBER_OVERRIDES)
+    return Object.entries(overrides)
         .filter(([, username]) => !usernames.has(username))
         .map(([csvName, username]) => `override "${csvName}" names username "${username}", which does not exist`)
 }
@@ -97,13 +100,25 @@ export function validateOverrides(members: MatchCandidate[]): string[] {
  * reports (a missing override target, two names landing on one member) merge
  * two people's service records, which is unrecoverable once the old arrays
  * have been replaced.
+ *
+ * `extraOverrides` lets a second import add adjudications of its own without
+ * editing the history table above. The two files do not cover the same names:
+ * the history CSV spans everyone who ever served, the ORBAT only who is
+ * currently seated, so each surfaces contested names the other never sees.
+ * Keeping them apart also keeps each table's evidence with the import that
+ * gathered it.
  */
-export function resolveMembers(csvNames: string[], members: MatchCandidate[]): {
+export function resolveMembers(
+    csvNames: string[],
+    members: MatchCandidate[],
+    extraOverrides: Record<string, string> = {},
+): {
     resolved: Map<string, MatchCandidate>
     unresolved: string[]
     errors: string[]
 } {
-    const errors = validateOverrides(members)
+    const overrides = { ...MEMBER_OVERRIDES, ...extraOverrides }
+    const errors = validateOverrides(members, overrides)
     const byUsername = new Map(members.map(m => [m.username, m]))
     const index = buildMemberIndex(members)
 
@@ -111,7 +126,7 @@ export function resolveMembers(csvNames: string[], members: MatchCandidate[]): {
     const unresolved: string[] = []
 
     for (const csvName of csvNames) {
-        const override = MEMBER_OVERRIDES[csvName]
+        const override = overrides[csvName]
         if (override) {
             const member = byUsername.get(override)
             if (member) resolved.set(csvName, member)

--- a/apps/web/lib/military/orbat-ranks.test.ts
+++ b/apps/web/lib/military/orbat-ranks.test.ts
@@ -1,0 +1,183 @@
+import { describe, test, expect } from 'vitest'
+import {
+    splitCsvRow, normaliseCell, canonicalAbbr, splitRankedName,
+    parseOrbat, orbatRanks, repairedName,
+} from './orbat-ranks'
+
+describe('splitCsvRow', () => {
+    test('splits a plain row', () => {
+        expect(splitCsvRow('a,b,c')).toEqual(['a', 'b', 'c'])
+    })
+
+    test('keeps empty cells, so column positions are preserved', () => {
+        expect(splitCsvRow(',,x,,')).toEqual(['', '', 'x', '', ''])
+    })
+
+    test('a comma inside quotes does not split the cell', () => {
+        expect(splitCsvRow('a,"b,c",d')).toEqual(['a', 'b,c', 'd'])
+    })
+
+    // The reason lib/orbat/csv-parser's parseRow is not reused. It toggles on
+    // every quote, so the second quote of an escaped pair re-enters quoted
+    // state and the following comma stops separating cells — every cell after
+    // it lands one column to the left, which in a grid this wide silently
+    // reassigns people to other sections.
+    test('an escaped quote does not shift the following columns', () => {
+        expect(splitCsvRow('a,"say ""hi""",b,c')).toEqual(['a', 'say "hi"', 'b', 'c'])
+    })
+
+    test('a quoted empty cell is still a cell', () => {
+        expect(splitCsvRow('a,"",b')).toEqual(['a', '', 'b'])
+    })
+})
+
+describe('normaliseCell', () => {
+    test('collapses runs of whitespace', () => {
+        expect(normaliseCell('  PTE   Johno ')).toBe('PTE Johno')
+    })
+
+    // "PTE (SL) Wanderer" in the sheet. Left alone, the first token is "PTE"
+    // and the member imports one rank too low.
+    test('rejoins a proficiency suffix typed with a space before it', () => {
+        expect(normaliseCell('PTE (SL) Wanderer')).toBe('PTE(SL) Wanderer')
+    })
+
+    test('leaves a parenthesised part that is not the rank suffix alone', () => {
+        expect(normaliseCell('COMPANY RESERVISTS (ACTIVE)')).toBe('COMPANY RESERVISTS (ACTIVE)')
+    })
+})
+
+describe('canonicalAbbr', () => {
+    test('accepts a catalog abbreviation', () => {
+        expect(canonicalAbbr('CPL(S)')).toBe('CPL(S)')
+        expect(canonicalAbbr('MAJGEN')).toBe('MAJGEN')
+    })
+
+    test('uppercases a lowercased one', () => {
+        expect(canonicalAbbr('pte(l)')).toBe('PTE(L)')
+    })
+
+    // "TRP(S) Pluto" — Trooper is TPR. The transposition is in the sheet and
+    // in the member's stored name.
+    test('corrects a transposed abbreviation, keeping its suffix', () => {
+        expect(canonicalAbbr('TRP(S)')).toBe('TPR(S)')
+        expect(canonicalAbbr('TRP')).toBe('TPR')
+    })
+
+    test('rejects anything that is not a rank', () => {
+        expect(canonicalAbbr('Sapper')).toBeNull()
+        expect(canonicalAbbr('COMPANY')).toBeNull()
+        expect(canonicalAbbr('Zeus')).toBeNull()
+    })
+
+    // A typo correction must not invent a rank the catalog does not have.
+    test('a corrected prefix with an impossible suffix is still rejected', () => {
+        expect(canonicalAbbr('TRP(Z)')).toBeNull()
+    })
+})
+
+describe('splitRankedName', () => {
+    test('splits rank from name', () => {
+        expect(splitRankedName('CPL(S) Nadric')).toEqual({ abbr: 'CPL(S)', name: 'Nadric' })
+    })
+
+    test('keeps a name containing spaces', () => {
+        expect(splitRankedName('LT(C) Res Head')).toEqual({ abbr: 'LT(C)', name: 'Res Head' })
+    })
+
+    test('applies the suffix rejoin and the typo map together', () => {
+        expect(splitRankedName('PTE (SL) Wanderer')).toEqual({ abbr: 'PTE(SL)', name: 'Wanderer' })
+        expect(splitRankedName('TRP(S) Pluto')).toEqual({ abbr: 'TPR(S)', name: 'Pluto' })
+    })
+
+    // Every heading, job title and stray label in the sheet lands here.
+    test('rejects a cell that is not a person', () => {
+        expect(splitRankedName('Section Commander')).toBeNull()
+        expect(splitRankedName('1-3 ECHO - COMBAT ENGINEERS')).toBeNull()
+        expect(splitRankedName('COMPANY RESERVISTS (ACTIVE)')).toBeNull()
+        expect(splitRankedName('ASOT Discord')).toBeNull()
+        expect(splitRankedName('')).toBeNull()
+        expect(splitRankedName('PTE')).toBeNull()
+        expect(splitRankedName('PTE ')).toBeNull()
+    })
+})
+
+describe('parseOrbat', () => {
+    const sheet = [
+        ',1-1 - Infantry Platoon,,,,,,COMPANY RESERVISTS (ACTIVE)',
+        ',Section Commander,,CPL(S) Nadric,,,,PTE(S) Slaydevil',
+        ',Machinegunner,,,,,,REC Frosty',
+    ].join('\r\n')
+
+    test('finds people anywhere in the grid and records where', () => {
+        expect(parseOrbat(sheet)).toEqual([
+            { abbr: 'CPL(S)', name: 'Nadric',    line: 2, col: 3 },
+            { abbr: 'PTE(S)', name: 'Slaydevil', line: 2, col: 7 },
+            { abbr: 'REC',    name: 'Frosty',    line: 3, col: 7 },
+        ])
+    })
+
+    test('strips the UTF-8 BOM', () => {
+        expect(parseOrbat('﻿REC Frosty')).toHaveLength(1)
+    })
+
+    test('an empty vacancy row yields nobody', () => {
+        expect(parseOrbat(',Machinegunner,,,,,,')).toEqual([])
+    })
+})
+
+describe('orbatRanks', () => {
+    test('one seat gives one rank', () => {
+        const { ranks, conflicts } = orbatRanks(',CPL(S) Nadric')
+        expect(ranks.get('Nadric')!.abbr).toBe('CPL(S)')
+        expect(conflicts).toEqual([])
+    })
+
+    // Sitting in a section and appearing in the reservist column is normal.
+    test('two seats that agree are not a conflict', () => {
+        const { ranks, conflicts } = orbatRanks('REC Fade,,REC Fade')
+        expect(ranks.get('Fade')!.abbr).toBe('REC')
+        expect(conflicts).toEqual([])
+    })
+
+    test('matching is case-insensitive across seats', () => {
+        const { ranks, conflicts } = orbatRanks('REC Fade,,REC fade')
+        expect(ranks.size).toBe(1)
+        expect(conflicts).toEqual([])
+    })
+
+    // The sheet is the authority, so a sheet that contradicts itself has not
+    // decided — report it rather than pick a seat.
+    test('two seats that disagree are reported and yield no rank', () => {
+        const { ranks, conflicts } = orbatRanks('PTE Bumble,,SAP Bumble')
+        expect(ranks.has('Bumble')).toBe(false)
+        expect(conflicts).toHaveLength(1)
+        expect(conflicts[0].seats.map(s => s.abbr)).toEqual(['PTE', 'SAP'])
+    })
+})
+
+describe('repairedName', () => {
+    // All three are live: an earlier import split "PTE (SL) Wanderer" on its
+    // first space and stored the remainder as the member's name.
+    test('removes an orphaned proficiency suffix', () => {
+        expect(repairedName('(SL) Wanderer')).toBe('Wanderer')
+        expect(repairedName('(L) Dawn')).toBe('Dawn')
+    })
+
+    test('removes a whole rank left on the name', () => {
+        expect(repairedName('TRP(S) Pluto')).toBe('Pluto')
+        expect(repairedName('PTE(S) Koda')).toBe('Koda')
+    })
+
+    test('leaves a clean name alone', () => {
+        expect(repairedName('Koda')).toBeNull()
+        expect(repairedName('Agent Dove')).toBeNull()
+        expect(repairedName('')).toBeNull()
+    })
+
+    // A name is not a rank cell: only a leading rank or orphan suffix is
+    // stripped, and never more than one.
+    test('strips only the leading rank, not a later one', () => {
+        expect(repairedName('PTE(S) PTE Koda')).toBe('PTE Koda')
+    })
+})

--- a/apps/web/lib/military/orbat-ranks.ts
+++ b/apps/web/lib/military/orbat-ranks.ts
@@ -1,0 +1,178 @@
+/**
+ * Reading current ranks out of the ORBAT spreadsheet.
+ *
+ * The ORBAT is a grid, not a table: every section is a pair of adjacent
+ * columns (job title, then occupant) laid out side by side across the sheet,
+ * and the same columns change meaning partway down the file. Rather than
+ * model the layout, this reads every cell and keeps the ones that look like a
+ * person — a known rank abbreviation followed by a name. Section headings,
+ * job titles and the sheet's own furniture have no rank prefix and fall out.
+ *
+ * Pure: no database, no filesystem, no clock.
+ */
+import { isRankAbbr } from '@asot/lib'
+
+/**
+ * Misspelled rank abbreviations in the sheet, mapped to the catalog's.
+ *
+ * Only transpositions and other unambiguous slips belong here. A prefix that
+ * could plausibly be a rank the catalog does not have must stay unrecognised,
+ * so the cell is reported rather than silently assigned the wrong rank.
+ */
+export const ABBR_TYPOS: Record<string, string> = {
+    TRP: 'TPR',   // Trooper — appears as "TRP(S) Pluto"
+}
+
+/**
+ * Splits one CSV line into cells.
+ *
+ * `parseRow` in lib/orbat/csv-parser is not reused: it toggles on every quote
+ * character, so a field containing an escaped quote ("" inside a quoted cell)
+ * loses the quote and, worse, flips the parser's state for the rest of the
+ * line — shifting every cell after it into the wrong column. Today's export
+ * has no quotes anywhere, so both parsers agree on it; a future one with a
+ * comma or an apostrophe-heavy cell would not be so forgiving, and a silent
+ * column shift is exactly the failure this file cannot survive.
+ */
+export function splitCsvRow(line: string): string[] {
+    const cells: string[] = []
+    let current = ''
+    let quoted = false
+
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i]
+        if (quoted) {
+            if (char !== '"') current += char
+            else if (line[i + 1] === '"') { current += '"'; i++ }
+            else quoted = false
+        } else if (char === '"') {
+            quoted = true
+        } else if (char === ',') {
+            cells.push(current)
+            current = ''
+        } else {
+            current += char
+        }
+    }
+    cells.push(current)
+    return cells
+}
+
+export type RankedName = {
+    abbr: string
+    name: string
+}
+
+export type OrbatCell = RankedName & {
+    /** 1-based line in the source file, so a conflict can be traced back. */
+    line: number
+    /** 0-based column, which identifies the section the person was sitting in. */
+    col: number
+}
+
+/**
+ * A cell as it should have been written.
+ *
+ * Collapses runs of whitespace, and rejoins a rank whose proficiency suffix
+ * was typed with a space before it ("PTE (SL) Wanderer"). The rejoin is
+ * anchored to the start so it can only ever touch the rank prefix — a name or
+ * heading with a parenthesised part further along is left alone.
+ */
+export function normaliseCell(raw: string): string {
+    return raw.replace(/\s+/g, ' ').trim().replace(/^([A-Za-z][A-Za-z/.-]*) (\([A-Za-z]{1,2}\))/, '$1$2')
+}
+
+/** The catalog spelling of an abbreviation, or null if it is not a rank. */
+export function canonicalAbbr(raw: string): string | null {
+    const value = raw.toUpperCase()
+    if (isRankAbbr(value)) return value
+
+    // Retry with the prefix corrected, so "TRP(S)" reaches "TPR(S)".
+    const root = value.split('(')[0]
+    const fixed = ABBR_TYPOS[root]
+    if (!fixed) return null
+    const corrected = fixed + value.slice(root.length)
+    return isRankAbbr(corrected) ? corrected : null
+}
+
+/**
+ * Splits "CPL(S) Nadric" into its rank and name, or returns null when the
+ * cell is not a person — which is what every heading and job title does.
+ */
+export function splitRankedName(raw: string): RankedName | null {
+    const cell = normaliseCell(raw)
+    const space = cell.indexOf(' ')
+    if (space < 1) return null
+
+    const abbr = canonicalAbbr(cell.slice(0, space))
+    if (!abbr) return null
+
+    const name = cell.slice(space + 1).trim()
+    return name ? { abbr, name } : null
+}
+
+/** Every cell in the sheet that names a person, in reading order. */
+export function parseOrbat(text: string): OrbatCell[] {
+    const found: OrbatCell[] = []
+
+    text.replace(/^﻿/, '').split(/\r?\n/).forEach((line, index) => {
+        splitCsvRow(line).forEach((raw, col) => {
+            const person = splitRankedName(raw)
+            if (person) found.push({ ...person, line: index + 1, col })
+        })
+    })
+    return found
+}
+
+export type OrbatConflict = {
+    name: string
+    seats: OrbatCell[]
+}
+
+/**
+ * The sheet's ranks, one per person.
+ *
+ * Appearing twice is normal — a reservist can also hold a seat in a section —
+ * and costs nothing while both cells agree. Two cells that disagree are a
+ * mistake in the sheet, and this reports them rather than picking one: the
+ * whole point of the sync is that the sheet is the authority, and an
+ * authority that contradicts itself has not decided yet.
+ */
+export function orbatRanks(text: string): { ranks: Map<string, OrbatCell>; conflicts: OrbatConflict[] } {
+    const seats = new Map<string, OrbatCell[]>()
+    for (const cell of parseOrbat(text)) {
+        const key = cell.name.toLowerCase()
+        seats.set(key, (seats.get(key) ?? []).concat(cell))
+    }
+
+    const ranks = new Map<string, OrbatCell>()
+    const conflicts: OrbatConflict[] = []
+    for (const list of seats.values()) {
+        if (list.every(c => c.abbr === list[0].abbr)) ranks.set(list[0].name, list[0])
+        else conflicts.push({ name: list[0].name, seats: list })
+    }
+    return { ranks, conflicts }
+}
+
+/**
+ * A stored `name` with a rank prefix still attached, repaired — or null when
+ * the name is already clean.
+ *
+ * An earlier import split "PTE (SL) Wanderer" on its first space and stored
+ * the remainder as the member's name, which is how three members ended up
+ * called "(SL) Wanderer", "(L) Dawn" and "TRP(S) Pluto". Both shapes are
+ * recognised: a whole rank the split never removed, and the orphaned suffix
+ * left behind when it removed only half of one.
+ */
+export function repairedName(stored: string): string | null {
+    const value = stored.replace(/\s+/g, ' ').trim()
+    const space = value.indexOf(' ')
+    if (space < 1) return null
+
+    const prefix = value.slice(0, space)
+    const isOrphanSuffix = /^\([A-Za-z]{1,2}\)$/.test(prefix)
+    if (!isOrphanSuffix && !canonicalAbbr(prefix)) return null
+
+    const rest = value.slice(space + 1).trim()
+    return rest && rest !== value ? rest : null
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "start": "dotenv -v NODE_ENV=production -e ../../.env -- node server.mjs",
     "lint": "next lint",
     "import:history": "dotenv -e ../../.env -- tsx scripts/import-member-history.ts",
+    "sync:ranks": "dotenv -e ../../.env -- tsx scripts/sync-orbat-ranks.ts",
     "test:unit": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/apps/web/scripts/sync-orbat-ranks.ts
+++ b/apps/web/scripts/sync-orbat-ranks.ts
@@ -1,0 +1,143 @@
+/**
+ * Sync every member's current rank to the ORBAT spreadsheet.
+ *
+ *   npm --prefix apps/web run sync:ranks -- <csv>           # dry run
+ *   npm --prefix apps/web run sync:ranks -- <csv> --apply   # writes
+ *
+ * Dry run is the default. The report lists every rank it would change, every
+ * name it could not resolve and every seat the sheet contradicts itself on —
+ * read it before passing --apply.
+ *
+ * Writes `milpac.currentRank`, and repairs any `name` still carrying a rank
+ * prefix (see repairedName). Nothing else is touched: seats, roles and ORBAT
+ * positions are the mass-import's job, not this one.
+ */
+import { readFileSync } from 'fs'
+import { MongoClient, type Filter, type AnyBulkWriteOperation } from 'mongodb'
+import { orbatRanks, repairedName } from '@/lib/military/orbat-ranks'
+import { resolveMembers, type MatchCandidate } from '@/lib/military/history-match'
+
+const args = process.argv.slice(2)
+const apply = args.includes('--apply')
+const csvPath = args.find(a => !a.startsWith('--'))
+
+function die(message: string): never {
+    console.error(`\n  ERROR  ${message}\n`)
+    process.exit(1)
+}
+
+if (!csvPath) die('usage: sync:ranks -- <path-to-orbat-csv> [--apply]')
+
+const { MONGO_URI, MONGO_DB } = process.env
+if (!MONGO_URI || !MONGO_DB) die('MONGO_URI and MONGO_DB must be set')
+
+/**
+ * Names the index cannot settle that the history import never had to face,
+ * adjudicated against stored history and Discord nicknames.
+ *
+ * MEMBER_OVERRIDES in lib/military/history-match.ts still applies underneath
+ * this — six of the ORBAT's contested names are already settled there.
+ */
+const ORBAT_OVERRIDES: Record<string, string> = {
+    // "hackjack." also answers to Kyle through their Discord global name, and
+    // they outrank the sheet's PTE Kyle at PTE(L) — matching the wrong one
+    // would read as a demotion.
+    Kyle: 'kyle11231',
+    // "marshall_580" answers to Frog the same way; "billyfrog." is nicknamed
+    // REC Frog in the guild, which is the seat the sheet is filling.
+    Frog: 'billyfrog.',
+}
+
+async function main() {
+    const text = readFileSync(csvPath!, 'utf-8')
+    const { ranks, conflicts } = orbatRanks(text)
+    if (ranks.size === 0) die('no ranked names found — is this the ORBAT export?')
+
+    const client = new MongoClient(MONGO_URI!)
+    await client.connect()
+    try {
+        const users = client.db(MONGO_DB!).collection<User>('users')
+        const all = await users.find({}).toArray()
+        const candidates: MatchCandidate[] = all.map(u => ({
+            _id: u._id, username: u.username, name: u.name,
+            globalName: u.globalName, nickname: u.guild?.nickname,
+        }))
+
+        const { resolved, unresolved, errors } = resolveMembers([...ranks.keys()], candidates, ORBAT_OVERRIDES)
+        // Throws rather than die()ing: die() exits immediately and would skip
+        // the finally block, leaving the Mongo client open.
+        if (errors.length) throw new Error(`member resolution failed:\n         ${errors.join('\n         ')}`)
+
+        const byId = new Map(all.map(u => [u._id, u]))
+        const updates = new Map<string, Record<string, string>>()
+
+        const changes: string[] = []
+        let unchanged = 0
+        for (const [orbatName, seat] of ranks) {
+            const match = resolved.get(orbatName)
+            if (!match) continue
+
+            const member = byId.get(match._id)!
+            const current = member.milpac?.currentRank
+            if (current === seat.abbr) { unchanged++; continue }
+
+            updates.set(member._id, { 'milpac.currentRank': seat.abbr })
+            changes.push(`${orbatName.padEnd(18)} ${(current ?? '—').padEnd(8)} -> ${seat.abbr.padEnd(8)} ${member.username}`)
+        }
+
+        // Independent of the sheet: a stored name carrying a rank is wrong
+        // whether or not that member is seated in this export.
+        const repairs: string[] = []
+        for (const member of all) {
+            const fixed = member.name ? repairedName(member.name) : null
+            if (!fixed) continue
+
+            updates.set(member._id, { ...(updates.get(member._id) ?? {}), name: fixed })
+            repairs.push(`${String(member.name).padEnd(18)} -> ${fixed.padEnd(18)} ${member.username}`)
+        }
+
+        console.log(`\nORBAT RANK SYNC — ${apply ? 'APPLYING' : 'DRY RUN (no changes written; pass --apply to write)'}\n`)
+        console.log(`Source   ${csvPath}`)
+        console.log(`Names    ${ranks.size} found in the sheet\n`)
+        console.log('Members')
+        console.log(`  ${String(resolved.size).padStart(4)}  resolved`)
+        console.log(`  ${String(unresolved.length).padStart(4)}  unresolved — skipped`)
+        for (const name of unresolved) console.log(`          ${name}  (no single member answers to this name)`)
+        console.log('')
+        console.log('Ranks')
+        console.log(`  ${String(unchanged).padStart(4)}  already correct`)
+        console.log(`  ${String(changes.length).padStart(4)}  changing`)
+        for (const line of changes) console.log(`          ${line}`)
+        console.log('')
+        console.log('Names')
+        console.log(`  ${String(repairs.length).padStart(4)}  carrying a rank prefix — repaired`)
+        for (const line of repairs) console.log(`          ${line}`)
+        console.log('')
+        console.log('Sheet conflicts')
+        console.log(`  ${String(conflicts.length).padStart(4)}  name(s) seated twice at different ranks — skipped`)
+        for (const c of conflicts) {
+            console.log(`          ${c.name}: ${c.seats.map(s => `${s.abbr} @ line ${s.line} col ${s.col}`).join('  vs  ')}`)
+        }
+        console.log(`\n  ${String(updates.size).padStart(4)}  member(s) to write\n`)
+
+        if (!apply) {
+            console.log('Dry run — nothing written. Re-run with --apply to apply.\n')
+            return
+        }
+
+        if (updates.size === 0) {
+            console.log('Nothing to write — every rank already matches.\n')
+            return
+        }
+
+        const ops: AnyBulkWriteOperation<User>[] = [...updates].map(([_id, set]) => ({
+            updateOne: { filter: { _id } as Filter<User>, update: { $set: set } },
+        }))
+        const result = await client.db(MONGO_DB!).collection<User>('users').bulkWrite(ops)
+        console.log(`Wrote ${result.modifiedCount} member(s).\n`)
+    } finally {
+        await client.close()
+    }
+}
+
+main().catch(err => die(err instanceof Error ? err.message : String(err)))

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -809,6 +809,12 @@ const MIGRATION_ITEMS = [
         args: ['--prefix', 'apps/web', 'run', 'import:history', '--', '../../ASOT_Member_History_Master_Batch_12.csv'],
         cwd: ROOT,
     },
+    {
+        label: '🗃️ Sync: member ranks from ORBAT CSV',
+        command: 'npm',
+        args: ['--prefix', 'apps/web', 'run', 'sync:ranks', '--', '../../ASOT - ORBAT - ASOT - ORBAT.csv'],
+        cwd: ROOT,
+    },
 ]
 
 // ─── Main loop ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Reads every member's current rank out of the ORBAT export and writes it to `milpac.currentRank`.

**Already applied** (2026-08-18, after restic snapshot `ea21fa10`): 24 members written — 23 rank changes and 3 name repairs, two members appearing in both. A second run is a no-op.

## How it reads the sheet

The ORBAT is a grid, not a table: sections are column pairs laid side by side, and the same columns change meaning partway down (the reservist block becomes the Gamemaster block at line 64). Rather than model that layout, this reads every cell and keeps the ones that look like a person — a known rank abbreviation from `@asot/lib` followed by a name. Headings, job titles and sheet furniture have no rank prefix and fall out on their own: 337 cells in, 176 people.

Two spellings needed normalising first. `PTE (SL) Wanderer` has its proficiency suffix typed with a space in front, and `TRP(S) Pluto` transposes `TPR`. Both had already been mis-split by an earlier importer that took everything after the first space as the member's name, which is how three members came to be stored as `(SL) Wanderer`, `(L) Dawn` and `TRP(S) Pluto` — repaired here as well.

## Why not `parseRow`

`lib/orbat/csv-parser`'s `parseRow` toggles quoted-state on every quote character, so the second quote of an escaped `""` pair re-enters quoted state and the following comma stops separating cells — every later cell lands one column to the left. In a grid this wide that silently reseats people into other sections. Today's export contains no quotes at all, so both parsers agree on it; `splitCsvRow` here is for the export that doesn't, and is tested on exactly that case.

## Name resolution

Reuses `resolveMembers`, which collects every claimant rather than letting one overwrite another. Six of the sheet's contested names were already adjudicated for the history import and resolve through `MEMBER_OVERRIDES`. Two more are added here, in `ORBAT_OVERRIDES`:

- **Kyle** — `hackjack.` also answers to Kyle through their Discord global name, and sits at `PTE(L)` against the sheet's `PTE Kyle`. Matching the wrong claimant would have read as a demotion.
- **Frog** — `marshall_580` claims the name the same way; `billyfrog.` is the one nicknamed `REC Frog` in the guild.

`resolveMembers` gained an optional third parameter for this. The two override tables stay separate because the two files cover different populations — the history CSV spans everyone who ever served, the ORBAT only who is currently seated — so each surfaces contested names the other never sees.

## Conflicts and skips

A name seated twice is normal (a reservist can also hold a section seat) and costs nothing while both seats agree. Two seats that disagree are reported and skipped rather than resolved by picking one: the sheet is the authority, and an authority that contradicts itself has not decided. The export had two such cases, both wrong duplicate entries in the reservist columns, removed at source before this run.

Two names went unresolved and were skipped, both harmless: `Etec` has two accounts already at `PTE(P)`, and `Sparkle` is a second spelling of `Sparkles`, already at `REC`.

## Usage

    npm --prefix apps/web run sync:ranks -- "<orbat.csv>"           # dry run
    npm --prefix apps/web run sync:ranks -- "<orbat.csv>" --apply

Dry run by default, and added to the `npm start` migrations menu. 28 new tests; full suite 259 passing, `tsc --noEmit` clean.

Merging this deploys — the repo has no CI gate on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)