### PR TITLE
Operations editor: an application shell, the deck, and logic out of the page

### DIFF
--- a/apps/web/app/(landing)/milpacs/[username]/milpac-file.tsx
+++ b/apps/web/app/(landing)/milpacs/[username]/milpac-file.tsx
@@ -251,7 +251,7 @@ export async function MilpacFile({ segment, tab, kitSegment }: {
 
 	return (
 		<div
-			className={s.shell}
+			className={`command ${s.shell}`}
 			// The member's own Discord accent, everything else neutral. ensureVisible
 			// lifts a near-black accent off the background; the triplet has to be
 			// derived from the same value or the text colour and its tints disagree.

--- a/apps/web/app/(landing)/milpacs/[username]/profile.module.css
+++ b/apps/web/app/(landing)/milpacs/[username]/profile.module.css
@@ -15,26 +15,6 @@
 
 .shell {
     /* --acc and --acc-rgb are injected per member */
-    --bg: #08090a;
-    --s1: #0d0f11;
-    --s2: #12151a;
-    --s3: #181c22;
-    --line: #1e232b;
-    --line-2: #2a3038;
-
-    --ink: #e8eaed;
-    --ink-2: #a8b0ba;
-    --ink-3: #6b7480;
-
-    --good: #7fae5c;
-    --warn: #d4a03a;
-    --crit: #c05a48;
-
-    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Roboto Mono", Menlo, Consolas, monospace;
-    --sans: "Helvetica Neue", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
-
-    --r: 3px;
-    --pad: clamp(16px, 3vw, 40px);
 
     background: var(--bg);
     color: var(--ink);

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next"
 import { Montserrat } from "next/font/google"
 import "@/styles/globals.css"
+import "@/styles/command.css"
 import { headers } from "next/headers"
 
 

--- a/apps/web/app/operations/[id]/edit/EditorShell.tsx
+++ b/apps/web/app/operations/[id]/edit/EditorShell.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { rgbTriplet } from '@/lib/colour'
+import styles from './shell.module.css'
+
+export type EditorTab = 'brief' | 'map' | 'development' | 'attendance'
+
+const TABS: readonly EditorTab[] = ['brief', 'map', 'development', 'attendance']
+
+const TAB_LABELS: Record<EditorTab, string> = {
+    brief: 'Brief',
+    map: 'Map',
+    development: 'Development',
+    attendance: 'Attendance',
+}
+
+function tabFromLocation(): EditorTab {
+    if (typeof window === 'undefined') return 'brief'
+    const t = new URLSearchParams(window.location.search).get('tab')
+    return (TABS as readonly string[]).includes(t ?? '') ? (t as EditorTab) : 'brief'
+}
+
+/**
+ * Tabs are plain client state with the URL mirrored via `replaceState` —
+ * deliberately not `next/link`/`router.push`. See `app/(landing)/milpacs/[username]/tabs.tsx`
+ * for the measured failure rate of Link-based tabs (11/18 commits), and note
+ * that a real navigation here would also tear down the Hocuspocus socket and
+ * force the Y.Doc to reconnect on every tab switch.
+ */
+export function useEditorTab(): [EditorTab, (t: EditorTab) => void] {
+    const [tab, setTab] = useState<EditorTab>('brief')
+
+    // Read the deep link after mount — the server render has no location.
+    useEffect(() => { setTab(tabFromLocation()) }, [])
+
+    const change = (next: EditorTab) => {
+        setTab(next)
+        const url = new URL(window.location.href)
+        url.searchParams.set('tab', next)
+        // replaceState, not router.push: no navigation, so the collab socket lives.
+        window.history.replaceState(null, '', url)
+    }
+
+    return [tab, change]
+}
+
+function TabPlaceholder({ label }: { label: string }) {
+    return <div className={styles.tabPlaceholder}>{label} — coming soon</div>
+}
+
+interface EditorShellProps {
+    operationId: string
+    themeColor: string
+    isHQ: boolean
+    tab: EditorTab
+    onTabChange: (t: EditorTab) => void
+    header: ReactNode
+    /** Optional for now — nothing populates it until the deck itself exists. */
+    deck?: ReactNode
+    statusBar: ReactNode
+    children: ReactNode
+}
+
+export default function EditorShell({
+    themeColor, isHQ, tab, onTabChange, header, deck, statusBar, children,
+}: EditorShellProps) {
+    const visibleTabs = TABS.filter(t => t !== 'attendance' || isHQ)
+
+    return (
+        <div
+            className={`command ${styles.shell}`}
+            style={{ ['--acc' as string]: themeColor, ['--acc-rgb' as string]: rgbTriplet(themeColor) }}
+        >
+            {header}
+
+            <nav className={styles.tabbar} aria-label='Operation editor sections'>
+                {visibleTabs.map(t => (
+                    <button
+                        key={t}
+                        type='button'
+                        onClick={() => onTabChange(t)}
+                        aria-current={t === tab ? 'page' : undefined}
+                        className={t === tab ? `${styles.tab} ${styles.tabOn}` : styles.tab}
+                    >
+                        {TAB_LABELS[t].toUpperCase()}
+                    </button>
+                ))}
+            </nav>
+
+            <div className={styles.body}>
+                <div className={styles.main}>
+                    <div className={styles.mainScroll}>
+                        {tab === 'brief' && children}
+                        {tab === 'map' && <TabPlaceholder label='Map' />}
+                        {tab === 'development' && <TabPlaceholder label='Development' />}
+                        {tab === 'attendance' && isHQ && <TabPlaceholder label='Attendance' />}
+                    </div>
+                </div>
+                {deck && <div className={styles.deck}>{deck}</div>}
+            </div>
+
+            {statusBar}
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/EditorShell.tsx
+++ b/apps/web/app/operations/[id]/edit/EditorShell.tsx
@@ -133,7 +133,19 @@ export default function EditorShell({
                          * reached via unmount instead of navigation. So it stays mounted
                          * always and is hidden with CSS instead.
                          */}
-                        <div style={{ display: active === 'brief' ? undefined : 'none' }}>
+                        {/*
+                         * height: '100%' (matching the `map` wrapper just below) gives
+                         * this box a definite height equal to .mainScroll's own — the
+                         * body region between the merged header and the status bar,
+                         * already computed purely via flexbox (no viewport maths) — so
+                         * CollabEditor's own `minHeight: '100%'` root (which otherwise
+                         * has no definite ancestor to resolve that percentage against)
+                         * actually takes effect. That's what lets PageSidebar's rail
+                         * stretch to fill the same region (visual-fixes FIX 2) instead
+                         * of relying on a hardcoded `calc(100vh - N)` that drifts every
+                         * time the chrome above or below it changes height.
+                         */}
+                        <div style={{ display: active === 'brief' ? undefined : 'none', height: '100%' }}>
                             {brief}
                         </div>
                         {mapVisited && (

--- a/apps/web/app/operations/[id]/edit/EditorShell.tsx
+++ b/apps/web/app/operations/[id]/edit/EditorShell.tsx
@@ -82,7 +82,7 @@ interface EditorShellProps {
 }
 
 export default function EditorShell({
-    themeColor, isHQ, tab, onTabChange, header, deck, statusBar,
+    operationId, themeColor, isHQ, tab, onTabChange, header, deck, statusBar,
     brief, map, development, attendance, contentPaddingRight,
 }: EditorShellProps) {
     const visibleTabs = TABS.filter(t => t !== 'attendance' || isHQ)
@@ -146,6 +146,25 @@ export default function EditorShell({
                         {active === 'development' && development}
                         {active === 'attendance' && isHQ && attendance}
                     </div>
+                    {/*
+                     * Preview — floats at the bottom-right of the editor column
+                     * itself (.main is `position: relative`, set above), not the
+                     * viewport, so it always sits just left of the mission deck
+                     * (deck is .main's sibling in .body) at every width, deck
+                     * state included. Opens the public operation page in a new
+                     * tab — same behaviour the old header overflow-menu "⊡
+                     * Preview" item had; only its position moved.
+                     */}
+                    {operationId && (
+                        <button
+                            type='button'
+                            onClick={() => window.open(`/operations/${operationId}`, '_blank')}
+                            title='Preview operation'
+                            className={styles.previewBtn}
+                        >
+                            ⊡ Preview
+                        </button>
+                    )}
                 </div>
                 {/*
                  * No wrapping div here: MissionDeck (deck/MissionDeck.tsx) is

--- a/apps/web/app/operations/[id]/edit/EditorShell.tsx
+++ b/apps/web/app/operations/[id]/edit/EditorShell.tsx
@@ -6,9 +6,11 @@ import styles from './shell.module.css'
 
 export type EditorTab = 'brief' | 'map' | 'development' | 'attendance'
 
-const TABS: readonly EditorTab[] = ['brief', 'map', 'development', 'attendance']
+/** Also used by Header.tsx, which renders the tab links inline in the merged
+ * header row — see that file for why the row owns them instead of this one. */
+export const TABS: readonly EditorTab[] = ['brief', 'map', 'development', 'attendance']
 
-const TAB_LABELS: Record<EditorTab, string> = {
+export const TAB_LABELS: Record<EditorTab, string> = {
     brief: 'Brief',
     map: 'Map',
     development: 'Development',
@@ -106,21 +108,17 @@ export default function EditorShell({
             className={`command ${styles.shell}`}
             style={{ ['--acc' as string]: themeColor, ['--acc-rgb' as string]: rgbTriplet(themeColor) }}
         >
+            {/*
+             * The tab links themselves render inline in Header's own row now
+             * (spec §3: one merged row, not a header row plus a separate tab
+             * bar) — Header gets `tab`/`onTabChange`/`isHQ` from page.tsx
+             * directly and computes the same `visibleTabs`/active fallback
+             * this component still needs below for content routing. This
+             * component intentionally still owns that routing logic (which
+             * tab's content is on screen) even though it no longer renders
+             * the buttons that drive it.
+             */}
             {header}
-
-            <nav className={styles.tabbar} aria-label='Operation editor sections'>
-                {visibleTabs.map(t => (
-                    <button
-                        key={t}
-                        type='button'
-                        onClick={() => onTabChange(t)}
-                        aria-current={t === active ? 'page' : undefined}
-                        className={t === active ? `${styles.tab} ${styles.tabOn}` : styles.tab}
-                    >
-                        {TAB_LABELS[t].toUpperCase()}
-                    </button>
-                ))}
-            </nav>
 
             <div className={styles.body}>
                 <div className={styles.main}>
@@ -168,13 +166,15 @@ export default function EditorShell({
                 </div>
                 {/*
                  * No wrapping div here: MissionDeck (deck/MissionDeck.tsx) is
-                 * fully self-contained — its own root element sets width,
-                 * border-left, background and overflow-y for both the
-                 * expanded (340px) and collapsed (44px) states. A wrapping
-                 * div styled from styles.deck/.deckCollapsed would fight
-                 * that (fixed 340px outer box while the inner rail shrinks
-                 * to 44px, doubled border-left, mismatched width on resize),
-                 * so `deck` is rendered directly and owns its own layout.
+                 * fully self-contained — its own root element sets width for
+                 * both the expanded (340px) and collapsed (0 — nothing but
+                 * the pull-tab remains) states, with border/background/
+                 * overflow-y living on an inner box so the pull-tab itself
+                 * can overhang uncropped. A wrapping div styled from
+                 * styles.deck/.deckCollapsed would fight that (fixed 340px
+                 * outer box while the inner rail shrinks to 0, doubled
+                 * border-left, mismatched width on resize), so `deck` is
+                 * rendered directly and owns its own layout.
                  */}
                 {deck}
             </div>

--- a/apps/web/app/operations/[id]/edit/EditorShell.tsx
+++ b/apps/web/app/operations/[id]/edit/EditorShell.tsx
@@ -27,6 +27,10 @@ function tabFromLocation(): EditorTab {
  * for the measured failure rate of Link-based tabs (11/18 commits), and note
  * that a real navigation here would also tear down the Hocuspocus socket and
  * force the Y.Doc to reconnect on every tab switch.
+ *
+ * This hook doesn't know about `isHQ`, so it can resolve `?tab=attendance` for
+ * a non-HQ user — EditorShell (which does know isHQ) is responsible for
+ * falling back to `brief` when the resolved tab isn't actually visible.
  */
 export function useEditorTab(): [EditorTab, (t: EditorTab) => void] {
     const [tab, setTab] = useState<EditorTab>('brief')
@@ -66,6 +70,11 @@ export default function EditorShell({
     themeColor, isHQ, tab, onTabChange, header, deck, statusBar, children,
 }: EditorShellProps) {
     const visibleTabs = TABS.filter(t => t !== 'attendance' || isHQ)
+    // A tab that isn't in the visible set — a non-HQ user deep-linking
+    // ?tab=attendance, or a stale value from before a role change — must not
+    // be selected: that renders nothing (no placeholder, no content) with no
+    // way back except editing the URL. Fall back to brief instead.
+    const active = visibleTabs.includes(tab) ? tab : 'brief'
 
     return (
         <div
@@ -80,8 +89,8 @@ export default function EditorShell({
                         key={t}
                         type='button'
                         onClick={() => onTabChange(t)}
-                        aria-current={t === tab ? 'page' : undefined}
-                        className={t === tab ? `${styles.tab} ${styles.tabOn}` : styles.tab}
+                        aria-current={t === active ? 'page' : undefined}
+                        className={t === active ? `${styles.tab} ${styles.tabOn}` : styles.tab}
                     >
                         {TAB_LABELS[t].toUpperCase()}
                     </button>
@@ -91,10 +100,22 @@ export default function EditorShell({
             <div className={styles.body}>
                 <div className={styles.main}>
                     <div className={styles.mainScroll}>
-                        {tab === 'brief' && children}
-                        {tab === 'map' && <TabPlaceholder label='Map' />}
-                        {tab === 'development' && <TabPlaceholder label='Development' />}
-                        {tab === 'attendance' && isHQ && <TabPlaceholder label='Attendance' />}
+                        {/*
+                         * Brief holds the collaborative editor — a Hocuspocus socket and a
+                         * Y.Doc that CollabEditor creates in useState and destroys on
+                         * unmount. Conditionally rendering it per tab (`tab === 'brief' &&
+                         * children`) would tear the socket down and force a Y.Doc rebuild
+                         * every time a user switches away and back — the exact hazard the
+                         * "no router navigation" rule (spec §7) exists to prevent, just
+                         * reached via unmount instead of navigation. So it stays mounted
+                         * always and is hidden with CSS instead.
+                         */}
+                        <div style={{ display: active === 'brief' ? undefined : 'none' }}>
+                            {children}
+                        </div>
+                        {active === 'map' && <TabPlaceholder label='Map' />}
+                        {active === 'development' && <TabPlaceholder label='Development' />}
+                        {active === 'attendance' && isHQ && <TabPlaceholder label='Attendance' />}
                     </div>
                 </div>
                 {deck && <div className={styles.deck}>{deck}</div>}

--- a/apps/web/app/operations/[id]/edit/EditorShell.tsx
+++ b/apps/web/app/operations/[id]/edit/EditorShell.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from 'react'
 import { rgbTriplet } from '@/lib/colour'
+import { useThinScrollFade } from '@/components/editor/useThinScrollFade'
 import styles from './shell.module.css'
 
 export type EditorTab = 'brief' | 'map' | 'development' | 'attendance'
@@ -103,6 +104,8 @@ export default function EditorShell({
         if (active === 'map') setMapVisited(true)
     }, [active])
 
+    const mainScrollFadeRef = useThinScrollFade<HTMLDivElement>()
+
     return (
         <div
             className={`command ${styles.shell}`}
@@ -122,7 +125,11 @@ export default function EditorShell({
 
             <div className={styles.body}>
                 <div className={styles.main}>
-                    <div className={styles.mainScroll} style={{ paddingRight: contentPaddingRight, transition: 'padding-right 0.25s ease' }}>
+                    <div
+                        ref={mainScrollFadeRef}
+                        className={`${styles.mainScroll} thin-scroll`}
+                        style={{ paddingRight: contentPaddingRight, transition: 'padding-right 0.25s ease' }}
+                    >
                         {/*
                          * Brief holds the collaborative editor — a Hocuspocus socket and a
                          * Y.Doc that CollabEditor creates in useState and destroys on

--- a/apps/web/app/operations/[id]/edit/EditorShell.tsx
+++ b/apps/web/app/operations/[id]/edit/EditorShell.tsx
@@ -118,7 +118,17 @@ export default function EditorShell({
                         {active === 'attendance' && isHQ && <TabPlaceholder label='Attendance' />}
                     </div>
                 </div>
-                {deck && <div className={styles.deck}>{deck}</div>}
+                {/*
+                 * No wrapping div here: MissionDeck (deck/MissionDeck.tsx) is
+                 * fully self-contained — its own root element sets width,
+                 * border-left, background and overflow-y for both the
+                 * expanded (340px) and collapsed (44px) states. A wrapping
+                 * div styled from styles.deck/.deckCollapsed would fight
+                 * that (fixed 340px outer box while the inner rail shrinks
+                 * to 44px, doubled border-left, mismatched width on resize),
+                 * so `deck` is rendered directly and owns its own layout.
+                 */}
+                {deck}
             </div>
 
             {statusBar}

--- a/apps/web/app/operations/[id]/edit/EditorShell.tsx
+++ b/apps/web/app/operations/[id]/edit/EditorShell.tsx
@@ -49,10 +49,6 @@ export function useEditorTab(): [EditorTab, (t: EditorTab) => void] {
     return [tab, change]
 }
 
-function TabPlaceholder({ label }: { label: string }) {
-    return <div className={styles.tabPlaceholder}>{label} — coming soon</div>
-}
-
 interface EditorShellProps {
     operationId: string
     themeColor: string
@@ -63,11 +59,31 @@ interface EditorShellProps {
     /** Optional for now — nothing populates it until the deck itself exists. */
     deck?: ReactNode
     statusBar: ReactNode
-    children: ReactNode
+    /** Documents rail + collaborative editor. Holds the Hocuspocus socket and
+     * Y.Doc (see the module doc below) — always mounted, hidden with CSS. */
+    brief: ReactNode
+    /** The map viewer. Has its own Y.js state (`useMapYjs`) with the same
+     * unmount hazard as Brief — mounted on first visit, then kept mounted and
+     * hidden with CSS like Brief, never unmounted again afterwards. */
+    map: ReactNode
+    /** Mission development gates. Holds no socket — free to mount/unmount
+     * with the tab switch. */
+    development: ReactNode
+    /** Who attends, notifications, acknowledgements — `isHQ` only. Holds no
+     * socket — free to mount/unmount with the tab switch. Gated by the caller
+     * (page.tsx passes `null` for a non-HQ user) and, redundantly, here too:
+     * an HQ user's role changing mid-session must not leave stale attendance
+     * content selectable via a stale tab value. */
+    attendance: ReactNode
+    /** Right-padding applied to the tab content area so a slide-over drawer
+     * (Activity/Preview, both fixed overlays rendered outside this shell)
+     * doesn't cover whichever tab is currently showing. */
+    contentPaddingRight?: string | number
 }
 
 export default function EditorShell({
-    themeColor, isHQ, tab, onTabChange, header, deck, statusBar, children,
+    themeColor, isHQ, tab, onTabChange, header, deck, statusBar,
+    brief, map, development, attendance, contentPaddingRight,
 }: EditorShellProps) {
     const visibleTabs = TABS.filter(t => t !== 'attendance' || isHQ)
     // A tab that isn't in the visible set — a non-HQ user deep-linking
@@ -75,6 +91,15 @@ export default function EditorShell({
     // be selected: that renders nothing (no placeholder, no content) with no
     // way back except editing the URL. Fall back to brief instead.
     const active = visibleTabs.includes(tab) ? tab : 'brief'
+
+    // Map mounts on first visit, then — like Brief — stays mounted forever
+    // and is only ever hidden with `display: none` (see the `brief` prop doc).
+    // Unlike Brief, it isn't mounted from the very first render: an author who
+    // never opens Map never pays for `useMapYjs`'s own Y.js document.
+    const [mapVisited, setMapVisited] = useState(active === 'map')
+    useEffect(() => {
+        if (active === 'map') setMapVisited(true)
+    }, [active])
 
     return (
         <div
@@ -99,23 +124,27 @@ export default function EditorShell({
 
             <div className={styles.body}>
                 <div className={styles.main}>
-                    <div className={styles.mainScroll}>
+                    <div className={styles.mainScroll} style={{ paddingRight: contentPaddingRight, transition: 'padding-right 0.25s ease' }}>
                         {/*
                          * Brief holds the collaborative editor — a Hocuspocus socket and a
                          * Y.Doc that CollabEditor creates in useState and destroys on
                          * unmount. Conditionally rendering it per tab (`tab === 'brief' &&
-                         * children`) would tear the socket down and force a Y.Doc rebuild
+                         * brief`) would tear the socket down and force a Y.Doc rebuild
                          * every time a user switches away and back — the exact hazard the
                          * "no router navigation" rule (spec §7) exists to prevent, just
                          * reached via unmount instead of navigation. So it stays mounted
                          * always and is hidden with CSS instead.
                          */}
                         <div style={{ display: active === 'brief' ? undefined : 'none' }}>
-                            {children}
+                            {brief}
                         </div>
-                        {active === 'map' && <TabPlaceholder label='Map' />}
-                        {active === 'development' && <TabPlaceholder label='Development' />}
-                        {active === 'attendance' && isHQ && <TabPlaceholder label='Attendance' />}
+                        {mapVisited && (
+                            <div style={{ display: active === 'map' ? undefined : 'none', height: '100%' }}>
+                                {map}
+                            </div>
+                        )}
+                        {active === 'development' && development}
+                        {active === 'attendance' && isHQ && attendance}
                     </div>
                 </div>
                 {/*

--- a/apps/web/app/operations/[id]/edit/Header.tsx
+++ b/apps/web/app/operations/[id]/edit/Header.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import Link from 'next/link'
 import { useOperationStatus } from './hooks/useOperationStatus'
 import { TABS, TAB_LABELS, type EditorTab } from './EditorShell'
+import { useThinScrollFade } from '@/components/editor/useThinScrollFade'
 import styles from './shell.module.css'
 
 export type SaveStatus = 'saved' | 'saving' | 'unsaved'
@@ -79,6 +80,7 @@ export default function Header({
 
     const [menuOpen, setMenuOpen] = useState(false)
     const menuRef = useRef<HTMLDivElement>(null)
+    const tabsRowFadeRef = useThinScrollFade<HTMLElement>()
 
     useEffect(() => {
         if (!menuOpen) return
@@ -135,7 +137,7 @@ export default function Header({
                 title above — separates the title/pill group from the tabs. */}
             <div style={{ width: 1, height: 14, background: 'var(--line)', flexShrink: 0 }} />
 
-            <nav className={styles.tabsRow} aria-label='Operation editor sections'>
+            <nav ref={tabsRowFadeRef} className={`${styles.tabsRow} thin-scroll`} aria-label='Operation editor sections'>
                 {visibleTabs.map(t => (
                     <button
                         key={t}

--- a/apps/web/app/operations/[id]/edit/Header.tsx
+++ b/apps/web/app/operations/[id]/edit/Header.tsx
@@ -120,10 +120,10 @@ export default function Header({
 
                 {showPublish && (
                     publishConfirmOpen ? (
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 10px', background: 'rgba(127,174,92,0.1)', border: '1px solid var(--good)', borderRadius: 'var(--r)' }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 10px', background: 'color-mix(in srgb, var(--good) 10%, transparent)', border: '1px solid var(--good)', borderRadius: 'var(--r)' }}>
                             <span style={{ fontSize: '0.6rem', color: 'var(--good)', fontWeight: 700, letterSpacing: '0.1em' }}>Publish "{title || 'this op'}"?</span>
                             <button type='button' disabled={publishSaving} onClick={onPublishConfirm}
-                                style={{ padding: '4px 10px', fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', background: 'rgba(127,174,92,0.22)', border: '1px solid var(--good)', color: 'var(--good)', cursor: 'pointer', borderRadius: 'var(--r)' }}
+                                style={{ padding: '4px 10px', fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', background: 'color-mix(in srgb, var(--good) 22%, transparent)', border: '1px solid var(--good)', color: 'var(--good)', cursor: 'pointer', borderRadius: 'var(--r)' }}
                             >{publishSaving ? 'Publishing…' : '✓ Confirm'}</button>
                             <button type='button' onClick={onPublishCancel}
                                 style={{ padding: '4px 8px', fontSize: '0.6rem', fontWeight: 700, background: 'none', border: '1px solid var(--line-2)', color: 'var(--ink-3)', cursor: 'pointer', borderRadius: 'var(--r)' }}
@@ -132,7 +132,7 @@ export default function Header({
                     ) : (
                         <button type='button' onClick={onPublishClick}
                             style={{
-                                padding: '6px 14px', background: 'rgba(127,174,92,0.08)',
+                                padding: '6px 14px', background: 'color-mix(in srgb, var(--good) 8%, transparent)',
                                 border: '1px solid var(--good)', color: 'var(--good)',
                                 fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
                                 cursor: 'pointer', borderRadius: 'var(--r)',

--- a/apps/web/app/operations/[id]/edit/Header.tsx
+++ b/apps/web/app/operations/[id]/edit/Header.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import Link from 'next/link'
 import { useOperationStatus } from './hooks/useOperationStatus'
+import { TABS, TAB_LABELS, type EditorTab } from './EditorShell'
+import styles from './shell.module.css'
 
 export type SaveStatus = 'saved' | 'saving' | 'unsaved'
 
@@ -23,6 +25,14 @@ interface HeaderProps {
     onPublishClick: () => void
     onPublishConfirm: () => void
     onPublishCancel: () => void
+    /** The section tabs (Brief/Map/Development/Attendance), rendered inline
+     * in this same row (spec §3) rather than in a separate bar underneath —
+     * EditorShell still owns which tab's *content* is on screen (it needs
+     * that regardless of where the buttons live), so this component mirrors
+     * its `visibleTabs`/fallback logic rather than importing a decision from
+     * it, to keep this a plain, self-contained header. */
+    tab: EditorTab
+    onTabChange: (t: EditorTab) => void
 }
 
 // Token-backed; translucent fills use the same hex→rgb the tokens carry
@@ -59,6 +69,7 @@ export default function Header({
     operationId, fromJ2, title, status, saveStatus, isHQ,
     onDelete, activityOpen, onToggleActivity,
     publishConfirmOpen, publishSaving, onPublishClick, onPublishConfirm, onPublishCancel,
+    tab, onTabChange,
 }: HeaderProps) {
     // Supplementary real data (not fabricated) for the status pill's countdown —
     // the pill's colour/label still comes from `status` above, which updates
@@ -80,14 +91,22 @@ export default function Header({
     const save = SAVE_COPY[saveStatus]
     const showPublish = isHQ && status === 'In Development'
 
+    // Same visibility/fallback rule as EditorShell's own `visibleTabs`/
+    // `active` (EditorShell.tsx) — kept in sync by construction since both
+    // read the same `TABS` constant and the same `tab`/`isHQ` props page.tsx
+    // passes to each. Attendance absent from the DOM entirely for non-HQ
+    // users, not merely disabled (spec §1's gate).
+    const visibleTabs = TABS.filter(t => t !== 'attendance' || isHQ)
+    const activeTab = visibleTabs.includes(tab) ? tab : 'brief'
+
     return (
         <div style={{
-            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-            gap: 16, padding: '0 16px', height: 48, flexShrink: 0,
+            display: 'flex', alignItems: 'center',
+            gap: 16, padding: '0 16px', height: 52, flexShrink: 0,
             borderBottom: '1px solid var(--line)',
             background: 'var(--s1)',
         }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0, flexShrink: 1 }}>
                 <Link
                     href={fromJ2 ? '/dashboard/j2' : '/operations'}
                     style={{ fontSize: '0.68rem', fontWeight: 600, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-3)', textDecoration: 'none', flexShrink: 0 }}
@@ -111,6 +130,29 @@ export default function Header({
                     {status === 'Upcoming' && daysUntil !== null && <span style={{ opacity: 0.7 }}> · T-{daysUntil}d</span>}
                 </span>
             </div>
+
+            {/* Same divider style as the one between the back crumb and the
+                title above — separates the title/pill group from the tabs. */}
+            <div style={{ width: 1, height: 14, background: 'var(--line)', flexShrink: 0 }} />
+
+            <nav className={styles.tabsRow} aria-label='Operation editor sections'>
+                {visibleTabs.map(t => (
+                    <button
+                        key={t}
+                        type='button'
+                        onClick={() => onTabChange(t)}
+                        aria-current={t === activeTab ? 'page' : undefined}
+                        className={t === activeTab ? `${styles.tab} ${styles.tabOn}` : styles.tab}
+                    >
+                        {TAB_LABELS[t].toUpperCase()}
+                    </button>
+                ))}
+            </nav>
+
+            {/* Flexible spacer — pushes the save state / Publish / overflow
+                cluster to the row's end regardless of how much room the
+                title and tabs are currently taking. */}
+            <div style={{ flex: 1, minWidth: 0 }} />
 
             <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexShrink: 0 }}>
                 <span style={{ fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: save.color }}>

--- a/apps/web/app/operations/[id]/edit/Header.tsx
+++ b/apps/web/app/operations/[id]/edit/Header.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useEffect, useRef, useState, type CSSProperties } from 'react'
+import Link from 'next/link'
+import { useOperationStatus } from './hooks/useOperationStatus'
+
+export type SaveStatus = 'saved' | 'saving' | 'unsaved'
+
+interface HeaderProps {
+    operationId: string
+    fromJ2: boolean
+    title: string
+    /** The operation's own lifecycle status — Upcoming / Active / Completed / In Development. */
+    status: string
+    /** The document save state — distinct from `status` above. */
+    saveStatus: SaveStatus
+    isHQ: boolean
+    onDelete: () => void
+    activityOpen: boolean
+    onToggleActivity: () => void
+    onOpenPreview: () => void
+    publishConfirmOpen: boolean
+    publishSaving: boolean
+    onPublishClick: () => void
+    onPublishConfirm: () => void
+    onPublishCancel: () => void
+}
+
+// Token-backed; translucent fills use the same hex→rgb the tokens carry
+// (styles/command.css doesn't expose *-rgb triplets for good/warn/crit, only --acc).
+const STATUS_COLOR: Record<string, string> = {
+    'Active': 'var(--good)',
+    'Upcoming': 'var(--warn)',
+    'Completed': 'var(--ink-3)',
+    'In Development': 'var(--crit)',
+}
+
+const SAVE_COPY: Record<SaveStatus, { label: string; color: string }> = {
+    saved: { label: 'Saved', color: 'var(--good)' },
+    saving: { label: 'Saving…', color: 'var(--warn)' },
+    unsaved: { label: 'Unsaved', color: 'var(--crit)' },
+}
+
+const menuItemStyle: CSSProperties = {
+    display: 'block',
+    padding: '7px 10px',
+    fontSize: '0.72rem',
+    fontWeight: 600,
+    color: 'var(--ink-2)',
+    textDecoration: 'none',
+    borderRadius: 2,
+    background: 'none',
+    border: 'none',
+    textAlign: 'left',
+    cursor: 'pointer',
+    width: '100%',
+}
+
+export default function Header({
+    operationId, fromJ2, title, status, saveStatus, isHQ,
+    onDelete, activityOpen, onToggleActivity, onOpenPreview,
+    publishConfirmOpen, publishSaving, onPublishClick, onPublishConfirm, onPublishCancel,
+}: HeaderProps) {
+    // Supplementary real data (not fabricated) for the status pill's countdown —
+    // the pill's colour/label still comes from `status` above, which updates
+    // immediately on local edits; this hook polls every 30s so it's used only
+    // for the "T-Nd" addendum, never as the source of truth for the pill itself.
+    const { daysUntil } = useOperationStatus(operationId)
+
+    const [menuOpen, setMenuOpen] = useState(false)
+    const menuRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!menuOpen) return
+        const close = (e: MouseEvent) => { if (!menuRef.current?.contains(e.target as Node)) setMenuOpen(false) }
+        document.addEventListener('mousedown', close)
+        return () => document.removeEventListener('mousedown', close)
+    }, [menuOpen])
+
+    const statusColor = STATUS_COLOR[status] ?? 'var(--ink-3)'
+    const save = SAVE_COPY[saveStatus]
+    const showPublish = isHQ && status === 'In Development'
+
+    return (
+        <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            gap: 16, padding: '0 16px', height: 48, flexShrink: 0,
+            borderBottom: '1px solid var(--line)',
+            background: 'var(--s1)',
+        }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
+                <Link
+                    href={fromJ2 ? '/dashboard/j2' : '/operations'}
+                    style={{ fontSize: '0.68rem', fontWeight: 600, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-3)', textDecoration: 'none', flexShrink: 0 }}
+                >
+                    {fromJ2 ? '← J2 Operations' : '← Back'}
+                </Link>
+                <div style={{ width: 1, height: 14, background: 'var(--line)', flexShrink: 0 }} />
+                <span style={{
+                    fontSize: '0.95rem', fontWeight: 700, letterSpacing: '0.02em',
+                    color: 'var(--ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>
+                    {title || 'Untitled Operation'}
+                </span>
+                <span style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 5, flexShrink: 0,
+                    fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase',
+                    color: statusColor, border: `1px solid ${statusColor}`, borderRadius: 'var(--r)',
+                    padding: '2px 8px',
+                }}>
+                    {status || 'Unknown'}
+                    {status === 'Upcoming' && daysUntil !== null && <span style={{ opacity: 0.7 }}> · T-{daysUntil}d</span>}
+                </span>
+            </div>
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexShrink: 0 }}>
+                <span style={{ fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: save.color }}>
+                    ● {save.label}
+                </span>
+
+                {showPublish && (
+                    publishConfirmOpen ? (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 10px', background: 'rgba(127,174,92,0.1)', border: '1px solid var(--good)', borderRadius: 'var(--r)' }}>
+                            <span style={{ fontSize: '0.6rem', color: 'var(--good)', fontWeight: 700, letterSpacing: '0.1em' }}>Publish "{title || 'this op'}"?</span>
+                            <button type='button' disabled={publishSaving} onClick={onPublishConfirm}
+                                style={{ padding: '4px 10px', fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', background: 'rgba(127,174,92,0.22)', border: '1px solid var(--good)', color: 'var(--good)', cursor: 'pointer', borderRadius: 'var(--r)' }}
+                            >{publishSaving ? 'Publishing…' : '✓ Confirm'}</button>
+                            <button type='button' onClick={onPublishCancel}
+                                style={{ padding: '4px 8px', fontSize: '0.6rem', fontWeight: 700, background: 'none', border: '1px solid var(--line-2)', color: 'var(--ink-3)', cursor: 'pointer', borderRadius: 'var(--r)' }}
+                            >Cancel</button>
+                        </div>
+                    ) : (
+                        <button type='button' onClick={onPublishClick}
+                            style={{
+                                padding: '6px 14px', background: 'rgba(127,174,92,0.08)',
+                                border: '1px solid var(--good)', color: 'var(--good)',
+                                fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
+                                cursor: 'pointer', borderRadius: 'var(--r)',
+                            }}
+                        >↑ Publish</button>
+                    )
+                )}
+
+                <div ref={menuRef} style={{ position: 'relative' }}>
+                    <button
+                        type='button'
+                        onClick={() => setMenuOpen(v => !v)}
+                        aria-haspopup='menu'
+                        aria-expanded={menuOpen}
+                        title='More actions'
+                        style={{
+                            width: 28, height: 28, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            background: menuOpen ? 'var(--s2)' : 'transparent',
+                            border: `1px solid ${menuOpen ? 'var(--line-2)' : 'var(--line)'}`,
+                            color: 'var(--ink-2)', cursor: 'pointer', borderRadius: 'var(--r)', fontSize: '1rem', lineHeight: 1,
+                        }}
+                    >⋮</button>
+
+                    {menuOpen && (
+                        <div role='menu' style={{
+                            position: 'absolute', top: '100%', right: 0, marginTop: 4, zIndex: 100,
+                            background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)',
+                            minWidth: 180, boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
+                            display: 'flex', flexDirection: 'column', padding: 4,
+                        }}>
+                            <Link href={`/operations/${operationId}`} onClick={() => setMenuOpen(false)} style={menuItemStyle}>
+                                View Operation →
+                            </Link>
+                            <Link href={`/operations/${operationId}/map`} onClick={() => setMenuOpen(false)} style={menuItemStyle}>
+                                Map ↗
+                            </Link>
+                            <button type='button' onClick={() => { onToggleActivity(); setMenuOpen(false) }}
+                                style={{ ...menuItemStyle, background: activityOpen ? 'var(--s3)' : 'none' }}
+                            >
+                                {activityOpen ? '✓ Activity' : 'Activity'}
+                            </button>
+                            <button type='button' onClick={() => { onOpenPreview(); setMenuOpen(false) }} style={menuItemStyle}>
+                                ⊡ Preview
+                            </button>
+                            <div style={{ height: 1, background: 'var(--line)', margin: '4px 0' }} />
+                            <button type='button' onClick={() => { onDelete(); setMenuOpen(false) }}
+                                style={{ ...menuItemStyle, color: 'var(--crit)' }}
+                            >
+                                Delete Mission
+                            </button>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/Header.tsx
+++ b/apps/web/app/operations/[id]/edit/Header.tsx
@@ -18,7 +18,6 @@ interface HeaderProps {
     onDelete: () => void
     activityOpen: boolean
     onToggleActivity: () => void
-    onOpenPreview: () => void
     publishConfirmOpen: boolean
     publishSaving: boolean
     onPublishClick: () => void
@@ -58,7 +57,7 @@ const menuItemStyle: CSSProperties = {
 
 export default function Header({
     operationId, fromJ2, title, status, saveStatus, isHQ,
-    onDelete, activityOpen, onToggleActivity, onOpenPreview,
+    onDelete, activityOpen, onToggleActivity,
     publishConfirmOpen, publishSaving, onPublishClick, onPublishConfirm, onPublishCancel,
 }: HeaderProps) {
     // Supplementary real data (not fabricated) for the status pill's countdown —
@@ -173,9 +172,6 @@ export default function Header({
                                 style={{ ...menuItemStyle, background: activityOpen ? 'var(--s3)' : 'none' }}
                             >
                                 {activityOpen ? '✓ Activity' : 'Activity'}
-                            </button>
-                            <button type='button' onClick={() => { onOpenPreview(); setMenuOpen(false) }} style={menuItemStyle}>
-                                ⊡ Preview
                             </button>
                             <div style={{ height: 1, background: 'var(--line)', margin: '4px 0' }} />
                             <button type='button' onClick={() => { onDelete(); setMenuOpen(false) }}

--- a/apps/web/app/operations/[id]/edit/Header.tsx
+++ b/apps/web/app/operations/[id]/edit/Header.tsx
@@ -117,7 +117,13 @@ export default function Header({
                 </Link>
                 <div style={{ width: 1, height: 14, background: 'var(--line)', flexShrink: 0 }} />
                 <span style={{
-                    fontSize: '0.95rem', fontWeight: 700, letterSpacing: '0.02em',
+                    /* Display-only caps. The name is stored and edited in
+                       whatever case the author typed (see DetailsCard's title
+                       field) — this only renders it uppercase to sit with the
+                       mono all-caps chrome around it, so the two never
+                       disagree about what the name actually is. */
+                    fontSize: '0.95rem', fontWeight: 700, letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
                     color: 'var(--ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
                 }}>
                     {title || 'Untitled Operation'}

--- a/apps/web/app/operations/[id]/edit/StatusBar.tsx
+++ b/apps/web/app/operations/[id]/edit/StatusBar.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+interface Props {
+    connected: boolean
+    activeDocTitle: string
+    words: number
+    sections: number
+    savedAt: Date | null
+    editorCount: number
+    department: string
+}
+
+export default function StatusBar({
+    connected, activeDocTitle, words, sections, savedAt, editorCount, department,
+}: Props) {
+    const cell: React.CSSProperties = {
+        display: 'flex', alignItems: 'center', gap: 9,
+        padding: '0 16px', height: '100%',
+        borderRight: '1px solid var(--line)',
+        color: 'var(--ink-2)',
+    }
+    return (
+        <div style={{
+            display: 'flex', alignItems: 'center', height: 32, flexShrink: 0,
+            borderTop: '1px solid var(--line)',
+            background: 'linear-gradient(180deg, var(--s1), var(--bg))',
+            fontFamily: 'var(--mono)', fontSize: 10,
+            letterSpacing: '0.12em', textTransform: 'uppercase',
+        }}>
+            <div style={{ ...cell, color: connected ? 'var(--good)' : 'var(--crit)' }}>
+                <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'currentColor' }} />
+                {connected ? 'Live' : 'Offline'}
+            </div>
+            <div style={cell}><span style={{ color: 'var(--ink-3)' }}>Doc</span> {activeDocTitle}</div>
+            <div style={cell}>{words.toLocaleString()} words</div>
+            <div style={cell}>{sections} sections</div>
+            <div style={{ ...cell, color: 'var(--ink-3)' }}>
+                {savedAt ? `Saved ${savedAt.toLocaleTimeString('en-AU', { hour: '2-digit', minute: '2-digit', hour12: false })}` : 'Not saved'}
+            </div>
+            <div style={{ flexGrow: 1 }} />
+            <div style={{ ...cell, borderRight: 'none', borderLeft: '1px solid var(--line)' }}>
+                {editorCount} editing
+            </div>
+            <div style={{ ...cell, borderRight: 'none', borderLeft: '1px solid var(--line)', color: 'var(--ink-3)' }}>
+                {department}
+            </div>
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/StatusBar.tsx
+++ b/apps/web/app/operations/[id]/edit/StatusBar.tsx
@@ -1,7 +1,13 @@
 'use client'
 
 interface Props {
-    connected: boolean
+    /**
+     * `null` means "not measured" — no provider is reachable yet to say either
+     * way — and must render as a neutral state, never as `true`. Rendering a
+     * green "Live" pill for a socket state nothing has observed would be a
+     * fabricated value, not a placeholder.
+     */
+    connected: boolean | null
     activeDocTitle: string
     words: number
     sections: number
@@ -19,6 +25,8 @@ export default function StatusBar({
         borderRight: '1px solid var(--line)',
         color: 'var(--ink-2)',
     }
+    const connectedColor = connected === true ? 'var(--good)' : connected === false ? 'var(--crit)' : 'var(--ink-3)'
+    const connectedLabel = connected === true ? 'Live' : connected === false ? 'Offline' : 'Link —'
     return (
         <div style={{
             display: 'flex', alignItems: 'center', height: 32, flexShrink: 0,
@@ -27,9 +35,9 @@ export default function StatusBar({
             fontFamily: 'var(--mono)', fontSize: 10,
             letterSpacing: '0.12em', textTransform: 'uppercase',
         }}>
-            <div style={{ ...cell, color: connected ? 'var(--good)' : 'var(--crit)' }}>
+            <div style={{ ...cell, color: connectedColor }}>
                 <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'currentColor' }} />
-                {connected ? 'Live' : 'Offline'}
+                {connectedLabel}
             </div>
             <div style={cell}><span style={{ color: 'var(--ink-3)' }}>Doc</span> {activeDocTitle}</div>
             <div style={cell}>{words.toLocaleString()} words</div>

--- a/apps/web/app/operations/[id]/edit/StatusBar.tsx
+++ b/apps/web/app/operations/[id]/edit/StatusBar.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import styles from './shell.module.css'
+
 interface Props {
     /**
      * `null` means "not measured" — no provider is reachable yet to say either
@@ -39,17 +41,17 @@ export default function StatusBar({
                 <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'currentColor' }} />
                 {connectedLabel}
             </div>
-            <div style={cell}><span style={{ color: 'var(--ink-3)' }}>Doc</span> {activeDocTitle}</div>
-            <div style={cell}>{words.toLocaleString()} words</div>
-            <div style={cell}>{sections} sections</div>
+            <div className={styles.sbDoc} style={cell}><span style={{ color: 'var(--ink-3)' }}>Doc</span> {activeDocTitle}</div>
+            <div className={styles.sbWords} style={cell}>{words.toLocaleString()} words</div>
+            <div className={styles.sbSections} style={cell}>{sections} sections</div>
             <div style={{ ...cell, color: 'var(--ink-3)' }}>
                 {savedAt ? `Saved ${savedAt.toLocaleTimeString('en-AU', { hour: '2-digit', minute: '2-digit', hour12: false })}` : 'Not saved'}
             </div>
             <div style={{ flexGrow: 1 }} />
-            <div style={{ ...cell, borderRight: 'none', borderLeft: '1px solid var(--line)' }}>
+            <div className={styles.sbEditors} style={{ ...cell, borderRight: 'none', borderLeft: '1px solid var(--line)' }}>
                 {editorCount} editing
             </div>
-            <div style={{ ...cell, borderRight: 'none', borderLeft: '1px solid var(--line)', color: 'var(--ink-3)' }}>
+            <div className={styles.sbDept} style={{ ...cell, borderRight: 'none', borderLeft: '1px solid var(--line)', color: 'var(--ink-3)' }}>
                 {department}
             </div>
         </div>

--- a/apps/web/app/operations/[id]/edit/StatusBar.tsx
+++ b/apps/web/app/operations/[id]/edit/StatusBar.tsx
@@ -37,14 +37,24 @@ export default function StatusBar({
             fontFamily: 'var(--mono)', fontSize: 10,
             letterSpacing: '0.12em', textTransform: 'uppercase',
         }}>
-            <div style={{ ...cell, color: connectedColor }}>
+            {/* data-testid: no accessible role/label distinguishes this cell from the
+                other status-bar cells, and its text ('Live'/'Offline'/'Link —') is
+                the value under test in operations-editor.spec.ts's tab-switch spec —
+                matching on that text would make the selector describe its own
+                assertion. */}
+            <div data-testid='status-connection' style={{ ...cell, color: connectedColor }}>
                 <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'currentColor' }} />
                 {connectedLabel}
             </div>
             <div className={styles.sbDoc} style={cell}><span style={{ color: 'var(--ink-3)' }}>Doc</span> {activeDocTitle}</div>
             <div className={styles.sbWords} style={cell}>{words.toLocaleString()} words</div>
             <div className={styles.sbSections} style={cell}>{sections} sections</div>
-            <div style={{ ...cell, color: 'var(--ink-3)' }}>
+            {/* data-testid: same reasoning as status-connection above — this is the
+                one place `savedAt` (set only by page.tsx's scheduleSave, independent
+                of the collab socket's own connect/disconnect-driven saveStatus) is
+                rendered, which operations-editor.spec.ts's date-edit spec waits on
+                rather than racing the ~1s debounce. */}
+            <div data-testid='status-saved-at' style={{ ...cell, color: 'var(--ink-3)' }}>
                 {savedAt ? `Saved ${savedAt.toLocaleTimeString('en-AU', { hour: '2-digit', minute: '2-digit', hour12: false })}` : 'Not saved'}
             </div>
             <div style={{ flexGrow: 1 }} />

--- a/apps/web/app/operations/[id]/edit/activity-log.tsx
+++ b/apps/web/app/operations/[id]/edit/activity-log.tsx
@@ -222,7 +222,7 @@ export default function ActivityLog({ operationId, onClose }: { operationId: str
             </div>
 
             {/* Log list */}
-            <div style={{ flex: 1, overflowY: 'auto' }}>
+            <div className='thin-scroll' style={{ flex: 1, overflowY: 'auto' }}>
                 {loading && (
                     <div style={{ padding: '24px 12px', textAlign: 'center', fontSize: '0.65rem', color: 'rgba(237,237,237,0.2)', letterSpacing: '0.1em' }}>
                         Loading…

--- a/apps/web/app/operations/[id]/edit/deck/AttendanceCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/AttendanceCard.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useState, type CSSProperties } from 'react'
+import Panel from './Panel'
+
+interface Props {
+    platoons: { id: string; label: string }[]
+    selected: string[]
+    onToggle: (id: string) => void
+
+    customUnits: { id: string; name: string; color?: string }[]
+    onAddCustomUnit: (name: string, color?: string) => void
+    onRemoveCustomUnit: (id: string) => void
+    customUnitsSaving: boolean
+
+    pingEnabled: boolean
+    onTogglePing: () => void
+}
+
+/**
+ * Platoon assignment + Discord ping toggle, pulled out of the Attendance
+ * Settings panel into the deck (Task 11). The full Attendance Settings panel
+ * (platoon checkboxes, ping ROLE checkboxes, mission-stage stepper) stays put
+ * for now — later tasks own removing it — so this card and that panel share
+ * the same underlying state (assignedPlatoons, discordPingEnabled, customUnits)
+ * via the same page.tsx handlers rather than owning a second copy of it.
+ *
+ * The old panel's per-role ping checkboxes (@everyone/@here/…) are NOT
+ * duplicated here — the brief calls for "one labelled toggle row" only, and
+ * that finer control is still live in the untouched Attendance Settings panel.
+ *
+ * Caller must gate rendering on `isHQ` entirely (don't render at all for a
+ * non-HQ user) — this card assumes HQ-only data is safe to show.
+ */
+export default function AttendanceCard({
+    platoons, selected, onToggle,
+    customUnits, onAddCustomUnit, onRemoveCustomUnit, customUnitsSaving,
+    pingEnabled, onTogglePing,
+}: Props) {
+    const [addOpen, setAddOpen] = useState(false)
+    const [name, setName] = useState('')
+    const [color, setColor] = useState('#6366f1')
+
+    function submitAdd() {
+        if (!name.trim()) return
+        onAddCustomUnit(name.trim(), color || undefined)
+        setName('')
+        setAddOpen(false)
+    }
+
+    return (
+        <Panel title="Attendance">
+            <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 14 }}>
+                <div>
+                    <div style={labelStyle}>Assigned Units</div>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                        {platoons.map(p => {
+                            const isSel = selected.includes(p.id)
+                            return (
+                                <button key={p.id} type="button" onClick={() => onToggle(p.id)} style={chipStyle(isSel)}>
+                                    <i style={dotStyle(isSel ? 'var(--acc)' : 'var(--ink-3)')} />
+                                    {p.label}
+                                </button>
+                            )
+                        })}
+                        {customUnits.map(u => (
+                            <span key={u.id} style={chipStyle(true)}>
+                                <i style={dotStyle(u.color ?? 'var(--acc)')} />
+                                {u.name}
+                                <button
+                                    type="button"
+                                    disabled={customUnitsSaving}
+                                    onClick={() => onRemoveCustomUnit(u.id)}
+                                    aria-label={`Remove ${u.name}`}
+                                    style={{ background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer', padding: 0, fontSize: 10, lineHeight: 1 }}
+                                >✕</button>
+                            </span>
+                        ))}
+                        <button type="button" onClick={() => setAddOpen(v => !v)} style={{ ...chipStyle(false), borderStyle: 'dashed' }}>
+                            + Custom Unit
+                        </button>
+                    </div>
+
+                    {addOpen && (
+                        <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginTop: 8 }}>
+                            <input
+                                autoFocus
+                                value={name}
+                                onChange={e => setName(e.target.value)}
+                                placeholder="Unit name…"
+                                maxLength={40}
+                                onKeyDown={e => { if (e.key === 'Enter') submitAdd(); if (e.key === 'Escape') setAddOpen(false) }}
+                                style={{ flex: 1, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', color: 'var(--ink)', fontFamily: 'var(--mono)', fontSize: 11, padding: '5px 8px', outline: 'none' }}
+                            />
+                            <input
+                                type="color"
+                                value={color}
+                                onChange={e => setColor(e.target.value)}
+                                title="Unit colour"
+                                style={{ width: 26, height: 26, padding: 2, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', cursor: 'pointer' }}
+                            />
+                            <button
+                                type="button"
+                                disabled={!name.trim() || customUnitsSaving}
+                                onClick={submitAdd}
+                                style={{ border: '1px solid var(--line-2)', background: 'var(--s2)', borderRadius: 'var(--r)', color: 'var(--ink-2)', fontFamily: 'var(--mono)', fontSize: 9.5, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '5px 9px', cursor: 'pointer', opacity: (!name.trim() || customUnitsSaving) ? 0.5 : 1 }}
+                            >Add</button>
+                        </div>
+                    )}
+                </div>
+
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingTop: 12, borderTop: '1px solid var(--line)' }}>
+                    <span style={labelStyle}>Discord Ping</span>
+                    <button
+                        type="button"
+                        onClick={onTogglePing}
+                        aria-pressed={pingEnabled}
+                        style={{
+                            width: 32, height: 18, borderRadius: 9, cursor: 'pointer',
+                            border: 'none', position: 'relative', padding: 0,
+                            background: pingEnabled ? 'var(--good)' : 'var(--s3)',
+                            transition: 'background 0.15s',
+                        }}
+                    >
+                        <span style={{
+                            position: 'absolute', top: 3, left: pingEnabled ? 17 : 3,
+                            width: 12, height: 12, borderRadius: '50%', background: 'var(--bg)',
+                            transition: 'left 0.15s',
+                        }} />
+                    </button>
+                </div>
+            </div>
+        </Panel>
+    )
+}
+
+const labelStyle: CSSProperties = {
+    fontSize: 10, fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase',
+    color: 'var(--ink-3)', marginBottom: 8,
+}
+
+function chipStyle(selected: boolean): CSSProperties {
+    return {
+        display: 'inline-flex', alignItems: 'center', gap: 7,
+        border: `1px solid ${selected ? 'rgba(var(--acc-rgb), 0.42)' : 'var(--line-2)'}`,
+        background: 'var(--s2)',
+        borderRadius: 'var(--r)',
+        padding: '6px 10px',
+        fontFamily: 'var(--mono)', fontSize: 10,
+        letterSpacing: '0.08em', textTransform: 'uppercase',
+        color: selected ? 'var(--ink)' : 'var(--ink-2)',
+        cursor: 'pointer',
+    }
+}
+
+function dotStyle(background: string): CSSProperties {
+    return { width: 5, height: 5, borderRadius: 1, display: 'block', flexShrink: 0, background }
+}

--- a/apps/web/app/operations/[id]/edit/deck/CountdownStrip.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/CountdownStrip.tsx
@@ -1,0 +1,46 @@
+interface StripProps {
+    daysUntil: number | null
+    checksDone: number
+    checksTotal: number
+}
+
+function Cell({ value, unit, label, tone }: {
+    value: string; unit?: string; label: string; tone: string
+}) {
+    return (
+        <div style={{ padding: '16px 18px', borderRight: '1px solid var(--line)' }}>
+            <div style={{ fontFamily: 'var(--mono)', fontSize: 26, fontWeight: 600, lineHeight: 1.1, color: tone }}>
+                {value}
+                {unit && <small style={{ fontSize: '0.5em', color: 'var(--ink-3)', marginLeft: 3, letterSpacing: '0.1em' }}>{unit}</small>}
+            </div>
+            <div style={{ marginTop: 5, fontSize: 9.5, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--ink-3)', fontWeight: 600 }}>
+                {label}
+            </div>
+        </div>
+    )
+}
+
+export default function CountdownStrip({ daysUntil, checksDone, checksTotal }: StripProps) {
+    const allDone = checksTotal > 0 && checksDone === checksTotal
+    return (
+        <div style={{
+            display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)',
+            borderBottom: '1px solid var(--line)',
+            background: 'linear-gradient(180deg, var(--s1), var(--bg))',
+            flexShrink: 0,
+        }}>
+            <Cell
+                value={daysUntil === null ? '—' : String(daysUntil)}
+                unit={daysUntil === null ? undefined : 'DAYS'}
+                label="Until Op"
+                tone="var(--acc)"
+            />
+            <Cell
+                value={String(checksDone)}
+                unit={`/${checksTotal}`}
+                label="Dev Checks"
+                tone={allDone ? 'var(--good)' : 'var(--warn)'}
+            />
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/deck/DetailsCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/DetailsCard.tsx
@@ -55,6 +55,21 @@ interface Props {
 
     loreDateDayjs: Dayjs | null
     onLoreDateChange: (v: Dayjs | null) => void
+
+    /** Restores the old panel's "Complete Mission" button (Task 11, ruling 1).
+     * Writes the operation's `status` (Active → Completed) via the same
+     * `applyStage('confirmations_open')` path as before — distinct from
+     * StageCard's attendance `stage`, even though that path also advances
+     * the stage as a side effect. Caller gates the write; this card gates
+     * the button's visibility on `isHQ && status === 'Active'`, matching the
+     * old inline condition. */
+    onCompleteMission: () => void
+    completingMission: boolean
+
+    coverImage: string | null
+    coverUploading: boolean
+    onUploadCover: (file: File) => void
+    onRemoveCover: () => void
 }
 
 const rowStyle: CSSProperties = {
@@ -94,12 +109,10 @@ function Row({ label, children }: { label: string; children: ReactNode }) {
  * card is presentation only, every handler is passed down from page.tsx so
  * the save paths (and their exact keys/endpoints) don't move.
  *
- * Not rehomed here: the cover photo upload and the orders-acknowledgement
- * block. Neither fits this row idiom (an image + upload/replace/remove, and
- * a count/expand/remind list, respectively) and Task 12's brief already
- * earmarks acknowledgements for the future Attendance tab — see the task-11
- * report for the full writeup. Both stay live in page.tsx, just outside the
- * deleted panel, pending a ruling on their permanent home.
+ * Not rehomed here: the orders-acknowledgement block, still left mounted in
+ * page.tsx pending Task 12's Attendance tab (see the task-11 report). The
+ * cover photo *is* rehomed here as a compact data row — see the "Cover" row
+ * below.
  */
 export default function DetailsCard({
     title, onTitleChange,
@@ -111,6 +124,8 @@ export default function DetailsCard({
     pageTheme, eraOptions, onPageThemeChange,
     mapWorld, availableWorlds, onMapWorldChange,
     loreDateDayjs, onLoreDateChange,
+    onCompleteMission, completingMission,
+    coverImage, coverUploading, onUploadCover, onRemoveCover,
 }: Props) {
     const statusColor = STATUS_COLOR[status] ?? 'var(--ink-3)'
 
@@ -200,6 +215,80 @@ export default function DetailsCard({
                         <option value="Completed">Completed</option>
                         {isHQ && <option value="In Development">In Development</option>}
                     </select>
+                </Row>
+
+                {/* Complete Mission — same visibility gate the old inline button had
+                    (`isHQ && status === 'Active'`), sitting directly under the Status
+                    row it acts on. No confirmation dialog, matching the original. */}
+                {isHQ && status === 'Active' && (
+                    <div style={{ padding: '0 16px 12px', display: 'flex', justifyContent: 'flex-end' }}>
+                        <button
+                            type="button"
+                            onClick={onCompleteMission}
+                            disabled={completingMission}
+                            style={{
+                                border: '1px solid rgba(var(--acc-rgb), 0.6)',
+                                background: 'rgba(var(--acc-rgb), 0.15)',
+                                borderRadius: 'var(--r)',
+                                color: 'var(--acc)',
+                                fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700,
+                                letterSpacing: '0.12em', textTransform: 'uppercase',
+                                padding: '6px 12px',
+                                cursor: completingMission ? 'not-allowed' : 'pointer',
+                                opacity: completingMission ? 0.6 : 1,
+                            }}
+                        >
+                            {completingMission ? 'Completing…' : 'Complete Mission'}
+                        </button>
+                    </div>
+                )}
+
+                <Row label="Cover">
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                        {coverImage && (
+                            <img
+                                src={coverImage}
+                                alt=""
+                                style={{
+                                    width: 56, height: 32, objectFit: 'cover',
+                                    borderRadius: 'var(--r)', border: '1px solid var(--line-2)',
+                                    display: 'block', flexShrink: 0,
+                                }}
+                            />
+                        )}
+                        <label style={{
+                            fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700,
+                            letterSpacing: '0.1em', textTransform: 'uppercase',
+                            color: coverUploading ? 'var(--ink-3)' : 'var(--acc)',
+                            cursor: coverUploading ? 'not-allowed' : 'pointer',
+                            whiteSpace: 'nowrap',
+                        }}>
+                            {coverUploading ? 'Uploading…' : coverImage ? 'Replace' : 'Upload'}
+                            <input
+                                type="file"
+                                accept="image/*"
+                                disabled={coverUploading}
+                                style={{ display: 'none' }}
+                                onChange={e => { const f = e.target.files?.[0]; if (f) onUploadCover(f) }}
+                            />
+                        </label>
+                        {coverImage && (
+                            <button
+                                type="button"
+                                onClick={onRemoveCover}
+                                disabled={coverUploading}
+                                style={{
+                                    background: 'none', border: 'none', padding: 0,
+                                    fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700,
+                                    letterSpacing: '0.1em', textTransform: 'uppercase',
+                                    color: 'var(--ink-3)',
+                                    cursor: coverUploading ? 'not-allowed' : 'pointer',
+                                }}
+                            >
+                                Remove
+                            </button>
+                        )}
+                    </span>
                 </Row>
 
                 <Row label="Theme Colour">

--- a/apps/web/app/operations/[id]/edit/deck/DetailsCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/DetailsCard.tsx
@@ -142,7 +142,7 @@ export default function DetailsCard({
                         width: '100%', background: 'transparent', border: 'none',
                         borderBottom: '1px solid var(--line-2)',
                         color: 'var(--ink)', fontSize: 15, fontWeight: 700,
-                        letterSpacing: '0.04em', textTransform: 'uppercase',
+                        letterSpacing: '0.04em',
                         outline: 'none', padding: '4px 0 8px', boxSizing: 'border-box',
                     }}
                 />

--- a/apps/web/app/operations/[id]/edit/deck/DetailsCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/DetailsCard.tsx
@@ -1,0 +1,283 @@
+'use client'
+
+import type { CSSProperties, ReactNode } from 'react'
+import type { Dayjs } from 'dayjs'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
+import Panel from './Panel'
+import MapWorldPicker from './MapWorldPicker'
+
+// Same lifecycle-status palette Header.tsx uses (token-backed there too) —
+// kept in sync by hand since Header doesn't export it.
+const STATUS_COLOR: Record<string, string> = {
+    'Active': 'var(--good)',
+    'Upcoming': 'var(--warn)',
+    'Completed': 'var(--ink-3)',
+    'In Development': 'var(--crit)',
+}
+
+interface Props {
+    title: string
+    onTitleChange: (v: string) => void
+
+    ownedBy: string
+    ownedByName: string
+    canPickOwner: boolean
+    ownerPickerOpen: boolean
+    j2Members: { id: string; displayName: string }[]
+    onOpenOwnerPicker: () => void
+    onCloseOwnerPicker: () => void
+    onSelectOwner: (id: string, displayName: string) => void
+
+    canSeeBilletPoints: boolean
+    billetPoints: number
+    onBilletPointsChange: (v: number) => void
+    onBilletPointsBlur: () => void
+
+    department: string
+    onDepartmentChange: (v: string) => void
+
+    status: string
+    isHQ: boolean
+    onStatusChange: (v: string) => void
+
+    themeColor: string
+    onThemeColorChange: (v: string) => void
+
+    pageTheme: string
+    eraOptions: { _id: string; name: string; value: string }[]
+    onPageThemeChange: (v: string) => void
+
+    mapWorld: string
+    availableWorlds: { name: string; displayName: string; hasPreview: boolean }[]
+    onMapWorldChange: (v: string) => void
+
+    loreDateDayjs: Dayjs | null
+    onLoreDateChange: (v: Dayjs | null) => void
+}
+
+const rowStyle: CSSProperties = {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12,
+    padding: '9px 16px', borderBottom: '1px solid var(--line)',
+}
+
+const keyStyle: CSSProperties = {
+    fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase',
+    color: 'var(--ink-3)', flexShrink: 0,
+}
+
+const valueStyle: CSSProperties = {
+    fontFamily: 'var(--mono)', fontSize: 12, color: 'var(--ink)',
+    textAlign: 'right', minWidth: 0,
+}
+
+const controlStyle: CSSProperties = {
+    background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)',
+    color: 'var(--ink)', fontFamily: 'var(--mono)', fontSize: 11.5,
+    padding: '5px 8px', outline: 'none', textAlign: 'right', maxWidth: 168,
+}
+
+/** One `rw`/`rwK`/`rwV` data row — label left, value/control right. */
+function Row({ label, children }: { label: string; children: ReactNode }) {
+    return (
+        <div style={rowStyle}>
+            <span style={keyStyle}>{label}</span>
+            <span style={valueStyle}>{children}</span>
+        </div>
+    )
+}
+
+/**
+ * Replaces the old "Operation Details" panel's metadata fields (Task 11).
+ * Owns the same scheduleSave/fetch call sites page.tsx already had — this
+ * card is presentation only, every handler is passed down from page.tsx so
+ * the save paths (and their exact keys/endpoints) don't move.
+ *
+ * Not rehomed here: the cover photo upload and the orders-acknowledgement
+ * block. Neither fits this row idiom (an image + upload/replace/remove, and
+ * a count/expand/remind list, respectively) and Task 12's brief already
+ * earmarks acknowledgements for the future Attendance tab — see the task-11
+ * report for the full writeup. Both stay live in page.tsx, just outside the
+ * deleted panel, pending a ruling on their permanent home.
+ */
+export default function DetailsCard({
+    title, onTitleChange,
+    ownedBy, ownedByName, canPickOwner, ownerPickerOpen, j2Members, onOpenOwnerPicker, onCloseOwnerPicker, onSelectOwner,
+    canSeeBilletPoints, billetPoints, onBilletPointsChange, onBilletPointsBlur,
+    department, onDepartmentChange,
+    status, isHQ, onStatusChange,
+    themeColor, onThemeColorChange,
+    pageTheme, eraOptions, onPageThemeChange,
+    mapWorld, availableWorlds, onMapWorldChange,
+    loreDateDayjs, onLoreDateChange,
+}: Props) {
+    const statusColor = STATUS_COLOR[status] ?? 'var(--ink-3)'
+
+    return (
+        <Panel title="Details">
+            {/* Title — kept as its own prominent field rather than a data row,
+                same visual weight the old panel gave it. */}
+            <div style={{ padding: '14px 16px 0' }}>
+                <input
+                    value={title}
+                    placeholder="Operation Name"
+                    onChange={e => onTitleChange(e.target.value)}
+                    style={{
+                        width: '100%', background: 'transparent', border: 'none',
+                        borderBottom: '1px solid var(--line-2)',
+                        color: 'var(--ink)', fontSize: 15, fontWeight: 700,
+                        letterSpacing: '0.04em', textTransform: 'uppercase',
+                        outline: 'none', padding: '4px 0 8px', boxSizing: 'border-box',
+                    }}
+                />
+            </div>
+
+            <div style={{ marginTop: 4 }}>
+                <Row label="Owner">
+                    {ownerPickerOpen && canPickOwner ? (
+                        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                            <select
+                                defaultValue={ownedBy}
+                                onChange={e => {
+                                    const sel = j2Members.find(m => m.id === e.target.value)
+                                    if (sel) onSelectOwner(sel.id, sel.displayName)
+                                }}
+                                style={{ ...controlStyle, textAlign: 'left' }}
+                            >
+                                <option value="">— Select member —</option>
+                                {j2Members.map(m => <option key={m.id} value={m.id}>{m.displayName}</option>)}
+                            </select>
+                            <button type="button" onClick={onCloseOwnerPicker}
+                                style={{ background: 'none', border: 'none', color: 'var(--ink-3)', fontSize: 10, cursor: 'pointer', padding: 0 }}
+                            >Cancel</button>
+                        </div>
+                    ) : (
+                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                            <span style={{ fontStyle: ownedByName ? 'normal' : 'italic', color: ownedByName ? 'var(--ink)' : 'var(--ink-3)' }}>
+                                {ownedByName || 'Unassigned'}
+                            </span>
+                            {canPickOwner && (
+                                <button type="button" onClick={onOpenOwnerPicker}
+                                    style={{ background: 'none', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', color: 'var(--acc)', fontSize: 9.5, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '2px 7px', cursor: 'pointer' }}
+                                >Change</button>
+                            )}
+                        </span>
+                    )}
+                </Row>
+
+                {canSeeBilletPoints && (
+                    <Row label="Billet Points">
+                        <input
+                            type="number"
+                            min={0}
+                            step={1}
+                            value={billetPoints}
+                            onChange={e => onBilletPointsChange(Math.max(0, parseInt(e.target.value) || 0))}
+                            onBlur={onBilletPointsBlur}
+                            style={{ ...controlStyle, width: 60, maxWidth: 60, textAlign: 'center' }}
+                        />
+                    </Row>
+                )}
+
+                <Row label="Department">
+                    <input
+                        value={department}
+                        placeholder="Department"
+                        onChange={e => onDepartmentChange(e.target.value)}
+                        style={controlStyle}
+                    />
+                </Row>
+
+                <Row label="Status">
+                    <select
+                        value={status}
+                        onChange={e => onStatusChange(e.target.value)}
+                        style={{ ...controlStyle, color: statusColor, fontWeight: 700, cursor: 'pointer' }}
+                    >
+                        <option value="Upcoming">Upcoming</option>
+                        <option value="Active">Active</option>
+                        <option value="Completed">Completed</option>
+                        {isHQ && <option value="In Development">In Development</option>}
+                    </select>
+                </Row>
+
+                <Row label="Theme Colour">
+                    <label style={{ display: 'inline-flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                        <input
+                            type="color"
+                            value={themeColor}
+                            onChange={e => onThemeColorChange(e.target.value)}
+                            style={{ width: 20, height: 20, border: 'none', padding: 0, background: 'transparent', cursor: 'pointer' }}
+                        />
+                        <span>{themeColor}</span>
+                    </label>
+                </Row>
+
+                <Row label="Era">
+                    <select
+                        value={pageTheme ?? 'modern'}
+                        onChange={e => onPageThemeChange(e.target.value)}
+                        style={{ ...controlStyle, cursor: 'pointer' }}
+                    >
+                        {eraOptions.length > 0
+                            ? eraOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.name}</option>)
+                            : (
+                                <>
+                                    <option value="modern">Modern</option>
+                                    <option value="wwii">WWII</option>
+                                    <option value="vietnam">Vietnam</option>
+                                    <option value="coldwar">Cold War</option>
+                                    <option value="fantasy">Fantasy</option>
+                                    <option value="scifi">Sci-Fi</option>
+                                </>
+                            )
+                        }
+                    </select>
+                </Row>
+
+                <Row label="Map">
+                    <MapWorldPicker
+                        value={mapWorld}
+                        worlds={availableWorlds}
+                        onChange={onMapWorldChange}
+                        themeColor={themeColor}
+                    />
+                </Row>
+
+                <div style={{ padding: '12px 16px 16px' }}>
+                    <div style={{ ...keyStyle, marginBottom: 8 }}>In-Game Date &amp; Time</div>
+                    <LocalizationProvider dateAdapter={AdapterDayjs}>
+                        <DateTimePicker
+                            value={loreDateDayjs}
+                            format="DD/MM/YYYY HH:mm"
+                            onChange={onLoreDateChange}
+                            slotProps={{ textField: { size: 'small', sx: pickerSx } }}
+                        />
+                    </LocalizationProvider>
+                </div>
+            </div>
+        </Panel>
+    )
+}
+
+const pickerSx = {
+    width: '100%',
+    '& .MuiInputBase-root': {
+        background: 'var(--s2)',
+        borderRadius: 'var(--r)',
+        fontFamily: 'var(--mono)',
+        fontSize: 12,
+    },
+    '& .MuiOutlinedInput-notchedOutline': {
+        border: '1px solid var(--line-2)',
+    },
+    '& .MuiInputBase-input': {
+        color: 'var(--ink-2)',
+        padding: '6px 10px',
+    },
+    '& .MuiSvgIcon-root': {
+        color: 'var(--ink-3)',
+        fontSize: 16,
+    },
+}

--- a/apps/web/app/operations/[id]/edit/deck/MapWorldPicker.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/MapWorldPicker.tsx
@@ -178,7 +178,7 @@ export default function MapWorldPicker({
                         </div>
                     )}
 
-                    <div style={{ overflowY: 'auto', flex: 1 }}>
+                    <div className='thin-scroll' style={{ overflowY: 'auto', flex: 1 }}>
                         {/* No map option */}
                         <div className='mwp-item' onClick={() => { onChange(''); setOpen(false) }}
                             style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 10, padding: '7px 12px', cursor: 'pointer', background: !value ? 'rgba(255,255,255,0.06)' : 'transparent', borderBottom: '1px solid rgba(255,255,255,0.06)', fontSize: '0.78rem', color: 'rgba(237,237,237,0.35)' }}>

--- a/apps/web/app/operations/[id]/edit/deck/MapWorldPicker.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/MapWorldPicker.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+// ─── Popular Arma 3 maps (shown when not in maps system) ─────────────────────
+
+const POPULAR_MAPS: { name: string; displayName: string }[] = [
+    { name: 'altis', displayName: 'Altis' },
+    { name: 'stratis', displayName: 'Stratis' },
+    { name: 'tanoa', displayName: 'Tanoa' },
+    { name: 'malden', displayName: 'Malden' },
+    { name: 'livonia', displayName: 'Livonia' },
+    { name: 'chernarus', displayName: 'Chernarus' },
+    { name: 'takistan', displayName: 'Takistan' },
+    { name: 'sahrani', displayName: 'Sahrani' },
+    { name: 'panthera', displayName: 'Panthera' },
+    { name: 'lingor', displayName: 'Lingor' },
+    { name: 'namalsk', displayName: 'Namalsk' },
+    { name: 'fallujah', displayName: 'Fallujah' },
+    { name: 'clafghan', displayName: 'Clafghan' },
+    { name: 'porto', displayName: 'Porto' },
+    { name: 'utes', displayName: 'Utes' },
+    { name: 'zargabad', displayName: 'Zargabad' },
+    { name: 'desert_e', displayName: 'Desert (IRL)' },
+]
+
+// ─── Map World Picker ─────────────────────────────────────────────────────────
+// Extracted verbatim from page.tsx (Task 11) — same behaviour, same styling,
+// just its own file so DetailsCard can import it instead of page.tsx
+// duplicating it.
+
+export default function MapWorldPicker({
+    value,
+    worlds,
+    onChange,
+    themeColor,
+}: {
+    value: string
+    worlds: { name: string; displayName: string; hasPreview: boolean }[]
+    onChange: (name: string) => void
+    themeColor: string
+}) {
+    const [open, setOpen] = useState(false)
+    const [search, setSearch] = useState('')
+    const [customValue, setCustomValue] = useState('')
+    const [showCustom, setShowCustom] = useState(false)
+    const ref = useRef<HTMLDivElement>(null)
+    const searchRef = useRef<HTMLInputElement>(null)
+
+    const selected = worlds.find(w => w.name === value)
+        ?? POPULAR_MAPS.find(m => m.name === value)
+        ?? (value ? { name: value, displayName: value } : null)
+
+    useEffect(() => {
+        if (!open) { setSearch(''); setShowCustom(false) }
+        else setTimeout(() => searchRef.current?.focus(), 50)
+    }, [open])
+
+    useEffect(() => {
+        if (!open) return
+        const close = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) setOpen(false) }
+        document.addEventListener('mousedown', close)
+        return () => document.removeEventListener('mousedown', close)
+    }, [open])
+
+    // Merge maps-system worlds with popular maps (deduplicate by name)
+    const systemNames = new Set(worlds.map(w => w.name))
+    const popularFiltered = POPULAR_MAPS.filter(m => !systemNames.has(m.name))
+
+    const allMaps: { name: string; displayName: string; hasPreview: boolean; isSystem?: boolean }[] = [
+        ...worlds.map(w => ({ ...w, isSystem: true })),
+        ...popularFiltered.map(m => ({ ...m, hasPreview: false, isSystem: false })),
+    ]
+
+    const q = search.toLowerCase()
+    const filtered = q
+        ? allMaps.filter(m => m.displayName.toLowerCase().includes(q) || m.name.toLowerCase().includes(q))
+        : allMaps
+
+    const systemMaps = filtered.filter(m => m.isSystem)
+    const popularMaps = filtered.filter(m => !m.isSystem)
+
+    function MapItem({ w }: { w: typeof allMaps[number] }) {
+        const isActive = w.name === value
+        return (
+            <div
+                className='mwp-item'
+                onClick={() => { onChange(w.name); setOpen(false) }}
+                style={{
+                    position: 'relative',
+                    display: 'flex', alignItems: 'center', gap: 10,
+                    padding: '7px 12px', cursor: 'pointer',
+                    background: isActive ? 'rgba(255,255,255,0.07)' : 'transparent',
+                    borderLeft: isActive ? `2px solid ${themeColor}` : '2px solid transparent',
+                    fontSize: '0.78rem', color: isActive ? 'rgba(237,237,237,0.95)' : 'rgba(237,237,237,0.6)',
+                }}
+            >
+                {!isActive && <div className='mwp-hover' style={{ position: 'absolute', inset: 0, background: 'rgba(255,255,255,0.04)', opacity: 0, transition: 'opacity 0.1s ease', pointerEvents: 'none', willChange: 'opacity' }} />}
+                {w.hasPreview ? (
+                    <img src={`/map-assets/${w.name}/preview.jpg`} alt='' loading='lazy' style={{ width: 40, height: 28, objectFit: 'cover', flexShrink: 0, border: `1px solid ${isActive ? 'rgba(255,255,255,0.2)' : 'rgba(255,255,255,0.08)'}` }} />
+                ) : (
+                    <div style={{ width: 40, height: 28, background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <span style={{ fontSize: 9, color: 'rgba(255,255,255,0.15)' }}>MAP</span>
+                    </div>
+                )}
+                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{w.displayName}</span>
+                {w.isSystem && <span style={{ fontSize: '0.55rem', color: 'rgba(34,197,94,0.6)', flexShrink: 0, letterSpacing: '0.08em' }}>SYSTEM</span>}
+            </div>
+        )
+    }
+
+    return (
+        <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
+            <button
+                type='button'
+                onClick={() => setOpen(v => !v)}
+                style={{
+                    display: 'flex', alignItems: 'center', gap: 8,
+                    background: 'rgba(0,0,0,0.4)',
+                    border: `1px solid ${open ? 'rgba(255,255,255,0.2)' : 'rgba(255,255,255,0.1)'}`,
+                    color: selected ? 'rgba(237,237,237,0.85)' : 'rgba(237,237,237,0.3)',
+                    fontSize: '0.8rem', letterSpacing: '0.06em',
+                    padding: '6px 10px', cursor: 'pointer', minWidth: 160,
+                    transition: 'border-color 0.15s',
+                }}
+            >
+                {selected && worlds.find(w => w.name === value)?.hasPreview && (
+                    <img src={`/map-assets/${value}/preview.jpg`} alt='' style={{ width: 28, height: 20, objectFit: 'cover', flexShrink: 0, border: '1px solid rgba(255,255,255,0.1)' }} />
+                )}
+                <span style={{ flex: 1, textAlign: 'left' }}>{selected?.displayName ?? 'No Map'}</span>
+                <span style={{ fontSize: '0.6rem', opacity: 0.4 }}>▾</span>
+            </button>
+
+            {open && (
+                <div style={{
+                    position: 'absolute', top: '100%', left: 0, marginTop: 4, zIndex: 400,
+                    background: 'rgb(14,14,14)', border: '1px solid rgba(255,255,255,0.12)',
+                    minWidth: 260, maxHeight: 380,
+                    boxShadow: '0 8px 24px rgba(0,0,0,0.7)',
+                    display: 'flex', flexDirection: 'column',
+                }}>
+                    <style>{`.mwp-item:hover .mwp-hover{opacity:1!important}`}</style>
+
+                    {/* Search */}
+                    <div style={{ padding: '8px 10px', borderBottom: '1px solid rgba(255,255,255,0.07)', flexShrink: 0 }}>
+                        <input
+                            ref={searchRef}
+                            value={search}
+                            onChange={e => setSearch(e.target.value)}
+                            placeholder='Search maps…'
+                            style={{ width: '100%', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.85)', fontSize: '0.75rem', padding: '5px 8px', outline: 'none', fontFamily: 'inherit' }}
+                        />
+                    </div>
+
+                    {/* Custom map option */}
+                    {!showCustom ? (
+                        <button
+                            type='button'
+                            onClick={() => setShowCustom(true)}
+                            style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', background: 'rgba(219,0,29,0.05)', borderTop: 'none', borderRight: 'none', borderBottom: '1px solid rgba(255,255,255,0.06)', borderLeft: 'none', cursor: 'pointer', color: 'rgba(219,0,29,0.7)', fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.06em', textAlign: 'left' }}
+                        >
+                            + Custom Map…
+                        </button>
+                    ) : (
+                        <div style={{ flexShrink: 0, display: 'flex', gap: 4, padding: '6px 10px', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+                            <input
+                                autoFocus
+                                value={customValue}
+                                onChange={e => setCustomValue(e.target.value)}
+                                placeholder='Enter map name…'
+                                onKeyDown={e => {
+                                    if (e.key === 'Enter' && customValue.trim()) { onChange(customValue.trim()); setOpen(false) }
+                                    if (e.key === 'Escape') setShowCustom(false)
+                                }}
+                                style={{ flex: 1, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(219,0,29,0.3)', color: 'rgba(237,237,237,0.85)', fontSize: '0.75rem', padding: '4px 8px', outline: 'none', fontFamily: 'inherit' }}
+                            />
+                            <button type='button' onClick={() => { if (customValue.trim()) { onChange(customValue.trim()); setOpen(false) } }} style={{ background: 'rgba(219,0,29,0.15)', border: '1px solid rgba(219,0,29,0.35)', color: 'rgba(219,0,29,0.8)', fontSize: '0.68rem', fontWeight: 700, padding: '4px 10px', cursor: 'pointer' }}>OK</button>
+                        </div>
+                    )}
+
+                    <div style={{ overflowY: 'auto', flex: 1 }}>
+                        {/* No map option */}
+                        <div className='mwp-item' onClick={() => { onChange(''); setOpen(false) }}
+                            style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 10, padding: '7px 12px', cursor: 'pointer', background: !value ? 'rgba(255,255,255,0.06)' : 'transparent', borderBottom: '1px solid rgba(255,255,255,0.06)', fontSize: '0.78rem', color: 'rgba(237,237,237,0.35)' }}>
+                            <div className='mwp-hover' style={{ position: 'absolute', inset: 0, background: 'rgba(255,255,255,0.04)', opacity: 0, transition: 'opacity 0.1s ease', pointerEvents: 'none', willChange: 'opacity' }} />
+                            <div style={{ width: 40, height: 28, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                                <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.2)' }}>—</span>
+                            </div>
+                            No Map
+                        </div>
+
+                        {/* Maps system maps */}
+                        {systemMaps.length > 0 && (
+                            <>
+                                <div style={{ padding: '5px 12px 3px', fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'rgba(34,197,94,0.5)' }}>Maps System</div>
+                                {systemMaps.map(w => <MapItem key={w.name} w={w} />)}
+                            </>
+                        )}
+
+                        {/* Popular Arma 3 maps */}
+                        {popularMaps.length > 0 && (
+                            <>
+                                <div style={{ padding: '5px 12px 3px', fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.2)' }}>Arma 3 Maps</div>
+                                {popularMaps.map(w => <MapItem key={w.name} w={w} />)}
+                            </>
+                        )}
+
+                        {filtered.length === 0 && q && (
+                            <div style={{ padding: '16px', textAlign: 'center', fontSize: '0.72rem', color: 'rgba(237,237,237,0.2)', fontStyle: 'italic' }}>No maps matching "{search}"</div>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
@@ -5,12 +5,12 @@ import { useEffect, useState, type ReactNode } from 'react'
 const STORAGE_KEY = 'asot.opsdeck.collapsed'
 
 // Below this the shell doesn't have room to push the deck's 340px alongside
-// the tab content (spec §8: "1024–1279px: deck collapses to a 44px rail,
-// expanding as an overlay on click" / "<1024px: … overlay drawers"). Both
-// bands get the same treatment here — a rail that expands as a floating
-// overlay rather than pushing layout — since nothing in the spec's two rows
-// distinguishes deck behaviour between them, only the (out-of-scope-for-this
-// file) documents rail does.
+// the tab content (spec §8: "1024–1279px: deck collapses fully, expanding as
+// an overlay on click" / "<1024px: … overlay drawers"). Both bands get the
+// same treatment here — collapsing to nothing but the pull-tab, then
+// expanding as a floating overlay rather than pushing layout — since nothing
+// in the spec's two rows distinguishes deck behaviour between them, only the
+// (out-of-scope-for-this-file) documents rail does.
 const WIDE_QUERY = '(min-width: 1280px)'
 
 /**
@@ -75,8 +75,16 @@ export default function MissionDeck({ strip, children }: {
     const overlay = !isWide && !collapsed
 
     if (collapsed) {
+        // Width 0, no border, no background — nothing of the deck itself is
+        // visible or occupies layout; the editor column reclaims the full
+        // width. `overflow: visible` (the default, stated explicitly here
+        // because the expanded case below has to override its own scroll
+        // rule to get the same effect) lets the pull-tab, which is
+        // `position: absolute` and sits mostly outside this 0-width box,
+        // still render — nothing about a 0-width ancestor clips a child that
+        // paints outside its bounds unless that ancestor also clips overflow.
         return (
-            <aside style={{ width: 44, flexShrink: 0, borderLeft: '1px solid var(--line)', background: 'var(--bg)', position: 'relative' }}>
+            <aside style={{ width: 0, flexShrink: 0, position: 'relative', overflow: 'visible' }}>
                 <CollapseTab
                     expanded={false}
                     onClick={isWide ? toggleCollapsedPref : () => setOverlayOpen(true)}
@@ -89,26 +97,30 @@ export default function MissionDeck({ strip, children }: {
         <aside style={{
             width: overlay ? 'min(340px, 92vw)' : 340,
             flexShrink: 0,
-            borderLeft: '1px solid var(--line)',
-            background: 'var(--bg)',
-            display: 'flex', flexDirection: 'column',
-            overflowY: 'auto',
             position: 'relative',
+            // Deliberately visible, not the `overflowY: 'auto'` the scroll
+            // area itself needs: setting overflow-y to anything but visible
+            // while leaving overflow-x untouched makes the UA compute
+            // overflow-x as `auto` too (CSSOM overflow §2), which would clip
+            // CollapseTab's horizontal overhang below. The scrolling rule
+            // moves to the inner div instead so this outer box can stay
+            // visible and let the tab protrude over .main uncropped.
+            overflow: 'visible',
             // Overlay case (<1280px, expanded): float above the tab content
             // instead of pushing it — there's no room to push. Positioned
             // against .body (shell.module.css sets `position: relative`
             // there for exactly this) rather than the viewport, so it docks
             // under the header/tab bar instead of covering them.
             ...(overlay
-                ? { position: 'absolute', right: 0, top: 0, bottom: 0, zIndex: 30, boxShadow: '-8px 0 24px rgba(0,0,0,0.45)' }
+                ? { position: 'absolute', right: 0, top: 0, bottom: 0, zIndex: 30 }
                 : {}),
         }}>
             {/*
              * Not in the original brief code — that version only ever renders
              * an expand button (in the collapsed rail below), with no way
              * back to collapsed once expanded. Kept so "collapse toggle"
-             * (this file's stated purpose) is actually bidirectional — now a
-             * small tab straddling the top-left corner instead of a full
+             * (this file's stated purpose) is actually bidirectional — a
+             * small tab overhanging the top-left corner instead of a full
              * row, so the countdown strip (`strip`) sits at the very top of
              * the deck's own scroll content.
              */}
@@ -116,21 +128,37 @@ export default function MissionDeck({ strip, children }: {
                 expanded={true}
                 onClick={isWide ? toggleCollapsedPref : () => setOverlayOpen(false)}
             />
-            {strip}
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 16, padding: 16 }}>
-                {children}
+            {/* The actual visible deck box — border, background and the
+                vertical scroll all live here now, not on the outer `aside`
+                (see the `overflow: visible` comment above). */}
+            <div style={{
+                height: '100%',
+                display: 'flex', flexDirection: 'column',
+                borderLeft: '1px solid var(--line)',
+                background: 'var(--bg)',
+                overflowY: 'auto',
+                ...(overlay ? { boxShadow: '-8px 0 24px rgba(0,0,0,0.45)' } : {}),
+            }}>
+                {strip}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 16, padding: 16 }}>
+                    {children}
+                </div>
             </div>
         </aside>
     )
 }
 
 /**
- * The deck's collapse/expand control: a small tab protruding from the top-left
- * corner, straddling the deck's own left border, rather than a full-width row
- * (see the module doc above — that row used to cost the deck a whole row of
- * vertical space). Rendered inside an `aside` with `position: relative` in
- * both the collapsed (44px rail) and expanded (340px) cases, so `left: -11px`
- * always resolves against that aside's own left edge.
+ * The deck's collapse/expand control: a pull-tab that hangs off the deck's
+ * top-left corner rather than sitting flush on its border or inside it, and
+ * rather than a full-width row (see the module doc above — that row used to
+ * cost the deck a whole row of vertical space). Rendered inside an `aside`
+ * with `position: relative` in both the collapsed (0-width) and expanded
+ * (340px) cases, so `left: -16px` always resolves against that aside's own
+ * left edge — i.e. against where the deck's visible border sits when
+ * expanded, and where it *used* to sit when collapsed. Most of the button's
+ * 22px width falls outside that edge, into the editor column, so it reads as
+ * a tab clipped to the side of the deck rather than part of the deck itself.
  */
 function CollapseTab({ expanded, onClick }: { expanded: boolean; onClick: () => void }) {
     return (
@@ -141,16 +169,20 @@ function CollapseTab({ expanded, onClick }: { expanded: boolean; onClick: () => 
             style={{
                 position: 'absolute',
                 top: 12,
-                left: -11,
+                left: -16,
                 width: 22,
-                height: 24,
+                height: 22,
                 display: 'flex', alignItems: 'center', justifyContent: 'center',
                 background: 'var(--s2)',
                 border: '1px solid var(--line-2)',
-                borderRadius: 'var(--r) 0 0 var(--r)',
+                borderRadius: 'var(--r)',
                 color: 'var(--ink-2)',
                 cursor: 'pointer',
-                zIndex: 5,
+                // Above the editor column (.main, an unpositioned sibling of
+                // this aside in EditorShell's .body) regardless of DOM/paint
+                // order, and above the collapsed 0-width aside's own empty
+                // box — this is the only thing ever painted from it.
+                zIndex: 20,
             }}
         >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, type ReactNode } from 'react'
+import { useThinScrollFade } from '@/components/editor/useThinScrollFade'
 
 const STORAGE_KEY = 'asot.opsdeck.collapsed'
 
@@ -37,6 +38,7 @@ export default function MissionDeck({ strip, children }: {
     children: ReactNode
 }) {
     const isWide = useIsWide()
+    const scrollFadeRef = useThinScrollFade<HTMLDivElement>()
 
     // The user's manual preference — meaningful only at >=1280px, where the
     // deck pushes layout and the old collapse/expand toggle behaves exactly
@@ -131,14 +133,18 @@ export default function MissionDeck({ strip, children }: {
             {/* The actual visible deck box — border, background and the
                 vertical scroll all live here now, not on the outer `aside`
                 (see the `overflow: visible` comment above). */}
-            <div style={{
-                height: '100%',
-                display: 'flex', flexDirection: 'column',
-                borderLeft: '1px solid var(--line)',
-                background: 'var(--bg)',
-                overflowY: 'auto',
-                ...(overlay ? { boxShadow: '-8px 0 24px rgba(0,0,0,0.45)' } : {}),
-            }}>
+            <div
+                ref={scrollFadeRef}
+                className='thin-scroll'
+                style={{
+                    height: '100%',
+                    display: 'flex', flexDirection: 'column',
+                    borderLeft: '1px solid var(--line)',
+                    background: 'var(--bg)',
+                    overflowY: 'auto',
+                    ...(overlay ? { boxShadow: '-8px 0 24px rgba(0,0,0,0.45)' } : {}),
+                }}
+            >
                 {strip}
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 16, padding: 16 }}>
                     {children}

--- a/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
@@ -76,17 +76,11 @@ export default function MissionDeck({ strip, children }: {
 
     if (collapsed) {
         return (
-            <aside style={{ width: 44, flexShrink: 0, borderLeft: '1px solid var(--line)', background: 'var(--bg)' }}>
-                <button
-                    type="button"
+            <aside style={{ width: 44, flexShrink: 0, borderLeft: '1px solid var(--line)', background: 'var(--bg)', position: 'relative' }}>
+                <CollapseTab
+                    expanded={false}
                     onClick={isWide ? toggleCollapsedPref : () => setOverlayOpen(true)}
-                    aria-label="Expand mission deck"
-                    style={{ width: 44, height: 44, background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer' }}
-                >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                        <path d="M15 18l-6-6 6-6" />
-                    </svg>
-                </button>
+                />
             </aside>
         )
     }
@@ -99,6 +93,7 @@ export default function MissionDeck({ strip, children }: {
             background: 'var(--bg)',
             display: 'flex', flexDirection: 'column',
             overflowY: 'auto',
+            position: 'relative',
             // Overlay case (<1280px, expanded): float above the tab content
             // instead of pushing it — there's no room to push. Positioned
             // against .body (shell.module.css sets `position: relative`
@@ -111,25 +106,56 @@ export default function MissionDeck({ strip, children }: {
             {/*
              * Not in the original brief code — that version only ever renders
              * an expand button (in the collapsed rail below), with no way
-             * back to collapsed once expanded. Added so "collapse toggle"
-             * (this file's stated purpose) is actually bidirectional.
+             * back to collapsed once expanded. Kept so "collapse toggle"
+             * (this file's stated purpose) is actually bidirectional — now a
+             * small tab straddling the top-left corner instead of a full
+             * row, so the countdown strip (`strip`) sits at the very top of
+             * the deck's own scroll content.
              */}
-            <div style={{ display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
-                <button
-                    type="button"
-                    onClick={isWide ? toggleCollapsedPref : () => setOverlayOpen(false)}
-                    aria-label="Collapse mission deck"
-                    style={{ width: 32, height: 32, margin: 4, background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer' }}
-                >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                        <path d="M9 6l6 6-6 6" />
-                    </svg>
-                </button>
-            </div>
+            <CollapseTab
+                expanded={true}
+                onClick={isWide ? toggleCollapsedPref : () => setOverlayOpen(false)}
+            />
             {strip}
             <div style={{ display: 'flex', flexDirection: 'column', gap: 16, padding: 16 }}>
                 {children}
             </div>
         </aside>
+    )
+}
+
+/**
+ * The deck's collapse/expand control: a small tab protruding from the top-left
+ * corner, straddling the deck's own left border, rather than a full-width row
+ * (see the module doc above — that row used to cost the deck a whole row of
+ * vertical space). Rendered inside an `aside` with `position: relative` in
+ * both the collapsed (44px rail) and expanded (340px) cases, so `left: -11px`
+ * always resolves against that aside's own left edge.
+ */
+function CollapseTab({ expanded, onClick }: { expanded: boolean; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            aria-label={expanded ? 'Collapse mission deck' : 'Expand mission deck'}
+            style={{
+                position: 'absolute',
+                top: 12,
+                left: -11,
+                width: 22,
+                height: 24,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                background: 'var(--s2)',
+                border: '1px solid var(--line-2)',
+                borderRadius: 'var(--r) 0 0 var(--r)',
+                color: 'var(--ink-2)',
+                cursor: 'pointer',
+                zIndex: 5,
+            }}
+        >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d={expanded ? 'M9 6l6 6-6 6' : 'M15 18l-6-6 6-6'} />
+            </svg>
+        </button>
     )
 }

--- a/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+
+const STORAGE_KEY = 'asot.opsdeck.collapsed'
+
+export default function MissionDeck({ strip, children }: {
+    strip: ReactNode
+    children: ReactNode
+}) {
+    const [collapsed, setCollapsed] = useState(false)
+
+    // Read persisted collapse state after mount only — the server render has
+    // no localStorage, so reading it during render (or synchronously on the
+    // initial client render) would make the very first client markup depend
+    // on a value the server couldn't have produced, a hydration mismatch.
+    useEffect(() => {
+        setCollapsed(window.localStorage.getItem(STORAGE_KEY) === '1')
+    }, [])
+
+    function toggle() {
+        setCollapsed(c => {
+            window.localStorage.setItem(STORAGE_KEY, c ? '0' : '1')
+            return !c
+        })
+    }
+
+    if (collapsed) {
+        return (
+            <aside style={{ width: 44, flexShrink: 0, borderLeft: '1px solid var(--line)', background: 'var(--bg)' }}>
+                <button
+                    type="button" onClick={toggle} aria-label="Expand mission deck"
+                    style={{ width: 44, height: 44, background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer' }}
+                >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <path d="M15 18l-6-6 6-6" />
+                    </svg>
+                </button>
+            </aside>
+        )
+    }
+
+    return (
+        <aside style={{
+            width: 340, flexShrink: 0,
+            borderLeft: '1px solid var(--line)',
+            background: 'var(--bg)',
+            display: 'flex', flexDirection: 'column',
+            overflowY: 'auto',
+        }}>
+            {/*
+             * Not in the original brief code — that version only ever renders
+             * an expand button (in the collapsed rail below), with no way
+             * back to collapsed once expanded. Added so "collapse toggle"
+             * (this file's stated purpose) is actually bidirectional.
+             */}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
+                <button
+                    type="button" onClick={toggle} aria-label="Collapse mission deck"
+                    style={{ width: 32, height: 32, margin: 4, background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer' }}
+                >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <path d="M9 6l6 6-6 6" />
+                    </svg>
+                </button>
+            </div>
+            {strip}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16, padding: 16 }}>
+                {children}
+            </div>
+        </aside>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx
@@ -4,32 +4,83 @@ import { useEffect, useState, type ReactNode } from 'react'
 
 const STORAGE_KEY = 'asot.opsdeck.collapsed'
 
+// Below this the shell doesn't have room to push the deck's 340px alongside
+// the tab content (spec §8: "1024–1279px: deck collapses to a 44px rail,
+// expanding as an overlay on click" / "<1024px: … overlay drawers"). Both
+// bands get the same treatment here — a rail that expands as a floating
+// overlay rather than pushing layout — since nothing in the spec's two rows
+// distinguishes deck behaviour between them, only the (out-of-scope-for-this
+// file) documents rail does.
+const WIDE_QUERY = '(min-width: 1280px)'
+
+/**
+ * True once the viewport is wide enough to push-layout the deck instead of
+ * overlaying it. Starts `true` (matches the >=1600px/1280-1599px rows, the
+ * common case) rather than reading matchMedia during render — the server
+ * has no viewport, so reading it synchronously on the client's first render
+ * would still risk a hydration mismatch on a client that boots narrow.
+ */
+function useIsWide(): boolean {
+    const [wide, setWide] = useState(true)
+    useEffect(() => {
+        const mq = window.matchMedia(WIDE_QUERY)
+        const update = () => setWide(mq.matches)
+        update()
+        mq.addEventListener('change', update)
+        return () => mq.removeEventListener('change', update)
+    }, [])
+    return wide
+}
+
 export default function MissionDeck({ strip, children }: {
     strip: ReactNode
     children: ReactNode
 }) {
-    const [collapsed, setCollapsed] = useState(false)
+    const isWide = useIsWide()
+
+    // The user's manual preference — meaningful only at >=1280px, where the
+    // deck pushes layout and the old collapse/expand toggle behaves exactly
+    // as it always has.
+    const [collapsedPref, setCollapsedPref] = useState(false)
+
+    // The overlay's open/closed state below 1280px. Deliberately separate
+    // from collapsedPref and never persisted: an overlay drawer that
+    // remembered "open" would auto-cover the tab content on every load on a
+    // narrow screen, which is worse than just re-opening it each time.
+    const [overlayOpen, setOverlayOpen] = useState(false)
 
     // Read persisted collapse state after mount only — the server render has
     // no localStorage, so reading it during render (or synchronously on the
     // initial client render) would make the very first client markup depend
     // on a value the server couldn't have produced, a hydration mismatch.
     useEffect(() => {
-        setCollapsed(window.localStorage.getItem(STORAGE_KEY) === '1')
+        setCollapsedPref(window.localStorage.getItem(STORAGE_KEY) === '1')
     }, [])
 
-    function toggle() {
-        setCollapsed(c => {
+    // Crossing back into the narrow band always starts from closed, per the
+    // no-persistence note above — covers both "resized narrow" and "loaded
+    // narrow" (the latter via isWide's own mount-time matchMedia read).
+    useEffect(() => {
+        if (!isWide) setOverlayOpen(false)
+    }, [isWide])
+
+    function toggleCollapsedPref() {
+        setCollapsedPref(c => {
             window.localStorage.setItem(STORAGE_KEY, c ? '0' : '1')
             return !c
         })
     }
 
+    const collapsed = isWide ? collapsedPref : !overlayOpen
+    const overlay = !isWide && !collapsed
+
     if (collapsed) {
         return (
             <aside style={{ width: 44, flexShrink: 0, borderLeft: '1px solid var(--line)', background: 'var(--bg)' }}>
                 <button
-                    type="button" onClick={toggle} aria-label="Expand mission deck"
+                    type="button"
+                    onClick={isWide ? toggleCollapsedPref : () => setOverlayOpen(true)}
+                    aria-label="Expand mission deck"
                     style={{ width: 44, height: 44, background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer' }}
                 >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -42,11 +93,20 @@ export default function MissionDeck({ strip, children }: {
 
     return (
         <aside style={{
-            width: 340, flexShrink: 0,
+            width: overlay ? 'min(340px, 92vw)' : 340,
+            flexShrink: 0,
             borderLeft: '1px solid var(--line)',
             background: 'var(--bg)',
             display: 'flex', flexDirection: 'column',
             overflowY: 'auto',
+            // Overlay case (<1280px, expanded): float above the tab content
+            // instead of pushing it — there's no room to push. Positioned
+            // against .body (shell.module.css sets `position: relative`
+            // there for exactly this) rather than the viewport, so it docks
+            // under the header/tab bar instead of covering them.
+            ...(overlay
+                ? { position: 'absolute', right: 0, top: 0, bottom: 0, zIndex: 30, boxShadow: '-8px 0 24px rgba(0,0,0,0.45)' }
+                : {}),
         }}>
             {/*
              * Not in the original brief code — that version only ever renders
@@ -56,7 +116,9 @@ export default function MissionDeck({ strip, children }: {
              */}
             <div style={{ display: 'flex', justifyContent: 'flex-end', flexShrink: 0 }}>
                 <button
-                    type="button" onClick={toggle} aria-label="Collapse mission deck"
+                    type="button"
+                    onClick={isWide ? toggleCollapsedPref : () => setOverlayOpen(false)}
+                    aria-label="Collapse mission deck"
                     style={{ width: 32, height: 32, margin: 4, background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer' }}
                 >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/apps/web/app/operations/[id]/edit/deck/Panel.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/Panel.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react'
+
+interface PanelProps {
+    title: string
+    tag?: string
+    children: ReactNode
+}
+
+/** The milpac panel: hairline box, 36px accent tick on the top-left corner. */
+export default function Panel({ title, tag, children }: PanelProps) {
+    return (
+        <div style={{
+            position: 'relative',
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r)',
+            background: 'linear-gradient(180deg, var(--s1) 0%, var(--bg) 100%)',
+        }}>
+            <div style={{
+                position: 'absolute', top: 0, left: 0,
+                width: 36, height: 2, background: 'var(--acc)', opacity: 0.75,
+            }} />
+            <div style={{
+                display: 'flex', alignItems: 'center', gap: 12,
+                padding: '14px 18px', borderBottom: '1px solid var(--line)',
+            }}>
+                <span style={{
+                    fontSize: 11, letterSpacing: '0.22em', textTransform: 'uppercase',
+                    fontWeight: 700, color: 'var(--ink)',
+                }}>{title}</span>
+                {tag && (
+                    <span style={{
+                        marginLeft: 'auto', fontFamily: 'var(--mono)',
+                        fontSize: 9.5, color: 'var(--ink-3)', letterSpacing: '0.12em',
+                    }}>{tag}</span>
+                )}
+            </div>
+            <div>{children}</div>
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx
@@ -231,7 +231,13 @@ export default function ScheduleCard({
                                             value={date}
                                             format="DD/MM/YYYY HH:mm"
                                             onChange={onChangeDate}
-                                            slotProps={{ textField: { size: 'small', sx: pickerSx } }}
+                                            // data-testid: the op-date input has no accessible
+                                            // name/label of its own (MUI renders the picker's
+                                            // sections as an unlabelled masked input), and it's
+                                            // the one control operations-editor.spec.ts's
+                                            // date-edit spec needs to select unambiguously among
+                                            // the timeline's several other pickers/selects.
+                                            slotProps={{ textField: { size: 'small', sx: pickerSx, inputProps: { 'data-testid': 'schedule-op-date-input' } } }}
                                         />
                                     </LocalizationProvider>
                                 </div>

--- a/apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+import type { Dayjs } from 'dayjs'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
+import Panel from './Panel'
+import type { TimelineMoment } from '@/lib/operations/schedule'
+
+interface Props {
+    timeline: TimelineMoment[]
+    /** Committed operation date — drives the op_starts picker. */
+    date: Dayjs | null
+    onChangeDate: (v: Dayjs | null) => void
+    /** Toggles rsvp_opens between manual (null) and a computed default. */
+    onChangeRsvpMode: () => void
+    /** Committed RSVP-close lead time — drives the rsvp_closes select. */
+    closeOffsetMins: number
+    onChangeCloseOffset: (mins: number) => void
+}
+
+const CLOSE_OFFSETS = [30, 60, 90, 120, 180]
+
+/**
+ * The five-moment timeline that replaces the old Schedule & Automation panel.
+ * Each row states its moment once — label, computed time, and (where it has
+ * one) the single control that changes it. `confirmations_open` and
+ * `completed` are derived from the attendance stage and carry no control.
+ */
+export default function ScheduleCard({
+    timeline, date, onChangeDate, onChangeRsvpMode, closeOffsetMins, onChangeCloseOffset,
+}: Props) {
+    return (
+        <Panel title="Timeline">
+            <div style={{ padding: '20px 16px 16px' }}>
+                <div style={{ position: 'relative', paddingLeft: 24 }}>
+                    <div style={{
+                        position: 'absolute', left: 4, top: 8, bottom: 8,
+                        width: 1, background: 'var(--line-2)',
+                    }} />
+
+                    {timeline.map((m, i) => (
+                        <div key={m.id} style={{ position: 'relative', paddingBottom: i === timeline.length - 1 ? 0 : 20 }}>
+                            <div style={{
+                                position: 'absolute', left: -24, top: 4,
+                                width: 9, height: 9, borderRadius: '50%',
+                                background: 'var(--bg)',
+                                border: `2px solid ${m.state === 'current' ? 'var(--acc)' : 'var(--line-2)'}`,
+                                boxShadow: m.state === 'current' ? '0 0 0 4px rgba(var(--acc-rgb), 0.12)' : undefined,
+                            }} />
+
+                            <div style={{
+                                fontSize: 13.5, fontWeight: 600,
+                                color: m.state === 'pending' ? 'var(--ink-2)' : 'var(--ink)',
+                            }}>
+                                {m.label}
+                            </div>
+
+                            <div style={{
+                                fontFamily: 'var(--mono)', fontSize: 12,
+                                color: m.state === 'current' ? 'var(--acc)' : 'var(--ink-3)',
+                                marginTop: 3,
+                            }}>
+                                {m.detail}
+                            </div>
+
+                            {m.id === 'rsvp_opens' && (
+                                <button type="button" onClick={onChangeRsvpMode} style={controlStyle}>
+                                    {m.at ? 'Switch to manual' : 'Schedule it'}
+                                </button>
+                            )}
+
+                            {m.id === 'rsvp_closes' && (
+                                <select
+                                    value={closeOffsetMins}
+                                    onChange={e => onChangeCloseOffset(Number(e.target.value))}
+                                    style={{ ...controlStyle, appearance: 'none' }}
+                                >
+                                    {CLOSE_OFFSETS.map(o => (
+                                        <option key={o} value={o}>{o} min before</option>
+                                    ))}
+                                </select>
+                            )}
+
+                            {m.id === 'op_starts' && (
+                                <div style={{ marginTop: 8 }}>
+                                    <LocalizationProvider dateAdapter={AdapterDayjs}>
+                                        <DateTimePicker
+                                            value={date}
+                                            format="DD/MM/YYYY HH:mm"
+                                            onChange={onChangeDate}
+                                            slotProps={{
+                                                textField: {
+                                                    size: 'small',
+                                                    sx: {
+                                                        width: '100%',
+                                                        '& .MuiInputBase-root': {
+                                                            background: 'var(--s2)',
+                                                            borderRadius: 'var(--r)',
+                                                            fontFamily: 'var(--mono)',
+                                                            fontSize: 12,
+                                                        },
+                                                        '& .MuiOutlinedInput-notchedOutline': {
+                                                            border: '1px solid var(--line-2)',
+                                                        },
+                                                        '& .MuiInputBase-input': {
+                                                            color: 'var(--ink-2)',
+                                                            padding: '6px 10px',
+                                                        },
+                                                        '& .MuiSvgIcon-root': {
+                                                            color: 'var(--ink-3)',
+                                                            fontSize: 16,
+                                                        },
+                                                    },
+                                                },
+                                            }}
+                                        />
+                                    </LocalizationProvider>
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </Panel>
+    )
+}
+
+const controlStyle: CSSProperties = {
+    display: 'inline-flex', alignItems: 'center', gap: 7,
+    marginTop: 8,
+    border: '1px solid var(--line-2)', background: 'var(--s2)',
+    borderRadius: 'var(--r)', padding: '6px 11px',
+    fontFamily: 'var(--mono)', fontSize: 9.5,
+    letterSpacing: '0.14em', textTransform: 'uppercase',
+    color: 'var(--ink-2)', cursor: 'pointer',
+}

--- a/apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx
@@ -6,7 +6,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import Panel from './Panel'
-import type { TimelineMoment } from '@/lib/operations/schedule'
+import { rsvpCloseAt, type TimelineMoment } from '@/lib/operations/schedule'
 
 interface Props {
     timeline: TimelineMoment[]
@@ -15,6 +15,14 @@ interface Props {
     date: Dayjs | null
     onChangeDate: (v: Dayjs | null) => void
 
+    /**
+     * Committed RSVP-open instant (null = manual). Drives the Manual/Scheduled
+     * pills and the open-time picker directly — NOT timeline[i].at, which comes
+     * from a 30s-polled live-status fetch and would lag every one of this
+     * row's own writes by up to 30s (see git history: the card originally read
+     * m.at here and the pills/picker went stale after every click).
+     */
+    rsvpOpenAt: string | null
     /** rsvp_opens: switch to manual (no automatic open) — a no-op if already manual. */
     onSetRsvpOpenManual: () => void
     /** rsvp_opens: switch to scheduled, defaulting to 3 days before the op date — a no-op if already scheduled, or if there's no op date to default from. */
@@ -24,11 +32,14 @@ interface Props {
     /** rsvp_opens: quick-set relative to the op date (see RELATIVE_OPEN_OPTS). */
     onQuickSetRsvpOpen: (mins: number) => void
 
-    /** Committed RSVP-close lead time — drives the rsvp_closes select. */
+    /** Committed RSVP-close lead time — drives the rsvp_closes select and (with `date`) its custom picker's value. */
     closeOffsetMins: number
     onChangeCloseOffset: (mins: number) => void
     /** rsvp_closes custom mode: set an exact close instant; the card converts it to minutes-before-op-date. */
     onChangeRsvpCloseAt: (v: Dayjs | null) => void
+
+    /** Status is "In Development" — cron/client-side auto-open/close/activate is suppressed (page.tsx's tickNow effect), so any scheduled time below is inert until the op is published. */
+    automationPaused: boolean
 }
 
 /** Relative-to-op-date quick-sets for RSVP open — same four the old panel offered. */
@@ -56,11 +67,21 @@ const CLOSE_OFFSET_OPTS = [
  * Each row states its moment once — label, computed time, and (where it has
  * one) the control(s) that change it. `confirmations_open` and `completed`
  * are derived from the attendance stage and carry no control.
+ *
+ * Duplication rule: a row's `detail` text (the plain-English instant) is
+ * shown only when no visible picker on that row already states the same
+ * instant. op_starts always has a picker, so it never shows detail.
+ * rsvp_opens hides detail once scheduled (the picker takes over); "Manual"
+ * still needs detail since the pills alone don't say it. rsvp_closes hides
+ * detail only in custom mode, where the picker restates the instant — the
+ * preset select never does (it names an offset, not a time), so detail stays
+ * the one place that states the resulting instant.
  */
 export default function ScheduleCard({
     timeline, date, onChangeDate,
-    onSetRsvpOpenManual, onSetRsvpOpenScheduled, onChangeRsvpOpenAt, onQuickSetRsvpOpen,
+    rsvpOpenAt, onSetRsvpOpenManual, onSetRsvpOpenScheduled, onChangeRsvpOpenAt, onQuickSetRsvpOpen,
     closeOffsetMins, onChangeCloseOffset, onChangeRsvpCloseAt,
+    automationPaused,
 }: Props) {
     // Whether the rsvp_closes row shows the "Custom…" date picker. Starts open
     // if the committed offset isn't one of the presets (an existing custom
@@ -70,6 +91,10 @@ export default function ScheduleCard({
         () => !CLOSE_OFFSET_OPTS.some(o => o.mins === closeOffsetMins),
     )
     const isPresetClose = CLOSE_OFFSET_OPTS.some(o => o.mins === closeOffsetMins)
+    const closeCustomVisible = closeCustomOpen || !isPresetClose
+
+    // Local, immediate — not the polled timeline. See the `rsvpOpenAt` prop doc.
+    const closeAtLocal = date ? rsvpCloseAt(date.toDate(), closeOffsetMins) : null
 
     return (
         <Panel title="Timeline">
@@ -80,7 +105,13 @@ export default function ScheduleCard({
                         width: 1, background: 'var(--line-2)',
                     }} />
 
-                    {timeline.map((m, i) => (
+                    {timeline.map((m, i) => {
+                        const suppressDetail =
+                            m.id === 'op_starts' ||
+                            (m.id === 'rsvp_opens' && !!rsvpOpenAt) ||
+                            (m.id === 'rsvp_closes' && closeCustomVisible)
+
+                        return (
                         <div key={m.id} style={{ position: 'relative', paddingBottom: i === timeline.length - 1 ? 0 : 20 }}>
                             <div style={{
                                 position: 'absolute', left: -24, top: 4,
@@ -97,30 +128,32 @@ export default function ScheduleCard({
                                 {m.label}
                             </div>
 
-                            <div style={{
-                                fontFamily: 'var(--mono)', fontSize: 12,
-                                color: m.state === 'current' ? 'var(--acc)' : 'var(--ink-3)',
-                                marginTop: 3,
-                            }}>
-                                {m.detail}
-                            </div>
+                            {!suppressDetail && (
+                                <div style={{
+                                    fontFamily: 'var(--mono)', fontSize: 12,
+                                    color: m.state === 'current' ? 'var(--acc)' : 'var(--ink-3)',
+                                    marginTop: 3,
+                                }}>
+                                    {m.detail}
+                                </div>
+                            )}
 
                             {m.id === 'rsvp_opens' && (
                                 <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 8 }}>
                                     <div style={{ display: 'flex', gap: 6 }}>
-                                        <button type="button" onClick={onSetRsvpOpenManual} style={pillStyle(!m.at)}>
+                                        <button type="button" onClick={onSetRsvpOpenManual} style={pillStyle(!rsvpOpenAt)}>
                                             Manual
                                         </button>
-                                        <button type="button" onClick={onSetRsvpOpenScheduled} style={pillStyle(!!m.at)}>
+                                        <button type="button" onClick={onSetRsvpOpenScheduled} style={pillStyle(!!rsvpOpenAt)}>
                                             Scheduled
                                         </button>
                                     </div>
 
-                                    {m.at && (
+                                    {rsvpOpenAt && (
                                         <>
                                             <LocalizationProvider dateAdapter={AdapterDayjs}>
                                                 <DateTimePicker
-                                                    value={dayjs(m.at)}
+                                                    value={dayjs(rsvpOpenAt)}
                                                     format="DD/MM/YYYY HH:mm"
                                                     onChange={onChangeRsvpOpenAt}
                                                     slotProps={{ textField: { size: 'small', sx: pickerSx } }}
@@ -141,6 +174,12 @@ export default function ScheduleCard({
                                                 ))}
                                             </select>
                                         </>
+                                    )}
+
+                                    {automationPaused && (
+                                        <div style={{ fontFamily: 'var(--mono)', fontSize: 10.5, color: 'var(--warn)' }}>
+                                            Automation paused — In Development
+                                        </div>
                                     )}
                                 </div>
                             )}
@@ -165,11 +204,11 @@ export default function ScheduleCard({
                                         <option value="custom">Custom…</option>
                                     </select>
 
-                                    {(closeCustomOpen || !isPresetClose) && (
+                                    {closeCustomVisible && (
                                         <>
                                             <LocalizationProvider dateAdapter={AdapterDayjs}>
                                                 <DateTimePicker
-                                                    value={m.at ? dayjs(m.at) : null}
+                                                    value={closeAtLocal ? dayjs(closeAtLocal) : null}
                                                     format="DD/MM/YYYY HH:mm"
                                                     onChange={onChangeRsvpCloseAt}
                                                     slotProps={{ textField: { size: 'small', sx: pickerSx } }}
@@ -198,7 +237,8 @@ export default function ScheduleCard({
                                 </div>
                             )}
                         </div>
-                    ))}
+                        )
+                    })}
                 </div>
             </div>
         </Panel>

--- a/apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import type { CSSProperties } from 'react'
-import type { Dayjs } from 'dayjs'
+import { useState, type CSSProperties } from 'react'
+import dayjs, { type Dayjs } from 'dayjs'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
@@ -10,27 +10,67 @@ import type { TimelineMoment } from '@/lib/operations/schedule'
 
 interface Props {
     timeline: TimelineMoment[]
+
     /** Committed operation date — drives the op_starts picker. */
     date: Dayjs | null
     onChangeDate: (v: Dayjs | null) => void
-    /** Toggles rsvp_opens between manual (null) and a computed default. */
-    onChangeRsvpMode: () => void
+
+    /** rsvp_opens: switch to manual (no automatic open) — a no-op if already manual. */
+    onSetRsvpOpenManual: () => void
+    /** rsvp_opens: switch to scheduled, defaulting to 3 days before the op date — a no-op if already scheduled, or if there's no op date to default from. */
+    onSetRsvpOpenScheduled: () => void
+    /** rsvp_opens: set an exact open instant directly off the picker. */
+    onChangeRsvpOpenAt: (v: Dayjs | null) => void
+    /** rsvp_opens: quick-set relative to the op date (see RELATIVE_OPEN_OPTS). */
+    onQuickSetRsvpOpen: (mins: number) => void
+
     /** Committed RSVP-close lead time — drives the rsvp_closes select. */
     closeOffsetMins: number
     onChangeCloseOffset: (mins: number) => void
+    /** rsvp_closes custom mode: set an exact close instant; the card converts it to minutes-before-op-date. */
+    onChangeRsvpCloseAt: (v: Dayjs | null) => void
 }
 
-const CLOSE_OFFSETS = [30, 60, 90, 120, 180]
+/** Relative-to-op-date quick-sets for RSVP open — same four the old panel offered. */
+const RELATIVE_OPEN_OPTS = [
+    { label: '1 day before', mins: 1440 },
+    { label: '3 days before', mins: 4320 },
+    { label: '1 week before', mins: 10080 },
+    { label: '2 weeks before', mins: 20160 },
+]
+
+/** RSVP-close presets — same eight the old panel offered, plus Custom…. */
+const CLOSE_OFFSET_OPTS = [
+    { label: '30 min before', mins: 30 },
+    { label: '1 hour before', mins: 60 },
+    { label: '1.5 hours before', mins: 90 },
+    { label: '2 hours before', mins: 120 },
+    { label: '3 hours before', mins: 180 },
+    { label: '6 hours before', mins: 360 },
+    { label: '12 hours before', mins: 720 },
+    { label: '1 day before', mins: 1440 },
+]
 
 /**
  * The five-moment timeline that replaces the old Schedule & Automation panel.
  * Each row states its moment once — label, computed time, and (where it has
- * one) the single control that changes it. `confirmations_open` and
- * `completed` are derived from the attendance stage and carry no control.
+ * one) the control(s) that change it. `confirmations_open` and `completed`
+ * are derived from the attendance stage and carry no control.
  */
 export default function ScheduleCard({
-    timeline, date, onChangeDate, onChangeRsvpMode, closeOffsetMins, onChangeCloseOffset,
+    timeline, date, onChangeDate,
+    onSetRsvpOpenManual, onSetRsvpOpenScheduled, onChangeRsvpOpenAt, onQuickSetRsvpOpen,
+    closeOffsetMins, onChangeCloseOffset, onChangeRsvpCloseAt,
 }: Props) {
+    // Whether the rsvp_closes row shows the "Custom…" date picker. Starts open
+    // if the committed offset isn't one of the presets (an existing custom
+    // value), then tracks the select explicitly so switching back to a preset
+    // hides it again without waiting for closeOffsetMins to change.
+    const [closeCustomOpen, setCloseCustomOpen] = useState(
+        () => !CLOSE_OFFSET_OPTS.some(o => o.mins === closeOffsetMins),
+    )
+    const isPresetClose = CLOSE_OFFSET_OPTS.some(o => o.mins === closeOffsetMins)
+
     return (
         <Panel title="Timeline">
             <div style={{ padding: '20px 16px 16px' }}>
@@ -66,21 +106,83 @@ export default function ScheduleCard({
                             </div>
 
                             {m.id === 'rsvp_opens' && (
-                                <button type="button" onClick={onChangeRsvpMode} style={controlStyle}>
-                                    {m.at ? 'Switch to manual' : 'Schedule it'}
-                                </button>
+                                <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                                    <div style={{ display: 'flex', gap: 6 }}>
+                                        <button type="button" onClick={onSetRsvpOpenManual} style={pillStyle(!m.at)}>
+                                            Manual
+                                        </button>
+                                        <button type="button" onClick={onSetRsvpOpenScheduled} style={pillStyle(!!m.at)}>
+                                            Scheduled
+                                        </button>
+                                    </div>
+
+                                    {m.at && (
+                                        <>
+                                            <LocalizationProvider dateAdapter={AdapterDayjs}>
+                                                <DateTimePicker
+                                                    value={dayjs(m.at)}
+                                                    format="DD/MM/YYYY HH:mm"
+                                                    onChange={onChangeRsvpOpenAt}
+                                                    slotProps={{ textField: { size: 'small', sx: pickerSx } }}
+                                                />
+                                            </LocalizationProvider>
+                                            <select
+                                                defaultValue=""
+                                                onChange={e => {
+                                                    const mins = Number(e.target.value)
+                                                    if (mins) onQuickSetRsvpOpen(mins)
+                                                    e.target.value = ''
+                                                }}
+                                                style={{ ...controlStyle, marginTop: 0, appearance: 'none' }}
+                                            >
+                                                <option value="" disabled>Relative to op date…</option>
+                                                {RELATIVE_OPEN_OPTS.map(o => (
+                                                    <option key={o.mins} value={o.mins}>{o.label}</option>
+                                                ))}
+                                            </select>
+                                        </>
+                                    )}
+                                </div>
                             )}
 
                             {m.id === 'rsvp_closes' && (
-                                <select
-                                    value={closeOffsetMins}
-                                    onChange={e => onChangeCloseOffset(Number(e.target.value))}
-                                    style={{ ...controlStyle, appearance: 'none' }}
-                                >
-                                    {CLOSE_OFFSETS.map(o => (
-                                        <option key={o} value={o}>{o} min before</option>
-                                    ))}
-                                </select>
+                                <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                                    <select
+                                        value={isPresetClose && !closeCustomOpen ? closeOffsetMins : 'custom'}
+                                        onChange={e => {
+                                            if (e.target.value === 'custom') {
+                                                setCloseCustomOpen(true)
+                                            } else {
+                                                setCloseCustomOpen(false)
+                                                onChangeCloseOffset(Number(e.target.value))
+                                            }
+                                        }}
+                                        style={{ ...controlStyle, appearance: 'none' }}
+                                    >
+                                        {CLOSE_OFFSET_OPTS.map(o => (
+                                            <option key={o.mins} value={o.mins}>{o.label}</option>
+                                        ))}
+                                        <option value="custom">Custom…</option>
+                                    </select>
+
+                                    {(closeCustomOpen || !isPresetClose) && (
+                                        <>
+                                            <LocalizationProvider dateAdapter={AdapterDayjs}>
+                                                <DateTimePicker
+                                                    value={m.at ? dayjs(m.at) : null}
+                                                    format="DD/MM/YYYY HH:mm"
+                                                    onChange={onChangeRsvpCloseAt}
+                                                    slotProps={{ textField: { size: 'small', sx: pickerSx } }}
+                                                />
+                                            </LocalizationProvider>
+                                            {!date && (
+                                                <div style={{ fontFamily: 'var(--mono)', fontSize: 10.5, color: 'var(--warn)' }}>
+                                                    Set an operation date first to compute the offset.
+                                                </div>
+                                            )}
+                                        </>
+                                    )}
+                                </div>
                             )}
 
                             {m.id === 'op_starts' && (
@@ -90,31 +192,7 @@ export default function ScheduleCard({
                                             value={date}
                                             format="DD/MM/YYYY HH:mm"
                                             onChange={onChangeDate}
-                                            slotProps={{
-                                                textField: {
-                                                    size: 'small',
-                                                    sx: {
-                                                        width: '100%',
-                                                        '& .MuiInputBase-root': {
-                                                            background: 'var(--s2)',
-                                                            borderRadius: 'var(--r)',
-                                                            fontFamily: 'var(--mono)',
-                                                            fontSize: 12,
-                                                        },
-                                                        '& .MuiOutlinedInput-notchedOutline': {
-                                                            border: '1px solid var(--line-2)',
-                                                        },
-                                                        '& .MuiInputBase-input': {
-                                                            color: 'var(--ink-2)',
-                                                            padding: '6px 10px',
-                                                        },
-                                                        '& .MuiSvgIcon-root': {
-                                                            color: 'var(--ink-3)',
-                                                            fontSize: 16,
-                                                        },
-                                                    },
-                                                },
-                                            }}
+                                            slotProps={{ textField: { size: 'small', sx: pickerSx } }}
                                         />
                                     </LocalizationProvider>
                                 </div>
@@ -135,4 +213,38 @@ const controlStyle: CSSProperties = {
     fontFamily: 'var(--mono)', fontSize: 9.5,
     letterSpacing: '0.14em', textTransform: 'uppercase',
     color: 'var(--ink-2)', cursor: 'pointer',
+}
+
+function pillStyle(active: boolean): CSSProperties {
+    return {
+        flex: '1 1 0', textAlign: 'center',
+        border: '1px solid var(--line-2)',
+        background: active ? 'rgba(var(--acc-rgb), 0.18)' : 'var(--s2)',
+        borderRadius: 'var(--r)', padding: '6px 11px',
+        fontFamily: 'var(--mono)', fontSize: 9.5,
+        letterSpacing: '0.14em', textTransform: 'uppercase',
+        color: active ? 'var(--ink)' : 'var(--ink-2)',
+        cursor: 'pointer',
+    }
+}
+
+const pickerSx = {
+    width: '100%',
+    '& .MuiInputBase-root': {
+        background: 'var(--s2)',
+        borderRadius: 'var(--r)',
+        fontFamily: 'var(--mono)',
+        fontSize: 12,
+    },
+    '& .MuiOutlinedInput-notchedOutline': {
+        border: '1px solid var(--line-2)',
+    },
+    '& .MuiInputBase-input': {
+        color: 'var(--ink-2)',
+        padding: '6px 10px',
+    },
+    '& .MuiSvgIcon-root': {
+        color: 'var(--ink-3)',
+        fontSize: 16,
+    },
 }

--- a/apps/web/app/operations/[id]/edit/deck/StageCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/StageCard.tsx
@@ -1,35 +1,69 @@
 'use client'
 
+import { useState } from 'react'
 import Panel from './Panel'
-import { STAGE_ORDER, stageLabel, stageProgress, nextStage } from '@/lib/operations/stage'
+import { STAGE_ORDER, stageIndex, stageLabel, stageProgress, nextStage } from '@/lib/operations/stage'
 import type { AttendanceStage } from '@/lib/operations/schedule'
 
 interface Props {
     stage: AttendanceStage | null
     onAdvance: (to: AttendanceStage) => void
+    /** Segment click — jump directly to any stage, including backwards. The
+     * caller (page.tsx) is responsible for confirming the same three
+     * impactful stages the old stepper guarded before committing. */
+    onSelect: (to: AttendanceStage) => void
     advancing: boolean
 }
 
 /**
  * Replaces the six-step labelled stepper in the Attendance Settings panel.
- * The cron (`app/api/cron/operations/`) drives these transitions normally —
- * this is a manual override, not a primary input, so it's a thin progress
- * bar plus one Advance button rather than a clickable-to-any-stage stepper.
+ * The cron (`app/api/cron/operations/`) drives these transitions normally,
+ * so Advance — the obvious primary action — only ever targets the next
+ * stage. But the old stepper also let HQ jump to *any* stage, including
+ * backwards to correct a mistake (the cron's or a person's) — losing that
+ * would mean a wrong stage could only be fixed by editing the database. So
+ * the six progress segments stay individually clickable as the override,
+ * while the bar itself stays the compact "thin progress bar" the spec asked
+ * for rather than the old stepper's labelled nodes.
  */
-export default function StageCard({ stage, onAdvance, advancing }: Props) {
+export default function StageCard({ stage, onAdvance, onSelect, advancing }: Props) {
     const filled = stageProgress(stage)
     const next = nextStage(stage)
+    const currentIdx = stageIndex(stage)
+    const [hoverIdx, setHoverIdx] = useState<number | null>(null)
 
     return (
         <Panel title="Stage" tag={`${filled} of ${STAGE_ORDER.length}`}>
             <div style={{ padding: 16 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 12 }}>
-                    {STAGE_ORDER.map((s, i) => (
-                        <span key={s} style={{
-                            flex: '1 1 0', height: 3, borderRadius: 2,
-                            background: i < filled ? 'var(--acc)' : 'var(--line)',
-                        }} />
-                    ))}
+                    {STAGE_ORDER.map((s, i) => {
+                        const isCurrent = i === currentIdx
+                        const isHovered = hoverIdx === i && !isCurrent && !advancing
+                        const isFilled = i < filled
+                        return (
+                            <button
+                                key={s}
+                                type="button"
+                                disabled={isCurrent || advancing}
+                                onClick={() => onSelect(s)}
+                                onMouseEnter={() => setHoverIdx(i)}
+                                onMouseLeave={() => setHoverIdx(null)}
+                                aria-label={`Set stage to ${stageLabel(s)}`}
+                                style={{
+                                    flex: '1 1 0', padding: '6px 0', margin: 0,
+                                    border: 'none', background: 'none',
+                                    cursor: isCurrent || advancing ? 'default' : 'pointer',
+                                }}
+                            >
+                                <span style={{
+                                    display: 'block', height: 3, borderRadius: 2,
+                                    background: isFilled
+                                        ? (isHovered ? 'rgba(var(--acc-rgb), 0.7)' : 'var(--acc)')
+                                        : (isHovered ? 'var(--line-2)' : 'var(--line)'),
+                                }} />
+                            </button>
+                        )
+                    })}
                 </div>
 
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>

--- a/apps/web/app/operations/[id]/edit/deck/StageCard.tsx
+++ b/apps/web/app/operations/[id]/edit/deck/StageCard.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import Panel from './Panel'
+import { STAGE_ORDER, stageLabel, stageProgress, nextStage } from '@/lib/operations/stage'
+import type { AttendanceStage } from '@/lib/operations/schedule'
+
+interface Props {
+    stage: AttendanceStage | null
+    onAdvance: (to: AttendanceStage) => void
+    advancing: boolean
+}
+
+/**
+ * Replaces the six-step labelled stepper in the Attendance Settings panel.
+ * The cron (`app/api/cron/operations/`) drives these transitions normally —
+ * this is a manual override, not a primary input, so it's a thin progress
+ * bar plus one Advance button rather than a clickable-to-any-stage stepper.
+ */
+export default function StageCard({ stage, onAdvance, advancing }: Props) {
+    const filled = stageProgress(stage)
+    const next = nextStage(stage)
+
+    return (
+        <Panel title="Stage" tag={`${filled} of ${STAGE_ORDER.length}`}>
+            <div style={{ padding: 16 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 12 }}>
+                    {STAGE_ORDER.map((s, i) => (
+                        <span key={s} style={{
+                            flex: '1 1 0', height: 3, borderRadius: 2,
+                            background: i < filled ? 'var(--acc)' : 'var(--line)',
+                        }} />
+                    ))}
+                </div>
+
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                    <span style={{
+                        fontFamily: 'var(--mono)', fontSize: 12,
+                        letterSpacing: '0.14em', textTransform: 'uppercase',
+                        color: 'var(--acc)',
+                    }}>
+                        {stageLabel(stage)}
+                    </span>
+
+                    <button
+                        type="button"
+                        disabled={!next || advancing}
+                        onClick={() => next && onAdvance(next)}
+                        style={{
+                            border: '1px solid var(--line-2)', background: 'var(--s2)',
+                            borderRadius: 'var(--r)', padding: '6px 11px',
+                            fontFamily: 'var(--mono)', fontSize: 9.5,
+                            letterSpacing: '0.14em', textTransform: 'uppercase',
+                            color: next ? 'var(--ink-2)' : 'var(--ink-3)',
+                            cursor: next ? 'pointer' : 'default',
+                            opacity: next ? 1 : 0.5,
+                        }}
+                    >
+                        {advancing ? 'Advancing…' : next ? `Advance to ${stageLabel(next)}` : 'Complete'}
+                    </button>
+                </div>
+            </div>
+        </Panel>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/hooks/useDocStats.ts
+++ b/apps/web/app/operations/[id]/edit/hooks/useDocStats.ts
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type * as Y from 'yjs'
+import { yXmlFragmentToProsemirrorJSON } from 'y-prosemirror'
+import { docStats, type DocStats } from '@/lib/operations/doc-stats'
+
+export function useDocStats(ydoc: Y.Doc | null, activePage: string): DocStats {
+    const [stats, setStats] = useState<DocStats>({ words: 0, sections: 0 })
+
+    useEffect(() => {
+        if (!ydoc) return
+        const frag = ydoc.getXmlFragment(activePage)
+
+        const recompute = () => {
+            // Y.XmlFragment#toJSON() serialises to an XML *string*, not a node
+            // tree — docStats needs the ProseMirror-shaped { type, content, text }
+            // tree that y-prosemirror's own (de)serialiser produces, so we reuse
+            // that instead of frag.toJSON().
+            try { setStats(docStats(yXmlFragmentToProsemirrorJSON(frag))) }
+            catch { setStats({ words: 0, sections: 0 }) }
+        }
+
+        recompute()
+        frag.observeDeep(recompute)
+        return () => frag.unobserveDeep(recompute)
+    }, [ydoc, activePage])
+
+    return stats
+}

--- a/apps/web/app/operations/[id]/edit/hooks/useOperationMeta.ts
+++ b/apps/web/app/operations/[id]/edit/hooks/useOperationMeta.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+export interface MetaFields {
+    title: string
+    department: string
+    date: string
+    loreDate: string
+}
+
+/**
+ * Lifted from `scheduleSave` in page.tsx: same 1000ms debounce, same
+ * `GET /api/operations/update?id=<id>&<key>=<encoded value>` call, same
+ * saved/saving/unsaved transitions. Additionally records when the save
+ * landed so the status bar can show it.
+ */
+export function useOperationMeta(operationId: string, initial: MetaFields): {
+    meta: MetaFields
+    setField: (k: keyof MetaFields, v: string) => void
+    saveStatus: 'saved' | 'saving' | 'unsaved'
+    savedAt: Date | null
+} {
+    const [meta, setMeta] = useState<MetaFields>(initial)
+    const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
+    const [savedAt, setSavedAt] = useState<Date | null>(null)
+    const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+    function setField(key: keyof MetaFields, value: string) {
+        setMeta(m => ({ ...m, [key]: value }))
+        setSaveStatus('unsaved')
+        clearTimeout(timer.current)
+        timer.current = setTimeout(async () => {
+            setSaveStatus('saving')
+            const qs = `${key}=${encodeURIComponent(value)}`
+            try {
+                await fetch(`/api/operations/update?id=${operationId}&${qs}`)
+                setSaveStatus('saved')
+                setSavedAt(new Date())
+            } catch {
+                setSaveStatus('unsaved')
+            }
+        }, 1000)
+    }
+
+    return { meta, setField, saveStatus, savedAt }
+}

--- a/apps/web/app/operations/[id]/edit/hooks/useOperationStatus.ts
+++ b/apps/web/app/operations/[id]/edit/hooks/useOperationStatus.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { buildTimeline, type LiveStatus, type TimelineMoment } from '@/lib/operations/schedule'
+
+/**
+ * Polls the same endpoint the public status bar uses, on the same 30s cadence,
+ * and ticks a 1s clock so countdowns move without another network call.
+ */
+export function useOperationStatus(operationId: string): {
+    status: LiveStatus | null
+    timeline: TimelineMoment[]
+    now: Date
+    daysUntil: number | null
+    refresh: () => void
+} {
+    const [status, setStatus] = useState<LiveStatus | null>(null)
+    const [now, setNow] = useState(() => new Date())
+
+    const refresh = useCallback(() => {
+        if (!operationId) return
+        fetch(`/api/operations/${operationId}/live-status`)
+            .then(res => res.json())
+            .then(setStatus)
+            .catch(() => {})
+    }, [operationId])
+
+    useEffect(() => {
+        refresh()
+        const id = setInterval(refresh, 30_000)
+        return () => clearInterval(id)
+    }, [refresh])
+
+    useEffect(() => {
+        const id = setInterval(() => setNow(new Date()), 1_000)
+        return () => clearInterval(id)
+    }, [])
+
+    const timeline = status ? buildTimeline(status) : []
+
+    const opDate = status?.operationDate ? new Date(status.operationDate) : null
+    const daysUntil = opDate
+        ? Math.max(0, Math.ceil((opDate.getTime() - now.getTime()) / 86_400_000))
+        : null
+
+    return { status, timeline, now, daysUntil, refresh }
+}

--- a/apps/web/app/operations/[id]/edit/hooks/usePresence.ts
+++ b/apps/web/app/operations/[id]/edit/hooks/usePresence.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { HocuspocusProvider } from '@hocuspocus/provider'
+
+/**
+ * The status bar's "n editing" comes from the awareness protocol
+ * `CollabEditor` already maintains for its collaborative cursors, so this
+ * reads it rather than opening a second channel.
+ */
+export function usePresence(provider: HocuspocusProvider | null): number {
+    const [count, setCount] = useState(0)
+
+    useEffect(() => {
+        if (!provider) return
+        const awareness = provider.awareness
+        if (!awareness) return
+
+        const update = () => setCount(awareness.getStates().size)
+        update()
+        awareness.on('change', update)
+        return () => awareness.off('change', update)
+    }, [provider])
+
+    return count
+}

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -14,6 +14,9 @@ import FullscreenPage from '@/components/FullscreenPage'
 import EditorShell, { useEditorTab } from './EditorShell'
 import Header from './Header'
 import StatusBar from './StatusBar'
+import { useOperationStatus } from './hooks/useOperationStatus'
+import MissionDeck from './deck/MissionDeck'
+import CountdownStrip from './deck/CountdownStrip'
 const OperationEditor = dynamic(() => import('@/components/editor/CollabEditor'), { ssr: false })
 
 interface MetaFields { title: string; department: string; date: string; loreDate: string }
@@ -110,6 +113,9 @@ export default function Page() {
     // does not participate in the save path itself (see scheduleSave below).
     const [savedAt, setSavedAt] = useState<Date | null>(null)
     const [tab, setTab] = useEditorTab()
+
+    // Mission deck (Task 8) — days-until-op countdown for the deck's strip.
+    const { daysUntil } = useOperationStatus(opID)
 
     // Mission Development
     const [missionDev, setMissionDev] = useState<MissionDevelopment | null>(null)
@@ -569,6 +575,21 @@ export default function Page() {
         </div>
     )
 
+    // Mission-development check counts for the deck's countdown strip.
+    // Mirrors the exact same week list / completion check the Mission
+    // Development panel below computes for its own `checks`/`allDone` — kept
+    // as a separate computation (rather than hoisting that panel's IIFE)
+    // because the panel's version also needs `dueDate`/`isOverdue` per check
+    // and its own save/remove handlers, which the strip doesn't.
+    const devCheckBaseDate = isCampaignOp && campaignStartDate
+        ? new Date(campaignStartDate)
+        : date?.toDate() ?? null
+    const devCheckWeeks = isCampaignOp ? [16, 12, 10, 8, 6, 4] : [12, 10, 8, 6, 4]
+    const checksTotal = opID && devCheckBaseDate ? devCheckWeeks.length : 0
+    const checksDone = opID && devCheckBaseDate
+        ? devCheckWeeks.filter(weeks => !!missionDev?.completions?.[`w${weeks}`]).length
+        : 0
+
     return (
         <>
             {/* Drops the global site navbar/footer (styles/globals.css:31-34) — same
@@ -624,6 +645,14 @@ export default function Page() {
                         editorCount={1}
                         department={department}
                     />
+                }
+                deck={
+                    <MissionDeck
+                        strip={<CountdownStrip daysUntil={daysUntil} checksDone={checksDone} checksTotal={checksTotal} />}
+                    >
+                        {/* Later tasks add deck cards here. */}
+                        {null}
+                    </MissionDeck>
                 }
             >
         <div className='w-full' style={{

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -18,6 +18,7 @@ import { useOperationStatus } from './hooks/useOperationStatus'
 import MissionDeck from './deck/MissionDeck'
 import CountdownStrip from './deck/CountdownStrip'
 import ScheduleCard from './deck/ScheduleCard'
+import StageCard from './deck/StageCard'
 const OperationEditor = dynamic(() => import('@/components/editor/CollabEditor'), { ssr: false })
 
 interface MetaFields { title: string; department: string; date: string; loreDate: string }
@@ -174,6 +175,7 @@ export default function Page() {
 
     const [attStage, setAttStage] = useState<AttendanceStage>('preparing')
     const [confirmStage, setConfirmStage] = useState<AttendanceStage | null>(null)
+    const [stageAdvancing, setStageAdvancing] = useState(false)
 
     const [confirmDelete, setConfirmDelete] = useState(false)
     const [previewOpen, setPreviewOpen] = useState(false)
@@ -580,6 +582,23 @@ export default function Page() {
         await saveAttendanceSettings(updates)
     }
 
+    // StageCard's single Advance button (Task 10) — reuses applyStage, the
+    // same handler the Attendance Settings stepper's node clicks call, so it
+    // saves through the exact same endpoint (POST .../attendance/platoons)
+    // and payload. Guards against a double-click firing two writes, and
+    // calls refresh() so the deck's timeline (and StatusBar) pick up the
+    // change immediately instead of waiting on the next 30s poll.
+    async function handleAdvanceStage(to: AttendanceStage) {
+        if (stageAdvancing) return
+        setStageAdvancing(true)
+        try {
+            await applyStage(to)
+            refresh()
+        } finally {
+            setStageAdvancing(false)
+        }
+    }
+
     const PLATOON_OPTS = [
         { id: 'companyHQ', label: '1-0 HQ',            color: 'rgba(185,0,24,0.7)' },
         { id: 'platoon11', label: '1-1 Platoon',         color: 'rgba(194,120,0,0.7)' },
@@ -726,6 +745,13 @@ export default function Page() {
                                 onChangeCloseOffset={handleChangeCloseOffset}
                                 onChangeRsvpCloseAt={handleChangeRsvpCloseAt}
                                 automationPaused={status === 'In Development'}
+                            />
+                        )}
+                        {isHQ && opID && (
+                            <StageCard
+                                stage={displayStage}
+                                onAdvance={handleAdvanceStage}
+                                advancing={stageAdvancing}
                             />
                         )}
                         {/* Later tasks add more deck cards here. */}

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -117,7 +117,7 @@ export default function Page() {
 
     // Mission deck (Task 8) — days-until-op countdown for the deck's strip.
     // Task 9 also consumes the timeline it builds, for the Timeline card.
-    const { timeline, daysUntil } = useOperationStatus(opID)
+    const { timeline, daysUntil, refresh } = useOperationStatus(opID)
 
     // Mission Development
     const [missionDev, setMissionDev] = useState<MissionDevelopment | null>(null)
@@ -190,6 +190,11 @@ export default function Page() {
     const metaSaveTimer = useRef<ReturnType<typeof setTimeout>>()
     const metaHandleRef = useRef<{ set: (key: string, value: string) => void } | null>(null)
     const previewIframeRef = useRef<HTMLIFrameElement>(null)
+    // Debounce timers for the Timeline card's two free-text pickers (Task 9 fix) —
+    // same idea as metaSaveTimer, just per-field, so dragging through a picker's
+    // month/day/hour/minute sections doesn't fire a save per completed section.
+    const rsvpOpenAtSaveTimer = useRef<ReturnType<typeof setTimeout>>()
+    const rsvpCloseAtSaveTimer = useRef<ReturnType<typeof setTimeout>>()
 
     useEffect(() => {
         const id = setInterval(() => setTickNow(new Date()), 1000)
@@ -463,64 +468,91 @@ export default function Page() {
         }
     }
 
-    // Timeline card handlers (Task 9) — replace the old Schedule & Automation
-    // panel's draft-then-"Confirm Schedule" flow with direct-acting controls,
-    // one per row. Same two save paths as before: the operation date goes
-    // through /api/operations/update (and the Y.doc meta handle, like every
-    // other metaSave field); the RSVP fields go through saveAttendanceSettings.
-    async function handleChangeDate(v: Dayjs | null) {
+    // Timeline card handlers (Task 9, fixed up per review) — direct-acting
+    // controls, one per row.
+    //
+    // The operation date now goes through the same debounced scheduleSave
+    // path every other meta field uses (title/department/status/... — see
+    // scheduleSave above), instead of a raw per-keystroke fetch: it debounces
+    // at 1s and drives the StatusBar's saved indicator like everything else.
+    //
+    // The five RSVP fields still go through saveAttendanceSettings (same
+    // POST /api/operations/${opID}/attendance/platoons as before). Each of
+    // the six RSVP handlers below calls refresh() (from useOperationStatus)
+    // once its save lands, so the timeline's server-derived bits — detail
+    // text, current/pending dot state — catch up immediately instead of
+    // waiting for the next 30s poll. The picker/pill *values* don't need
+    // that round trip: they're driven off local rsvpOpenAt/rsvpCloseOffsetMins
+    // state (passed into ScheduleCard as props), the same way date and
+    // closeOffsetMins already were, not off the polled timeline.
+    function handleChangeDate(v: Dayjs | null) {
         if (!v) return
-        metaHandleRef.current?.set('date', v.toISOString())
+        const iso = v.toISOString()
+        metaHandleRef.current?.set('date', iso)
         setDate(v)
-        await fetch(`/api/operations/update?id=${opID}&date=${encodeURIComponent(v.toISOString())}`)
+        scheduleSave({ date: iso })
     }
 
     // "Manual" pill — matches the old panel's Manual button (always clears it).
-    function handleSetRsvpOpenManual() {
+    async function handleSetRsvpOpenManual() {
         if (!rsvpOpenAt) return
         setRsvpOpenAt(null)
-        saveAttendanceSettings({ rsvpOpenAt: null })
+        await saveAttendanceSettings({ rsvpOpenAt: null })
+        refresh()
     }
 
     // "Scheduled" pill — matches the old panel's Scheduled button: only
     // defaults (3 days before the op date) if nothing's set yet and there's
     // an op date to default from; otherwise a no-op, same as before.
-    function handleSetRsvpOpenScheduled() {
+    async function handleSetRsvpOpenScheduled() {
         if (rsvpOpenAt || !date) return
         const openAt = new Date(date.toDate().getTime() - 3 * 24 * 3600000).toISOString()
         setRsvpOpenAt(openAt)
-        saveAttendanceSettings({ rsvpOpenAt: openAt })
+        await saveAttendanceSettings({ rsvpOpenAt: openAt })
+        refresh()
     }
 
-    // Exact RSVP-open instant picked directly off the DateTimePicker.
+    // Exact RSVP-open instant picked directly off the DateTimePicker. Debounced —
+    // dragging through the picker's date/time sections fires onChange per section.
     function handleChangeRsvpOpenAt(v: Dayjs | null) {
         if (!v) return
         const iso = v.toISOString()
         setRsvpOpenAt(iso)
-        saveAttendanceSettings({ rsvpOpenAt: iso })
+        clearTimeout(rsvpOpenAtSaveTimer.current)
+        rsvpOpenAtSaveTimer.current = setTimeout(async () => {
+            await saveAttendanceSettings({ rsvpOpenAt: iso })
+            refresh()
+        }, 1000)
     }
 
     // RSVP-open quick-set relative to the op date (1 day/3 days/1 week/2 weeks before).
-    function handleQuickSetRsvpOpen(mins: number) {
+    async function handleQuickSetRsvpOpen(mins: number) {
         if (!date) return
         const iso = new Date(date.toDate().getTime() - mins * 60000).toISOString()
         setRsvpOpenAt(iso)
-        saveAttendanceSettings({ rsvpOpenAt: iso })
+        await saveAttendanceSettings({ rsvpOpenAt: iso })
+        refresh()
     }
 
-    function handleChangeCloseOffset(mins: number) {
+    async function handleChangeCloseOffset(mins: number) {
         setRsvpCloseOffsetMins(mins)
-        saveAttendanceSettings({ rsvpCloseOffsetMins: mins })
+        await saveAttendanceSettings({ rsvpCloseOffsetMins: mins })
+        refresh()
     }
 
     // Custom RSVP-close instant — same as the old panel's "Custom…" picker:
     // it only ever persists as the derived minutes-before-op-date, and does
-    // nothing without an op date to derive that offset from.
+    // nothing without an op date to derive that offset from. Debounced for
+    // the same reason as handleChangeRsvpOpenAt.
     function handleChangeRsvpCloseAt(v: Dayjs | null) {
         if (!v || !date) return
         const mins = Math.max(0, Math.round((date.toDate().getTime() - v.toDate().getTime()) / 60000))
         setRsvpCloseOffsetMins(mins)
-        saveAttendanceSettings({ rsvpCloseOffsetMins: mins })
+        clearTimeout(rsvpCloseAtSaveTimer.current)
+        rsvpCloseAtSaveTimer.current = setTimeout(async () => {
+            await saveAttendanceSettings({ rsvpCloseOffsetMins: mins })
+            refresh()
+        }, 1000)
     }
 
     async function applyStage(newStage: AttendanceStage) {
@@ -685,6 +717,7 @@ export default function Page() {
                                 timeline={timeline}
                                 date={date}
                                 onChangeDate={handleChangeDate}
+                                rsvpOpenAt={rsvpOpenAt}
                                 onSetRsvpOpenManual={handleSetRsvpOpenManual}
                                 onSetRsvpOpenScheduled={handleSetRsvpOpenScheduled}
                                 onChangeRsvpOpenAt={handleChangeRsvpOpenAt}
@@ -692,6 +725,7 @@ export default function Page() {
                                 closeOffsetMins={rsvpCloseOffsetMins}
                                 onChangeCloseOffset={handleChangeCloseOffset}
                                 onChangeRsvpCloseAt={handleChangeRsvpCloseAt}
+                                automationPaused={status === 'In Development'}
                             />
                         )}
                         {/* Later tasks add more deck cards here. */}

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -1,13 +1,10 @@
-'use client'
+﻿'use client'
 
 import { useState, useEffect, useRef, type CSSProperties } from 'react'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import ConfirmDialog from '@/components/confirm-dialog'
 import dayjs, { Dayjs } from 'dayjs'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
-import dynamic from 'next/dynamic'
+import type { HocuspocusProvider } from '@hocuspocus/provider'
 import PERMISSIONS from '@/lib/permissions'
 import ActivityLog from './activity-log'
 import FullscreenPage from '@/components/FullscreenPage'
@@ -15,44 +12,23 @@ import EditorShell, { useEditorTab } from './EditorShell'
 import Header from './Header'
 import StatusBar from './StatusBar'
 import { useOperationStatus } from './hooks/useOperationStatus'
+import { usePresence } from './hooks/usePresence'
+import { useDocStats } from './hooks/useDocStats'
 import MissionDeck from './deck/MissionDeck'
 import CountdownStrip from './deck/CountdownStrip'
 import ScheduleCard from './deck/ScheduleCard'
 import StageCard from './deck/StageCard'
 import DetailsCard from './deck/DetailsCard'
 import AttendanceCard from './deck/AttendanceCard'
-const OperationEditor = dynamic(() => import('@/components/editor/CollabEditor'), { ssr: false })
+import BriefTab from './tabs/BriefTab'
+import MapTab from './tabs/MapTab'
+import DevelopmentTab from './tabs/DevelopmentTab'
+import AttendanceTab from './tabs/AttendanceTab'
+import type { MapWorld } from '@/components/operations/map/types'
 
 interface MetaFields { title: string; department: string; date: string; loreDate: string }
 
 type AttendanceStage = 'preparing' | 'rsvp_open' | 'rsvp_closed' | 'op_running' | 'confirmations_open' | 'completed'
-
-const STAGE_DEFS: { id: AttendanceStage; label: string; sub: string }[] = [
-    { id: 'preparing',          label: 'Preparing',    sub: '' },
-    { id: 'rsvp_open',          label: 'RSVP',         sub: 'Open' },
-    { id: 'rsvp_closed',        label: 'RSVP',         sub: 'Closed' },
-    { id: 'op_running',         label: 'Op',           sub: 'Running' },
-    { id: 'confirmations_open', label: 'Confirm',      sub: 'Open' },
-    { id: 'completed',          label: 'Completed',    sub: '' },
-]
-
-const CHECK_CONTENT: Record<'campaign' | 'single', Record<string, string[]>> = {
-    campaign: {
-        w16: ['Mission concept/idea submitted to J2', 'Initial discussion completed with team leads'],
-        w12: ['Confirmed mission development has started', 'Initial planning document created', 'First mission scenario and orders started', 'J2 lead briefed on mission concept'],
-        w10: ['Core framework and fundamentals established', 'First mission scenario and orders complete', 'Second and third missions started'],
-        w8: ['Second and third missions complete', 'All subsequent missions started', 'All mission orders finalised'],
-        w6: ['Final checks and revisions completed', 'Bug fixing pass completed', 'Server loadout and mission tested', 'Weekly Monday reminder sent (if any items incomplete)'],
-        w4: ['Final development check completed', 'Arsenal and loadout updates confirmed'],
-    },
-    single: {
-        w12: ['Mission concept/idea submitted to J2'],
-        w10: ['Confirmed mission development has started', 'Mission scenario and orders started', 'J2 lead briefed on mission concept'],
-        w8: ['Mission scenario and orders complete', 'Replacement mission arranged if not complete'],
-        w6: ['Final checks and bug fixing completed', 'Server mission tested', 'Weekly Monday reminder sent (if any items incomplete)'],
-        w4: ['Final development check completed', 'Arsenal and loadout updates confirmed'],
-    },
-}
 
 // Header (48px) + tab bar (36px) from shell.module.css — the drawers below dock
 // under the shell's own chrome now that FullscreenPage has dropped the site
@@ -64,18 +40,6 @@ const EDITOR_CHROME_HEIGHT = 84
 // These build the all-longhand equivalent instead.
 const sideBorders = (all: string, top: string): CSSProperties =>
     ({ borderTop: top, borderRight: all, borderBottom: all, borderLeft: all })
-
-const bottomBorder = (bottom: string): CSSProperties =>
-    ({ borderTop: 'none', borderRight: 'none', borderBottom: bottom, borderLeft: 'none' })
-
-// Shared style for the collapsible section header buttons.
-const sectionToggleStyle = (open: boolean): CSSProperties => ({
-    ...bottomBorder(open ? '1px solid rgba(255,255,255,0.05)' : 'none'),
-    width: '100%',
-    background: 'none',
-    cursor: 'pointer',
-    textAlign: 'left',
-})
 
 function hexToRgb(hex: string) {
     const h = hex.replace('#', '')
@@ -106,7 +70,7 @@ export default function Page() {
     const [coverImage, setCoverImage] = useState<string | null>(null)
     const [coverUploading, setCoverUploading] = useState(false)
     const [mapWorld, setMapWorld] = useState<string>('')
-    const [availableWorlds, setAvailableWorlds] = useState<{ name: string; displayName: string; hasPreview: boolean }[]>([])
+    const [availableWorlds, setAvailableWorlds] = useState<MapWorld[]>([])
     const [isHQ, setIsHQ] = useState(false)
     const [isJ2Lead, setIsJ2Lead] = useState(false)
     const [isJ4Admin, setIsJ4Admin] = useState(false)
@@ -118,20 +82,35 @@ export default function Page() {
     const [savedAt, setSavedAt] = useState<Date | null>(null)
     const [tab, setTab] = useEditorTab()
 
+    // Status bar (Task 12) — the Hocuspocus provider CollabEditor creates,
+    // reached via the one prop it's allowed to gain (`onProviderReady`).
+    // `usePresence`/`useDocStats` are the same hooks StatusBar's own doc
+    // already names as its two data sources; wired here because page.tsx is
+    // where the provider first becomes reachable.
+    const [provider, setProvider] = useState<HocuspocusProvider | null>(null)
+    const [wsStatus, setWsStatus] = useState<'connecting' | 'connected' | 'disconnected' | null>(null)
+    useEffect(() => {
+        if (!provider) { setWsStatus(null); return }
+        const onStatus = ({ status }: { status: 'connecting' | 'connected' | 'disconnected' }) => setWsStatus(status)
+        provider.on('status', onStatus)
+        return () => { provider.off('status', onStatus) }
+    }, [provider])
+    const presenceCount = usePresence(provider)
+    const docStats = useDocStats(provider?.document ?? null, 'main')
+    // null (not measured) while connecting — see StatusBar's own doc on why
+    // that must not collapse to a fabricated true/false.
+    const connected = wsStatus === 'connected' ? true : wsStatus === 'disconnected' ? false : null
+
     // Mission deck (Task 8) — days-until-op countdown for the deck's strip.
     // Task 9 also consumes the timeline it builds, for the Timeline card.
     const { timeline, daysUntil, refresh } = useOperationStatus(opID)
 
-    // Mission Development
+    // Mission Development — the gate timeline's own UI-local state (collapse
+    // toggle, completion-modal form fields) now lives in DevelopmentTab;
+    // `missionDev` stays lifted because the deck's CountdownStrip reads it too.
     const [missionDev, setMissionDev] = useState<MissionDevelopment | null>(null)
-    const [missionDevOpen, setMissionDevOpen] = useState(true)
-    const [missionDevSaving, setMissionDevSaving] = useState(false)
     const [isCampaignOp, setIsCampaignOp] = useState(false)
     const [campaignStartDate, setCampaignStartDate] = useState<string | null>(null)
-    const [completingCheckId, setCompletingCheckId] = useState<string | null>(null)
-    const [completionReviewerName, setCompletionReviewerName] = useState('')
-    const [completionComments, setCompletionComments] = useState('')
-    const [completionOutcome, setCompletionOutcome] = useState('')
 
     // Publish flow
     const [publishSaving, setPublishSaving] = useState(false)
@@ -144,23 +123,16 @@ export default function Page() {
     const [j2Members, setJ2Members] = useState<{ id: string; displayName: string }[]>([])
     const [ownerPickerOpen, setOwnerPickerOpen] = useState(false)
 
-    // Acknowledgements
+    // Acknowledgements — `ackExpanded`/remind-button state is now local to
+    // AttendanceTab; `ackCount`/`ackList` stay lifted since they're populated
+    // by the same load effect as everything else below.
     const [ackCount, setAckCount] = useState(0)
     const [ackList, setAckList] = useState<{ userId: string; userName: string; acknowledgedAt: string }[]>([])
-    const [ackExpanded, setAckExpanded] = useState(false)
-    const [remindSaving, setRemindSaving] = useState(false)
-    const [remindSent, setRemindSent] = useState<number | null>(null)
 
-    // Orders Check Request
-    const [ordersCheckModal, setOrdersCheckModal]           = useState(false)
-    const [ordersCheckPreferredAt, setOrdersCheckPreferredAt] = useState<Dayjs | null>(null)
-    const [ordersCheckComments, setOrdersCheckComments]     = useState('')
-    const [ordersCheckSaving, setOrdersCheckSaving]         = useState(false)
+    // Orders Check Request — the request/reminder form's own UI-local state
+    // now lives in DevelopmentTab; `ordersCheckTask` stays lifted because it's
+    // populated by the load effect below.
     const [ordersCheckTask, setOrdersCheckTask]             = useState<null | { _id?: string; status: string; ordersCheckAt?: string; ordersCheckStatus?: string; ordersCheckProposedAt?: string; ordersCheckProposedBy?: string }>(null)
-    const [ordersCheckCancelling, setOrdersCheckCancelling] = useState(false)
-    const [ordersCheckReminderAt, setOrdersCheckReminderAt] = useState<Dayjs | null>(null)
-    const [ordersCheckReminderSaving, setOrdersCheckReminderSaving] = useState(false)
-    const [ordersCheckReminderSet, setOrdersCheckReminderSet] = useState(false)
 
     const [assignedPlatoons, setAssignedPlatoons] = useState<string[]>([])
     const [discordPingEnabled, setDiscordPingEnabled] = useState(false)
@@ -173,14 +145,11 @@ export default function Page() {
     const [attendanceSaving, setAttendanceSaving] = useState(false)
     const [tickNow, setTickNow] = useState(() => new Date())
 
-    const [attendanceOpen, setAttendanceOpen] = useState(true)
-
     const [attStage, setAttStage] = useState<AttendanceStage>('preparing')
-    const [confirmStage, setConfirmStage] = useState<AttendanceStage | null>(null)
     const [stageAdvancing, setStageAdvancing] = useState(false)
-    // StageCard's own confirm target — kept separate from confirmStage
-    // (the old Attendance Settings stepper's confirm state, untouched below)
-    // so the two flows don't share dialog state while both remain live.
+    // StageCard's confirm target — the six-step stepper this used to share
+    // this concern with (the old Attendance Settings panel) is retired
+    // outright (Task 12), superseded by StageCard since Task 10.
     const [stageCardConfirmTarget, setStageCardConfirmTarget] = useState<AttendanceStage | null>(null)
 
     const [confirmDelete, setConfirmDelete] = useState(false)
@@ -188,11 +157,13 @@ export default function Page() {
     const [activityOpen, setActivityOpen] = useState(false)
     const router = useRouter()
 
-    // Custom attendance units
+    // Custom attendance units — the standalone Custom Attendance Units panel
+    // that owned `customUnitsOpen`/`newUnitName`/`newUnitColor` is retired
+    // (Task 12): fully superseded by the deck AttendanceCard's "+ Custom
+    // Unit" chip since Task 11. `customUnits`/`customUnitsSaving` stay lifted
+    // — AttendanceCard still reads and writes them via addCustomUnit/
+    // removeCustomUnit below.
     const [customUnits, setCustomUnits] = useState<{ id: string; name: string; color?: string }[]>([])
-    const [customUnitsOpen, setCustomUnitsOpen] = useState(false)
-    const [newUnitName, setNewUnitName] = useState('')
-    const [newUnitColor, setNewUnitColor] = useState('#6366f1')
     const [customUnitsSaving, setCustomUnitsSaving] = useState(false)
 
     const metaSaveTimer = useRef<ReturnType<typeof setTimeout>>()
@@ -582,6 +553,15 @@ export default function Page() {
         saveAttendanceSettings({ discordPingEnabled: next })
     }
 
+    // AttendanceTab's per-role ping targets (Task 12) — the old Attendance
+    // Settings panel's @everyone/@here/@friend of unit/@veteran member chips,
+    // rehomed. Same saveAttendanceSettings path as every other attendance
+    // write.
+    function handleChangeDiscordPingRoles(roles: string[]) {
+        setDiscordPingRoles(roles)
+        saveAttendanceSettings({ discordPingRoles: roles })
+    }
+
     // Custom-unit add/remove for AttendanceCard's "+ Custom Unit" chip — same
     // endpoint the (untouched) Custom Attendance Units panel below uses, kept
     // as separate functions rather than reusing that panel's inline handlers
@@ -776,6 +756,11 @@ export default function Page() {
     const { r, g, b } = hexToRgb(themeColor)
     const c = (a: number) => `rgba(${r},${g},${b},${a})`
 
+    // MapTab (Task 12) — same resolution the standalone /operations/[id]/map
+    // route does server-side: find the stored `mapWorld` name in the fetched
+    // worlds list, or null if unset/not found.
+    const resolvedMapWorld = availableWorlds.find(w => w.name === mapWorld) ?? null
+
     // Derive the displayed stage from live state so it stays in sync with cron/DB changes.
     // attStage (DB-stored) is only used to distinguish 'preparing' vs 'rsvp_closed',
     // since both have rsvpOpen=false and status=Upcoming.
@@ -848,8 +833,9 @@ export default function Page() {
             />
 
             {/* StageCard's confirm gate (Advance button + segment clicks) — same
-                three impactful stages, same messages, as the old Attendance
-                Settings stepper's own dialog further down. */}
+                three impactful stages, same messages, the old Attendance
+                Settings stepper's own dialog used before it was retired
+                (Task 12), superseded by StageCard since Task 10. */}
             <ConfirmDialog
                 open={stageCardConfirmTarget !== null}
                 title='Change Stage'
@@ -887,15 +873,12 @@ export default function Page() {
                 }
                 statusBar={
                     <StatusBar
-                        // null, not true — no Hocuspocus provider is reachable from this
-                        // page (CollabEditor doesn't expose it), so the socket state is
-                        // genuinely unmeasured here, not "known connected".
-                        connected={null}
+                        connected={connected}
                         activeDocTitle={title || 'Untitled'}
-                        words={0}
-                        sections={0}
+                        words={docStats.words}
+                        sections={docStats.sections}
                         savedAt={savedAt}
-                        editorCount={1}
+                        editorCount={presenceCount}
                         department={department}
                     />
                 }
@@ -983,939 +966,60 @@ export default function Page() {
                         {/* Later tasks add more deck cards here. */}
                     </MissionDeck>
                 }
-            >
-        <div className='w-full' style={{
-            paddingRight: previewOpen ? 'clamp(360px, 40vw, 700px)' : activityOpen ? 'clamp(280px, 30vw, 460px)' : 0,
-            transition: 'padding-right 0.25s ease',
-        }}>
-
-            {/* Edit column — natural flow, body scrolls */}
-            <div style={{
-                width: '100%',
-                maxWidth: 1220,
-                margin: '0 auto',
-                flexShrink: 0,
-                padding: 'clamp(1.5rem, 2.5vw, 2.5rem)',
-            }}>
-
-            {/* Mission Development */}
-            {opID && (() => {
-                const baseDate = isCampaignOp && campaignStartDate
-                    ? new Date(campaignStartDate)
-                    : date?.toDate() ?? null
-                if (!baseDate) return null
-
-                const weeksList = isCampaignOp ? [16, 12, 10, 8, 6, 4] : [12, 10, 8, 6, 4]
-                const now = new Date()
-                const checks = weeksList.map(weeks => {
-                    const dueDate = new Date(baseDate.getTime() - weeks * 7 * 24 * 3600000)
-                    const completion = missionDev?.completions?.[`w${weeks}`]
-                    return {
-                        id: `w${weeks}`,
-                        label: `${weeks}W`,
-                        weeks,
-                        dueDate,
-                        isOverdue: now > dueDate && !completion,
-                        isCompleted: !!completion,
-                        completion,
-                    }
-                })
-                const allDone = checks.every(ch => ch.isCompleted)
-
-                const fmtDate = (d: Date) => d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })
-
-                async function saveCompletion(checkId: string) {
-                    setMissionDevSaving(true)
-                    try {
-                        const res = await fetch(`/api/operations/${opID}/mission-development`, {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({
-                                checkId,
-                                reviewerName: completionReviewerName.trim() || undefined,
-                                comments: completionComments.trim() || undefined,
-                                outcome: completionOutcome.trim() || undefined,
-                            }),
-                        })
-                        const data = await res.json()
-                        if (data.ok) {
-                            setMissionDev(prev => ({
-                                completions: { ...(prev?.completions ?? {}), [checkId]: data.completion },
-                                lastUpdatedAt: new Date().toISOString(),
-                            }))
-                            setCompletingCheckId(null)
-                            setCompletionReviewerName('')
-                            setCompletionComments('')
-                            setCompletionOutcome('')
-                        }
-                    } finally {
-                        setMissionDevSaving(false)
-                    }
-                }
-
-                async function removeCompletion(checkId: string) {
-                    setMissionDevSaving(true)
-                    try {
-                        await fetch(`/api/operations/${opID}/mission-development?checkId=${checkId}`, { method: 'DELETE' })
-                        setMissionDev(prev => {
-                            if (!prev) return prev
-                            const next = { ...prev, completions: { ...prev.completions } }
-                            delete next.completions[checkId]
-                            return next
-                        })
-                    } finally {
-                        setMissionDevSaving(false)
-                    }
-                }
-
-                return (
-                    <>
-                        <div style={{ ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${allDone ? 'rgba(0,200,80,0.6)' : c(0.5)}`), background: 'rgba(255,255,255,0.01)', marginBottom: 20 }}>
-                            <button type='button' onClick={() => setMissionDevOpen(v => !v)}
-                                className='flex items-center justify-between px-4 py-3'
-                                style={sectionToggleStyle(missionDevOpen)}
-                            >
-                                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                                    <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: allDone ? 'rgba(0,200,80,0.6)' : 'rgba(237,237,237,0.3)' }}>
-                                        Mission Development
-                                    </span>
-                                    {allDone && <span style={{ fontSize: '0.6rem', fontWeight: 700, color: 'rgba(0,200,80,0.8)', letterSpacing: '0.1em' }}>✓ All Checks Complete</span>}
-                                    {!allDone && checks.some(ch => ch.isOverdue) && (
-                                        <span style={{ fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(219,100,0,0.85)', border: '1px solid rgba(219,100,0,0.35)', padding: '2px 8px' }}>
-                                            {checks.filter(ch => ch.isOverdue).length} Overdue
-                                        </span>
-                                    )}
-                                    {missionDevSaving && <span style={{ fontSize: '0.6rem', color: 'rgba(219,0,29,0.65)', fontWeight: 700 }}>Saving…</span>}
-                                </div>
-                                <span style={{ fontSize: '0.65rem', color: 'rgba(237,237,237,0.25)', fontFamily: 'monospace' }}>{missionDevOpen ? '[−]' : '[+]'}</span>
-                            </button>
-
-                            {missionDevOpen && (
-                                <div style={{ padding: '20px 16px 16px' }}>
-                                    <div style={{ display: 'flex', alignItems: 'flex-start', marginBottom: 16 }}>
-                                        {checks.map((ch, i) => {
-                                            const nodeColor = ch.isCompleted ? 'rgba(0,200,80,0.7)'
-                                                : ch.isOverdue ? 'rgba(219,80,0,0.55)'
-                                                : 'rgba(255,255,255,0.1)'
-                                            const borderClr = ch.isCompleted ? 'rgba(0,200,80,0.6)'
-                                                : ch.isOverdue ? 'rgba(219,80,0,0.55)'
-                                                : 'rgba(255,255,255,0.15)'
-                                            const labelClr = ch.isCompleted ? 'rgba(0,200,80,0.8)'
-                                                : ch.isOverdue ? 'rgba(219,100,0,0.85)'
-                                                : 'rgba(237,237,237,0.35)'
-                                            const connectorColor = ch.isCompleted && checks[i + 1]?.isCompleted
-                                                ? 'rgba(0,200,80,0.35)'
-                                                : 'rgba(255,255,255,0.08)'
-                                            return (
-                                                <div key={ch.id} style={{ display: 'flex', alignItems: 'flex-start', flex: i < checks.length - 1 ? 1 : undefined }}>
-                                                    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 5, minWidth: 52 }}>
-                                                        <button
-                                                            type='button'
-                                                            disabled={!isJ2Lead || missionDevSaving}
-                                                            onClick={() => {
-                                                                if (!isJ2Lead) return
-                                                                if (ch.isCompleted) {
-                                                                    if (confirm(`Remove completion for ${ch.label} check?`)) removeCompletion(ch.id)
-                                                                } else {
-                                                                    setCompletingCheckId(ch.id)
-                                                                    setCompletionReviewerName('')
-                                                                    setCompletionComments('')
-                                                                    setCompletionOutcome('')
-                                                                }
-                                                            }}
-                                                            title={isJ2Lead ? (ch.isCompleted ? 'Click to remove completion' : 'Click to complete this check') : 'J2 leads only'}
-                                                            style={{
-                                                                width: 22, height: 22, borderRadius: '50%', flexShrink: 0,
-                                                                background: nodeColor, border: `2px solid ${borderClr}`,
-                                                                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                                                cursor: isJ2Lead ? 'pointer' : 'default',
-                                                                padding: 0, transition: 'all 0.2s',
-                                                            }}
-                                                        >
-                                                            {ch.isCompleted && <span style={{ fontSize: 9, color: 'rgba(255,255,255,0.9)', lineHeight: 1 }}>✓</span>}
-                                                            {ch.isOverdue && !ch.isCompleted && <span style={{ fontSize: 9, color: 'rgba(219,120,0,0.9)', lineHeight: 1 }}>!</span>}
-                                                        </button>
-                                                        <div style={{ textAlign: 'center', lineHeight: 1.3 }}>
-                                                            <div style={{ fontSize: '0.52rem', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: labelClr }}>{ch.label}</div>
-                                                            <div style={{ fontSize: '0.48rem', color: 'rgba(237,237,237,0.22)', letterSpacing: '0.04em' }}>{fmtDate(ch.dueDate)}</div>
-                                                        </div>
-                                                        {ch.completion && (
-                                                            <div style={{ fontSize: '0.44rem', color: 'rgba(0,200,80,0.55)', textAlign: 'center', lineHeight: 1.3, maxWidth: 50 }}>
-                                                                {ch.completion.reviewerName}
-                                                            </div>
-                                                        )}
-                                                    </div>
-                                                    {i < checks.length - 1 && (
-                                                        <div style={{ flex: 1, height: 2, marginTop: 10, background: connectorColor }} />
-                                                    )}
-                                                </div>
-                                            )
-                                        })}
-                                    </div>
-
-                                    {/* Legend */}
-                                    <div style={{ display: 'flex', gap: 16, fontSize: '0.55rem', color: 'rgba(237,237,237,0.25)' }}>
-                                        <span><span style={{ color: 'rgba(0,200,80,0.7)' }}>●</span> Completed</span>
-                                        <span><span style={{ color: 'rgba(219,80,0,0.7)' }}>●</span> Overdue</span>
-                                        <span><span style={{ color: 'rgba(255,255,255,0.2)' }}>●</span> Pending</span>
-                                        {!isJ2Lead && <span style={{ color: 'rgba(237,237,237,0.18)', fontStyle: 'italic' }}>J2 leads can complete checks</span>}
-                                        <span style={{ marginLeft: 'auto', color: 'rgba(237,237,237,0.18)' }}>
-                                            {isCampaignOp ? 'Campaign — 6 checks from campaign start' : 'Single mission — 5 checks from op date'}
-                                        </span>
-                                    </div>
-
-                                    {/* Per-check detail rows for completed checks */}
-                                    {checks.filter(ch => ch.completion).length > 0 && (
-                                        <div style={{ marginTop: 14, display: 'flex', flexDirection: 'column', gap: 6 }}>
-                                            {checks.filter(ch => ch.completion).map(ch => (
-                                                <div key={ch.id} style={{ padding: '8px 12px', background: 'rgba(0,200,80,0.04)', border: '1px solid rgba(0,200,80,0.12)', display: 'flex', flexDirection: 'column', gap: 3 }}>
-                                                    <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-                                                        <span style={{ fontSize: '0.6rem', fontWeight: 700, color: 'rgba(0,200,80,0.75)', letterSpacing: '0.08em' }}>{ch.label}</span>
-                                                        <span style={{ fontSize: '0.58rem', color: 'rgba(237,237,237,0.35)' }}>Reviewed by {ch.completion!.reviewerName}</span>
-                                                        <span style={{ fontSize: '0.55rem', color: 'rgba(237,237,237,0.22)', marginLeft: 'auto' }}>
-                                                            {new Date(ch.completion!.completedAt).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit', hour: '2-digit', minute: '2-digit' })}
-                                                        </span>
-                                                    </div>
-                                                    {ch.completion!.comments && (
-                                                        <div style={{ fontSize: '0.58rem', color: 'rgba(237,237,237,0.4)', paddingLeft: 2 }}>{ch.completion!.comments}</div>
-                                                    )}
-                                                    {ch.completion!.outcome && (
-                                                        <div style={{ fontSize: '0.58rem', color: 'rgba(237,200,0,0.5)', paddingLeft: 2 }}>Outcome: {ch.completion!.outcome}</div>
-                                                    )}
-                                                </div>
-                                            ))}
-                                        </div>
-                                    )}
-
-                                    {/* Orders Check Request */}
-                                    <div style={{ marginTop: 16, borderTop: '1px solid rgba(255,255,255,0.07)', paddingTop: 14 }}>
-                                        {ordersCheckTask ? (
-                                            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                                                <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 12px', background: 'rgba(100,150,237,0.06)', border: '1px solid rgba(100,150,237,0.18)' }}>
-                                                    <div style={{ flex: 1 }}>
-                                                        <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'rgba(100,150,237,0.7)', marginBottom: 3 }}>
-                                                            Orders Check {ordersCheckTask.ordersCheckStatus === 'confirmed' ? '✓ Confirmed' : ordersCheckTask.ordersCheckStatus === 'proposed' ? '— Alternative Proposed' : '— Requested'}
-                                                        </div>
-                                                        {ordersCheckTask.ordersCheckAt && (
-                                                            <div style={{ fontSize: '0.68rem', color: 'rgba(237,237,237,0.5)' }}>
-                                                                Requested: {new Date(ordersCheckTask.ordersCheckAt).toLocaleString('en-AU', { dateStyle: 'medium', timeStyle: 'short' })}
-                                                            </div>
-                                                        )}
-                                                        {ordersCheckTask.ordersCheckStatus === 'proposed' && ordersCheckTask.ordersCheckProposedAt && (
-                                                            <div style={{ fontSize: '0.65rem', color: 'rgba(219,160,0,0.75)', marginTop: 2 }}>
-                                                                Alternative by {ordersCheckTask.ordersCheckProposedBy}: {new Date(ordersCheckTask.ordersCheckProposedAt).toLocaleString('en-AU', { dateStyle: 'medium', timeStyle: 'short' })}
-                                                            </div>
-                                                        )}
-                                                    </div>
-                                                    {/* Cancel button */}
-                                                    {ordersCheckTask.ordersCheckStatus !== 'confirmed' && ordersCheckTask._id && (
-                                                        <button
-                                                            type='button'
-                                                            disabled={ordersCheckCancelling}
-                                                            onClick={async () => {
-                                                                if (!confirm('Cancel this orders check request?')) return
-                                                                setOrdersCheckCancelling(true)
-                                                                try {
-                                                                    const res = await fetch(`/api/operations/${opID}/orders-check?taskId=${ordersCheckTask._id}`, { method: 'DELETE' })
-                                                                    if (res.ok) {
-                                                                        setOrdersCheckTask(null)
-                                                                        setOrdersCheckReminderSet(false)
-                                                                    } else {
-                                                                        const d = await res.json()
-                                                                        alert(d.error ?? 'Failed to cancel.')
-                                                                    }
-                                                                } finally {
-                                                                    setOrdersCheckCancelling(false)
-                                                                }
-                                                            }}
-                                                            style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '4px 10px', background: 'none', border: '1px solid rgba(219,0,29,0.3)', color: 'rgba(219,0,29,0.6)', cursor: 'pointer', flexShrink: 0 }}
-                                                        >
-                                                            {ordersCheckCancelling ? '…' : 'Cancel Request'}
-                                                        </button>
-                                                    )}
-                                                </div>
-
-                                                {/* Reminder — shown after confirmation */}
-                                                {ordersCheckTask.ordersCheckStatus === 'confirmed' && ordersCheckTask._id && (
-                                                    <LocalizationProvider dateAdapter={AdapterDayjs}>
-                                                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 12px', background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.07)' }}>
-                                                            <span style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.3)', flexShrink: 0 }}>Remind me:</span>
-                                                            <DateTimePicker
-                                                                value={ordersCheckReminderAt}
-                                                                onChange={v => setOrdersCheckReminderAt(v)}
-                                                                slotProps={{
-                                                                    textField: { size: 'small', sx: { '& .MuiInputBase-root': { background: 'rgba(0,0,0,0.3)', borderRadius: 0, fontSize: '0.75rem' }, '& .MuiOutlinedInput-notchedOutline': { border: '1px solid rgba(255,255,255,0.08)' }, '& .MuiInputBase-input': { color: 'rgba(237,237,237,0.75)', padding: '4px 8px' }, '& .MuiSvgIcon-root': { color: 'rgba(237,237,237,0.3)', fontSize: 16 } } },
-                                                                    popper: { sx: { zIndex: 19999 } },
-                                                                }}
-                                                            />
-                                                            <button
-                                                                type='button'
-                                                                disabled={!ordersCheckReminderAt || ordersCheckReminderSaving}
-                                                                onClick={async () => {
-                                                                    if (!ordersCheckReminderAt) return
-                                                                    setOrdersCheckReminderSaving(true)
-                                                                    try {
-                                                                        const res = await fetch(`/api/operations/${opID}/orders-check`, {
-                                                                            method: 'PATCH',
-                                                                            headers: { 'Content-Type': 'application/json' },
-                                                                            body: JSON.stringify({ taskId: ordersCheckTask._id, action: 'set_reminder', proposedAt: ordersCheckReminderAt.toISOString() }),
-                                                                        })
-                                                                        if (res.ok) { setOrdersCheckReminderSet(true) }
-                                                                        else { const d = await res.json(); alert(d.error ?? 'Failed.') }
-                                                                    } finally {
-                                                                        setOrdersCheckReminderSaving(false)
-                                                                    }
-                                                                }}
-                                                                style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '4px 10px', background: ordersCheckReminderSet ? 'rgba(76,175,80,0.15)' : 'rgba(100,150,237,0.15)', border: `1px solid ${ordersCheckReminderSet ? 'rgba(76,175,80,0.3)' : 'rgba(100,150,237,0.3)'}`, color: ordersCheckReminderSet ? 'rgba(76,175,80,0.8)' : 'rgba(100,150,237,0.8)', cursor: 'pointer', flexShrink: 0 }}
-                                                            >
-                                                                {ordersCheckReminderSet ? '✓ Set' : 'Set Reminder'}
-                                                            </button>
-                                                        </div>
-                                                    </LocalizationProvider>
-                                                )}
-                                            </div>
-                                        ) : (
-                                            <button type='button' onClick={() => setOrdersCheckModal(true)}
-                                                style={{
-                                                    fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase',
-                                                    padding: '7px 16px', background: 'rgba(100,150,237,0.1)', border: '1px solid rgba(100,150,237,0.3)',
-                                                    color: 'rgba(100,150,237,0.85)', cursor: 'pointer',
-                                                }}
-                                            >
-                                                + Request Orders Check
-                                            </button>
-                                        )}
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-
-                        {/* Completion modal */}
-                        {completingCheckId && (() => {
-                            const ch = checks.find(c => c.id === completingCheckId)
-                            if (!ch) return null
-                            return (
-                                <div style={{ position: 'fixed', inset: 0, zIndex: 9999, background: 'rgba(0,0,0,0.8)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                                    onClick={e => { if (e.target === e.currentTarget) setCompletingCheckId(null) }}
-                                >
-                                    <div style={{ background: '#0f0f10', ...sideBorders(`1px solid ${c(0.35)}`, `2px solid rgba(0,200,80,0.7)`), padding: '24px 28px', maxWidth: 500, width: '90%', display: 'flex', flexDirection: 'column', gap: 16 }}>
-                                        <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'rgba(0,200,80,0.5)', fontFamily: 'monospace' }}>
-                                            {'// COMPLETE CHECK'}
-                                        </div>
-                                        <div style={{ fontSize: '0.88rem', fontWeight: 700, textTransform: 'uppercase', color: 'rgba(237,237,237,0.9)' }}>
-                                            {ch.label} Development Check
-                                        </div>
-                                        <div style={{ fontSize: '0.65rem', color: 'rgba(237,237,237,0.4)' }}>
-                                            Due: {ch.dueDate.toLocaleDateString('en-GB', { weekday: 'short', day: '2-digit', month: 'long', year: 'numeric' })}
-                                            {ch.isOverdue && <span style={{ color: 'rgba(219,80,0,0.85)', marginLeft: 8 }}>● Overdue</span>}
-                                        </div>
-
-                                        {(() => {
-                                            const items = CHECK_CONTENT[isCampaignOp ? 'campaign' : 'single'][ch.id] ?? []
-                                            if (!items.length) return null
-                                            return (
-                                                <div style={{ background: 'rgba(0,200,80,0.04)', border: '1px solid rgba(0,200,80,0.12)', padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 6 }}>
-                                                    <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'rgba(0,200,80,0.45)', marginBottom: 4, fontFamily: 'monospace' }}>
-                                                        Stage Checklist
-                                                    </div>
-                                                    {items.map((item, i) => (
-                                                        <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-                                                            <span style={{ fontSize: '0.6rem', color: 'rgba(0,200,80,0.5)', marginTop: 1, flexShrink: 0 }}>◻</span>
-                                                            <span style={{ fontSize: '0.7rem', color: 'rgba(237,237,237,0.6)', lineHeight: 1.45 }}>{item}</span>
-                                                        </div>
-                                                    ))}
-                                                </div>
-                                            )
-                                        })()}
-
-                                        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-                                            <div>
-                                                <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: c(0.55), marginBottom: 6 }}>Reviewer Name</div>
-                                                <input
-                                                    value={completionReviewerName}
-                                                    onChange={e => setCompletionReviewerName(e.target.value)}
-                                                    placeholder='Your name or assigned reviewer…'
-                                                    style={{ width: '100%', background: 'rgba(0,0,0,0.35)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.85)', fontSize: '0.8rem', padding: '8px 10px', outline: 'none', boxSizing: 'border-box' }}
-                                                />
-                                            </div>
-                                            <div>
-                                                <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: c(0.55), marginBottom: 6 }}>Comments</div>
-                                                <textarea
-                                                    value={completionComments}
-                                                    onChange={e => setCompletionComments(e.target.value)}
-                                                    placeholder='Review notes, observations…'
-                                                    rows={3}
-                                                    style={{ width: '100%', background: 'rgba(0,0,0,0.35)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.85)', fontSize: '0.78rem', padding: '8px 10px', outline: 'none', resize: 'vertical', boxSizing: 'border-box' }}
-                                                />
-                                            </div>
-                                            <div>
-                                                <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: c(0.55), marginBottom: 6 }}>Outcome / Notes</div>
-                                                <textarea
-                                                    value={completionOutcome}
-                                                    onChange={e => setCompletionOutcome(e.target.value)}
-                                                    placeholder='Outcome, decisions made, action items…'
-                                                    rows={2}
-                                                    style={{ width: '100%', background: 'rgba(0,0,0,0.35)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.85)', fontSize: '0.78rem', padding: '8px 10px', outline: 'none', resize: 'vertical', boxSizing: 'border-box' }}
-                                                />
-                                            </div>
-                                        </div>
-
-                                        <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 4 }}>
-                                            <button type='button' onClick={() => setCompletingCheckId(null)}
-                                                style={{ padding: '7px 18px', fontSize: '0.7rem', fontWeight: 700, background: 'none', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.4)', cursor: 'pointer' }}
-                                            >CANCEL</button>
-                                            <button type='button' disabled={missionDevSaving} onClick={() => saveCompletion(completingCheckId)}
-                                                style={{ padding: '7px 18px', fontSize: '0.7rem', fontWeight: 700, background: 'rgba(0,200,80,0.18)', border: '1px solid rgba(0,200,80,0.45)', color: 'rgba(0,200,80,0.9)', cursor: 'pointer' }}
-                                            >{missionDevSaving ? 'Saving…' : '✓ Mark Complete'}</button>
-                                        </div>
-                                    </div>
-                                </div>
-                            )
-                        })()}
-
-                        {/* Orders Check modal */}
-                        {ordersCheckModal && (
-                            <div style={{ position: 'fixed', inset: 0, zIndex: 9999, background: 'rgba(0,0,0,0.8)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                                onClick={e => { if (e.target === e.currentTarget) setOrdersCheckModal(false) }}
-                            >
-                                <LocalizationProvider dateAdapter={AdapterDayjs}>
-                                    <div style={{ background: '#0f0f10', ...sideBorders(`1px solid rgba(100,150,237,0.35)`, `2px solid rgba(100,150,237,0.8)`), padding: '24px 28px', maxWidth: 440, width: '90%', display: 'flex', flexDirection: 'column', gap: 16 }}>
-                                        <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'rgba(100,150,237,0.5)', fontFamily: 'monospace' }}>
-                                            {'// REQUEST ORDERS CHECK'}
-                                        </div>
-                                        <div style={{ fontSize: '0.88rem', fontWeight: 700, color: 'rgba(237,237,237,0.9)' }}>
-                                            {title || 'This Operation'}
-                                        </div>
-                                        <div style={{ fontSize: '0.7rem', color: 'rgba(237,237,237,0.45)', lineHeight: 1.5 }}>
-                                            Select a preferred date and time for your orders check. A task will be created for J2 leads to review and confirm.
-                                        </div>
-
-                                        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-                                            <div>
-                                                <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.35)', marginBottom: 8 }}>
-                                                    Preferred Date &amp; Time
-                                                </div>
-                                                <DateTimePicker
-                                                    value={ordersCheckPreferredAt}
-                                                    onChange={v => setOrdersCheckPreferredAt(v)}
-                                                    slotProps={{
-                                                        textField: {
-                                                            size: 'small',
-                                                            fullWidth: true,
-                                                            sx: {
-                                                                '& .MuiInputBase-root': { background: 'rgba(0,0,0,0.35)', borderRadius: 0, fontSize: '0.82rem' },
-                                                                '& .MuiOutlinedInput-notchedOutline': { border: '1px solid rgba(255,255,255,0.1)' },
-                                                                '& .MuiInputBase-input': { color: 'rgba(237,237,237,0.85)' },
-                                                                '& .MuiSvgIcon-root': { color: 'rgba(237,237,237,0.4)' },
-                                                            },
-                                                        },
-                                                        popper: { sx: { zIndex: 19999 } },
-                                                    }}
-                                                />
-                                            </div>
-                                            <div>
-                                                <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.35)', marginBottom: 8 }}>
-                                                    Comments (optional)
-                                                </div>
-                                                <textarea
-                                                    value={ordersCheckComments}
-                                                    onChange={e => setOrdersCheckComments(e.target.value)}
-                                                    placeholder='Any notes or context for J2 leads…'
-                                                    rows={3}
-                                                    style={{ width: '100%', background: 'rgba(0,0,0,0.35)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.85)', fontSize: '0.78rem', padding: '8px 10px', outline: 'none', resize: 'vertical', boxSizing: 'border-box' }}
-                                                />
-                                            </div>
-                                        </div>
-
-                                        <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 4 }}>
-                                            <button type='button' onClick={() => setOrdersCheckModal(false)}
-                                                style={{ padding: '7px 18px', fontSize: '0.7rem', fontWeight: 700, background: 'none', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.4)', cursor: 'pointer' }}
-                                            >CANCEL</button>
-                                            <button type='button'
-                                                disabled={!ordersCheckPreferredAt || ordersCheckSaving}
-                                                onClick={async () => {
-                                                    if (!ordersCheckPreferredAt) return
-                                                    setOrdersCheckSaving(true)
-                                                    try {
-                                                        const res = await fetch(`/api/operations/${opID}/orders-check`, {
-                                                            method: 'POST',
-                                                            headers: { 'Content-Type': 'application/json' },
-                                                            body: JSON.stringify({
-                                                                preferredAt: ordersCheckPreferredAt.toISOString(),
-                                                                comments: ordersCheckComments.trim() || undefined,
-                                                            }),
-                                                        })
-                                                        if (res.ok) {
-                                                            setOrdersCheckTask({ status: 'pending', ordersCheckAt: ordersCheckPreferredAt.toISOString(), ordersCheckStatus: 'pending' })
-                                                            setOrdersCheckModal(false)
-                                                            setOrdersCheckComments('')
-                                                            setOrdersCheckPreferredAt(null)
-                                                        } else {
-                                                            const d = await res.json()
-                                                            alert(d.error ?? 'Failed to submit orders check request.')
-                                                        }
-                                                    } finally {
-                                                        setOrdersCheckSaving(false)
-                                                    }
-                                                }}
-                                                style={{ padding: '7px 18px', fontSize: '0.7rem', fontWeight: 700, background: ordersCheckPreferredAt && !ordersCheckSaving ? 'rgba(100,150,237,0.2)' : 'rgba(255,255,255,0.05)', border: '1px solid rgba(100,150,237,0.4)', color: ordersCheckPreferredAt && !ordersCheckSaving ? 'rgba(100,150,237,0.9)' : 'rgba(237,237,237,0.3)', cursor: ordersCheckPreferredAt ? 'pointer' : 'not-allowed' }}
-                                            >{ordersCheckSaving ? 'Submitting…' : 'Submit Request'}</button>
-                                        </div>
-                                    </div>
-                                </LocalizationProvider>
-                            </div>
-                        )}
-                    </>
-                )
-            })()}
-
-            {/* Acknowledgements — owned by Task 12, not this one. Its proper
-                home is the Attendance tab Task 12 builds; left mounted here,
-                functionally unchanged from the old "Operation Details" panel,
-                so it isn't lost in the meantime. Do not restyle, move, or
-                delete it as part of any other task — see task-11-report.md
-                for the ruling. Everything else that old panel held (title,
-                owner, billet points, department, status, theme colour, era,
-                map, in-game date, cover photo) now lives in the deck's
-                DetailsCard. */}
-            <div style={{ marginBottom: 20 }}>
-                {status === 'Upcoming' && (
-                    <div style={{ ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${c(0.5)}`), background: 'rgba(255,255,255,0.01)', padding: '12px 16px' }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: ackExpanded ? 10 : 0 }}>
-                            <span style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: c(0.55) }}>Orders Acknowledged</span>
-                            <span style={{ fontSize: '0.65rem', fontWeight: 700, color: ackCount > 0 ? 'rgba(0,200,80,0.8)' : 'rgba(237,237,237,0.3)' }}>{ackCount} staff</span>
-                            <button type='button' onClick={() => setAckExpanded(v => !v)} style={{ fontSize: '0.58rem', background: 'none', border: 'none', color: 'rgba(237,237,237,0.3)', cursor: 'pointer', padding: '0 4px' }}>{ackExpanded ? '▲ Hide' : '▼ Show'}</button>
-                            <button type='button' disabled={remindSaving} onClick={async () => {
-                                setRemindSaving(true)
-                                try {
-                                    const res = await fetch(`/api/operations/${opID}/remind`, { method: 'POST' })
-                                    if (res.ok) { const d = await res.json(); setRemindSent(d.sent ?? 0) }
-                                } finally { setRemindSaving(false) }
-                            }}
-                                style={{ marginLeft: 'auto', fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.1em', padding: '3px 10px', background: remindSaving ? 'rgba(255,255,255,0.03)' : 'rgba(100,150,237,0.1)', border: '1px solid rgba(100,150,237,0.3)', color: remindSaving ? 'rgba(237,237,237,0.25)' : 'rgba(100,150,237,0.75)', cursor: remindSaving ? 'not-allowed' : 'pointer' }}
-                            >
-                                {remindSaving ? 'Sending…' : remindSent !== null ? `Sent (${remindSent})` : 'Remind Unacknowledged'}
-                            </button>
-                        </div>
-                        {ackExpanded && ackList.length > 0 && (
-                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                                {ackList.map(a => (
-                                    <div key={a.userId} style={{ fontSize: '0.58rem', padding: '3px 8px', background: 'rgba(0,200,80,0.06)', border: '1px solid rgba(0,200,80,0.18)', color: 'rgba(0,200,80,0.7)' }}>
-                                        {a.userName} <span style={{ opacity: 0.5 }}>{new Date(a.acknowledgedAt).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}</span>
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-                        {ackExpanded && ackList.length === 0 && (
-                            <div style={{ fontSize: '0.6rem', color: 'rgba(237,237,237,0.25)', fontStyle: 'italic' }}>No staff have acknowledged yet.</div>
-                        )}
-                    </div>
-                )}
-            </div>
-
-            {/* Attendance settings — HQ only */}
-            {isHQ && opID && (
-                <div style={{ ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${c(0.5)}`), background: 'rgba(255,255,255,0.01)', marginBottom: 20 }}>
-                    <button type='button' onClick={() => setAttendanceOpen(v => !v)}
-                        className='flex items-center justify-between px-4 py-3'
-                        style={sectionToggleStyle(attendanceOpen)}
-                    >
-                        <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.3)' }}>
-                            Attendance Settings
-                        </span>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                            {attendanceSaving && (
-                                <span style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(219,0,29,0.65)' }}>Saving…</span>
-                            )}
-                            <span style={{ fontSize: '0.65rem', color: 'rgba(237,237,237,0.25)', fontFamily: 'monospace' }}>{attendanceOpen ? '[−]' : '[+]'}</span>
-                        </div>
-                    </button>
-                    {attendanceOpen && <div className='flex flex-col gap-4 p-4'>
-                        {/* Platoon checkboxes */}
-                        <div>
-                            <div style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: c(0.6), marginBottom: 10 }}>
-                                Assigned Platoons
-                            </div>
-                            <div className='flex flex-wrap gap-3'>
-                                {PLATOON_OPTS.map(opt => {
-                                    const checked = assignedPlatoons.includes(opt.id)
-                                    return (
-                                        <button
-                                            key={opt.id}
-                                            onClick={() => {
-                                                const updated = checked
-                                                    ? assignedPlatoons.filter(p => p !== opt.id)
-                                                    : [...assignedPlatoons, opt.id]
-                                                setAssignedPlatoons(updated)
-                                                saveAttendanceSettings({ assignedPlatoons: updated })
-                                            }}
-                                            style={{
-                                                display: 'flex', alignItems: 'center', gap: 6,
-                                                padding: '6px 12px',
-                                                border: checked ? `2px solid ${opt.color}` : '1px solid rgba(255,255,255,0.1)',
-                                                background: checked ? opt.color.replace(/[\d.]+\)$/, '0.1)') : 'rgba(255,255,255,0.02)',
-                                                color: checked ? opt.color.replace(/[\d.]+\)$/, '1)') : 'rgba(237,237,237,0.35)',
-                                                fontSize: '0.75rem', fontWeight: 700,
-                                                letterSpacing: '0.07em', textTransform: 'uppercase',
-                                                cursor: 'pointer', userSelect: 'none',
-                                                transition: 'all 0.15s',
-                                            }}
-                                        >
-                                            {checked && (
-                                                <svg width='11' height='11' viewBox='0 0 12 12' fill='none'>
-                                                    <path d='M2 6l3 3 5-5' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
-                                                </svg>
-                                            )}
-                                            {opt.label}
-                                        </button>
-                                    )
-                                })}
-                            </div>
-                        </div>
-
-                        {/* Discord Ping Roles */}
-                        <div>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-                                <div style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: c(0.6) }}>
-                                    Discord Ping Roles
-                                </div>
-                                <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', marginLeft: 'auto' }}>
-                                    <span style={{ fontSize: '0.62rem', color: discordPingEnabled ? '#10b981' : 'rgba(237,237,237,0.3)' }}>
-                                        {discordPingEnabled ? 'Enabled' : 'Disabled'}
-                                    </span>
-                                    <div
-                                        onClick={() => {
-                                            const next = !discordPingEnabled
-                                            setDiscordPingEnabled(next)
-                                            saveAttendanceSettings({ discordPingEnabled: next })
-                                        }}
-                                        style={{
-                                            width: 32, height: 18, borderRadius: 9, cursor: 'pointer',
-                                            background: discordPingEnabled ? 'rgba(16,185,129,0.7)' : 'rgba(255,255,255,0.12)',
-                                            position: 'relative', transition: 'background 0.15s',
-                                        }}
-                                    >
-                                        <div style={{
-                                            position: 'absolute', top: 3, left: discordPingEnabled ? 17 : 3,
-                                            width: 12, height: 12, borderRadius: '50%', background: '#fff',
-                                            transition: 'left 0.15s',
-                                        }} />
-                                    </div>
-                                </label>
-                            </div>
-                            {discordPingEnabled && (
-                                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                                    {[
-                                        { id: '@everyone', label: '@everyone', color: 'rgba(139,92,246,0.65)' },
-                                        { id: '@here', label: '@here', color: 'rgba(59,130,246,0.65)' },
-                                        { id: '@friend of unit', label: '@friend of unit', color: 'rgba(16,185,129,0.65)' },
-                                        { id: '@veteran member', label: '@veteran member', color: 'rgba(245,158,11,0.65)' },
-                                    ].map(role => {
-                                        const checked = discordPingRoles.includes(role.id)
-                                        return (
-                                            <button
-                                                key={role.id}
-                                                onClick={() => {
-                                                    const updated = checked
-                                                        ? discordPingRoles.filter(r => r !== role.id)
-                                                        : [...discordPingRoles, role.id]
-                                                    setDiscordPingRoles(updated)
-                                                    saveAttendanceSettings({ discordPingRoles: updated })
-                                                }}
-                                                style={{
-                                                    display: 'flex', alignItems: 'center', gap: 6,
-                                                    padding: '6px 12px',
-                                                    border: checked ? `1px solid ${role.color}` : '1px solid rgba(255,255,255,0.12)',
-                                                    background: checked ? role.color.replace('0.65)', '0.14)') : 'rgba(255,255,255,0.03)',
-                                                    color: checked ? role.color.replace('0.65)', '1)') : 'rgba(237,237,237,0.35)',
-                                                    fontSize: '0.75rem', fontWeight: 700,
-                                                    letterSpacing: '0.07em',
-                                                    cursor: 'pointer', userSelect: 'none',
-                                                    transition: 'all 0.15s',
-                                                }}
-                                            >
-                                                {checked && (
-                                                    <svg width='11' height='11' viewBox='0 0 12 12' fill='none'>
-                                                        <path d='M2 6l3 3 5-5' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
-                                                    </svg>
-                                                )}
-                                                {role.label}
-                                            </button>
-                                        )
-                                    })}
-                                </div>
-                            )}
-                        </div>
-
-                        {/* Mission Stage bar */}
-                        {(() => {
-                            const currentIdx = STAGE_DEFS.findIndex(s => s.id === displayStage)
-                            const NEEDS_CONFIRM = new Set<AttendanceStage>(['op_running', 'confirmations_open', 'completed'])
-                            const CONFIRM_MSGS: Record<string, string> = {
-                                op_running:          'Mark the operation as Active? This sets it to "Op Running".',
-                                confirmations_open:  `End "${title || 'this mission'}"? This marks it Completed and opens attendance confirmation.`,
-                                completed:           'Close attendance confirmation? Squad leaders will no longer be able to confirm.',
-                            }
-                            return (
-                                <div>
-                                    <div style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: c(0.55), marginBottom: 16 }}>
-                                        Mission Stage
-                                    </div>
-                                    <div style={{ display: 'flex', alignItems: 'flex-start' }}>
-                                        {STAGE_DEFS.map((s, i) => {
-                                            const isPast    = i < currentIdx
-                                            const isCurrent = i === currentIdx
-                                            const nodeColor = isCurrent ? c(1) : isPast ? 'rgba(0,200,80,0.6)' : 'rgba(255,255,255,0.1)'
-                                            const borderClr = isCurrent ? c(0.9) : isPast ? 'rgba(0,200,80,0.5)' : 'rgba(255,255,255,0.15)'
-                                            const labelClr  = isCurrent ? 'rgba(237,237,237,0.95)' : isPast ? 'rgba(0,200,80,0.7)' : 'rgba(237,237,237,0.2)'
-                                            return (
-                                                <div key={s.id} style={{ display: 'flex', alignItems: 'flex-start', flex: i < STAGE_DEFS.length - 1 ? 1 : undefined }}>
-                                                    {/* Node + label */}
-                                                    <div
-                                                        onClick={isHQ ? () => {
-                                                            if (i === currentIdx) return
-                                                            if (NEEDS_CONFIRM.has(s.id)) { setConfirmStage(s.id); return }
-                                                            applyStage(s.id)
-                                                        } : undefined}
-                                                        style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 7, cursor: isHQ && i !== currentIdx ? 'pointer' : 'default', minWidth: 44 }}
-                                                    >
-                                                        <div style={{
-                                                            width: 20, height: 20, borderRadius: '50%', flexShrink: 0,
-                                                            background: nodeColor, border: `2px solid ${borderClr}`,
-                                                            boxShadow: isCurrent ? `0 0 10px ${c(0.45)}` : 'none',
-                                                            display: 'flex', alignItems: 'center', justifyContent: 'center',
-                                                            transition: 'all 0.2s',
-                                                        }}>
-                                                            {isPast && <span style={{ fontSize: 9, color: 'rgba(255,255,255,0.9)', lineHeight: 1 }}>✓</span>}
-                                                        </div>
-                                                        <div style={{ textAlign: 'center', lineHeight: 1.3 }}>
-                                                            <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: labelClr }}>{s.label}</div>
-                                                            {s.sub && <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: labelClr }}>{s.sub}</div>}
-                                                        </div>
-                                                    </div>
-                                                    {/* Connector */}
-                                                    {i < STAGE_DEFS.length - 1 && (
-                                                        <div style={{ flex: 1, height: 2, marginTop: 9, background: isPast ? 'rgba(0,200,80,0.35)' : 'rgba(255,255,255,0.08)' }} />
-                                                    )}
-                                                </div>
-                                            )
-                                        })}
-                                    </div>
-                                    {/* Confirm dialog for impactful stage changes */}
-                                    <ConfirmDialog
-                                        open={confirmStage !== null}
-                                        title='Change Stage'
-                                        message={confirmStage ? (CONFIRM_MSGS[confirmStage] ?? `Move to "${confirmStage}"?`) : ''}
-                                        confirmLabel='Confirm'
-                                        danger
-                                        onConfirm={() => { const s = confirmStage!; setConfirmStage(null); applyStage(s) }}
-                                        onCancel={() => setConfirmStage(null)}
-                                    />
-                                </div>
-                            )
-                        })()}
-                    </div>}
-                </div>
-            )}
-
-            {/* Custom Attendance Units — HQ only */}
-            {isHQ && opID && (
-                <div style={{
-                    ...sideBorders(`1px solid ${c(0.12)}`, `2px solid rgba(251,191,36,0.35)`),
-                    marginBottom: 20,
-                    background: 'rgba(0,0,0,0.22)',
-                }}>
-                    {/* Header */}
-                    <div
-                        onClick={() => setCustomUnitsOpen(o => !o)}
-                        style={{
-                            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                            padding: '10px 16px', cursor: 'pointer',
-                            background: 'rgba(0,0,0,0.28)',
-                            borderBottom: customUnitsOpen ? `1px solid ${c(0.08)}` : 'none',
-                            userSelect: 'none',
+                brief={
+                    <BriefTab
+                        opID={opID}
+                        initialContent={initialContent}
+                        themeColor={themeColor}
+                        title={title}
+                        department={department}
+                        date={date?.toISOString() ?? ''}
+                        loreDate={loreDate ?? ''}
+                        onMetaChange={fields => {
+                            if (fields.title !== undefined) setTitle(fields.title)
+                            if (fields.department !== undefined) setDepartment(fields.department)
+                            if (fields.date !== undefined) setDate(fields.date ? dayjs(fields.date) : null)
+                            if (fields.loreDate !== undefined) setLoreDate(fields.loreDate ?? '')
                         }}
-                    >
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                            <div style={{ width: 6, height: 6, background: 'rgba(251,191,36,0.6)', flexShrink: 0 }} />
-                            <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: c(0.85) }}>
-                                Custom Attendance Units
-                            </span>
-                            {customUnits.length > 0 && (
-                                <span style={{
-                                    fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.08em',
-                                    padding: '1px 7px', background: 'rgba(251,191,36,0.14)',
-                                    border: '1px solid rgba(251,191,36,0.3)', color: 'rgba(251,191,36,0.9)',
-                                }}>
-                                    {customUnits.length}
-                                </span>
-                            )}
-                        </div>
-                        <svg width='14' height='14' viewBox='0 0 14 14' fill='none' style={{ transition: 'transform 0.18s', transform: customUnitsOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}>
-                            <path d='M3 5l4 4 4-4' stroke={c(0.5)} strokeWidth='1.5' strokeLinecap='round' strokeLinejoin='round' />
-                        </svg>
-                    </div>
-
-                    {customUnitsOpen && (
-                        <div style={{ padding: '14px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
-                            {/* Existing units list */}
-                            {customUnits.length > 0 && (
-                                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                                    {customUnits.map(unit => (
-                                        <div key={unit.id} style={{
-                                            display: 'flex', alignItems: 'center', gap: 10,
-                                            padding: '7px 12px',
-                                            background: 'rgba(255,255,255,0.04)',
-                                            border: '1px solid rgba(255,255,255,0.07)',
-                                        }}>
-                                            {unit.color && (
-                                                <div style={{
-                                                    width: 12, height: 12, borderRadius: '50%', flexShrink: 0,
-                                                    background: unit.color,
-                                                    border: '1px solid rgba(255,255,255,0.2)',
-                                                }} />
-                                            )}
-                                            <span style={{ fontSize: '0.78rem', color: c(0.9), flex: 1 }}>{unit.name}</span>
-                                            <button
-                                                onClick={async () => {
-                                                    setCustomUnitsSaving(true)
-                                                    try {
-                                                        await fetch(`/api/operations/${opID}/attendance/custom-units?unitId=${unit.id}`, { method: 'DELETE' })
-                                                        setCustomUnits(prev => prev.filter(u => u.id !== unit.id))
-                                                    } finally {
-                                                        setCustomUnitsSaving(false)
-                                                    }
-                                                }}
-                                                disabled={customUnitsSaving}
-                                                style={{
-                                                    padding: '3px 8px', fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em',
-                                                    border: '1px solid rgba(239,68,68,0.3)', background: 'rgba(239,68,68,0.06)',
-                                                    color: 'rgba(239,68,68,0.7)', cursor: 'pointer',
-                                                    opacity: customUnitsSaving ? 0.5 : 1,
-                                                }}
-                                            >
-                                                REMOVE
-                                            </button>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-
-                            {customUnits.length === 0 && (
-                                <div style={{ fontSize: '0.72rem', color: c(0.35), fontStyle: 'italic', textAlign: 'center', padding: '8px 0' }}>
-                                    No custom units defined. Add one below.
-                                </div>
-                            )}
-
-                            {/* Add new unit form */}
-                            <div style={{ display: 'flex', gap: 8, alignItems: 'center', paddingTop: 4, borderTop: `1px solid ${c(0.07)}` }}>
-                                <input
-                                    value={newUnitName}
-                                    onChange={e => setNewUnitName(e.target.value)}
-                                    placeholder='Unit name…'
-                                    maxLength={40}
-                                    style={{
-                                        flex: 1, padding: '7px 10px', fontSize: '0.78rem',
-                                        background: 'rgba(255,255,255,0.05)',
-                                        border: `1px solid ${c(0.15)}`, color: c(0.9),
-                                        outline: 'none',
-                                    }}
-                                />
-                                <input
-                                    type='color'
-                                    value={newUnitColor || '#888888'}
-                                    onChange={e => setNewUnitColor(e.target.value)}
-                                    title='Unit colour'
-                                    style={{
-                                        width: 34, height: 34, padding: 2, cursor: 'pointer',
-                                        background: 'rgba(255,255,255,0.05)',
-                                        border: `1px solid ${c(0.15)}`,
-                                    }}
-                                />
-                                <button
-                                    disabled={!newUnitName.trim() || customUnitsSaving}
-                                    onClick={async () => {
-                                        if (!newUnitName.trim()) return
-                                        setCustomUnitsSaving(true)
-                                        try {
-                                            const res = await fetch(`/api/operations/${opID}/attendance/custom-units`, {
-                                                method: 'POST',
-                                                headers: { 'Content-Type': 'application/json' },
-                                                body: JSON.stringify({ name: newUnitName.trim(), color: newUnitColor || undefined }),
-                                            })
-                                            const data = await res.json()
-                                            if (data.unit) {
-                                                setCustomUnits(prev => [...prev, data.unit])
-                                                setNewUnitName('')
-                                                setNewUnitColor('')
-                                            }
-                                        } finally {
-                                            setCustomUnitsSaving(false)
-                                        }
-                                    }}
-                                    style={{
-                                        padding: '7px 14px', fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.1em',
-                                        border: '1px solid rgba(251,191,36,0.35)', background: 'rgba(251,191,36,0.1)',
-                                        color: 'rgba(251,191,36,0.9)', cursor: 'pointer',
-                                        opacity: (!newUnitName.trim() || customUnitsSaving) ? 0.4 : 1,
-                                        transition: 'opacity 0.15s',
-                                    }}
-                                >
-                                    + ADD
-                                </button>
-                            </div>
-                        </div>
-                    )}
-                </div>
-            )}
-
-            {/* Document sections */}
-            {loaded ? (
-                <OperationEditor
-                    documentId={opID}
-                    uploadUrl='/api/operations/upload'
-                    defaultSectionTitle='Situation'
-                    initialContent={initialContent}
-                    themeColor={themeColor}
-                    initialMeta={{ title, department, date: date?.toISOString() ?? '', loreDate: loreDate ?? '' }}
-                    onMetaChange={fields => {
-                        if (fields.title !== undefined) setTitle(fields.title)
-                        if (fields.department !== undefined) setDepartment(fields.department)
-                        if (fields.date !== undefined) setDate(fields.date ? dayjs(fields.date) : null)
-                        if (fields.loreDate !== undefined) setLoreDate(fields.loreDate ?? '')
-                    }}
-                    metaHandleRef={metaHandleRef}
-                    onSaveStatusChange={setSaveStatus}
-                />
-            ) : (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-                    <style>{`@keyframes op-pulse{0%,100%{opacity:.35}50%{opacity:.75}}.op-pulse{animation:op-pulse 1.8s ease-in-out infinite}`}</style>
-                    {[1, 0.6].map((opacity, i) => (
-                        <div key={i} style={{ ...sideBorders(`1px solid ${c(0.1)}`, `2px solid ${c(0.25)}`), opacity }}>
-                            <div style={{ background: 'rgba(0,0,0,0.35)', padding: '9px 16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
-                                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                                    <div className='op-pulse' style={{ width: 6, height: 6, background: c(0.35), flexShrink: 0 }} />
-                                    <div className='op-pulse' style={{ height: 7, width: 110 + i * 30, background: c(0.18), borderRadius: 2 }} />
-                                </div>
-                                <div style={{ display: 'flex', gap: 6 }}>
-                                    {[28, 28, 28, 28, 28].map((w, j) => (
-                                        <div key={j} className='op-pulse' style={{ width: w, height: 24, background: 'rgba(255,255,255,0.04)', borderRadius: 2 }} />
-                                    ))}
-                                </div>
-                            </div>
-                            <div style={{ padding: '20px 24px', display: 'flex', flexDirection: 'column', gap: 11 }}>
-                                {[88, 72, 80, 52].map((w, j) => (
-                                    <div key={j} className='op-pulse' style={{ height: 8, width: `${w}%`, background: 'rgba(237,237,237,0.055)', borderRadius: 2, animationDelay: `${j * 0.12}s` }} />
-                                ))}
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            )}
-
-            </div>{/* end edit column */}
-        </div>
-            </EditorShell>
+                        metaHandleRef={metaHandleRef}
+                        onSaveStatusChange={setSaveStatus}
+                        onProviderReady={setProvider}
+                    />
+                }
+                map={
+                    <MapTab operationId={opID} canEdit={isHQ} world={resolvedMapWorld} />
+                }
+                development={
+                    opID ? (
+                        <DevelopmentTab
+                            opID={opID}
+                            isJ2Lead={isJ2Lead}
+                            title={title}
+                            date={date}
+                            isCampaignOp={isCampaignOp}
+                            campaignStartDate={campaignStartDate}
+                            missionDev={missionDev}
+                            setMissionDev={setMissionDev}
+                            ordersCheckTask={ordersCheckTask}
+                            setOrdersCheckTask={setOrdersCheckTask}
+                        />
+                    ) : null
+                }
+                attendance={
+                    isHQ && opID ? (
+                        <AttendanceTab
+                            opID={opID}
+                            status={status}
+                            discordPingEnabled={discordPingEnabled}
+                            discordPingRoles={discordPingRoles}
+                            onChangeDiscordPingRoles={handleChangeDiscordPingRoles}
+                            ackCount={ackCount}
+                            ackList={ackList}
+                        />
+                    ) : null
+                }
+                contentPaddingRight={previewOpen ? 'clamp(360px, 40vw, 700px)' : activityOpen ? 'clamp(280px, 30vw, 460px)' : 0}
+            />
 
             {/* Activity log drawer — fixed overlay from right */}
             {opID && (

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -17,6 +17,7 @@ import StatusBar from './StatusBar'
 import { useOperationStatus } from './hooks/useOperationStatus'
 import MissionDeck from './deck/MissionDeck'
 import CountdownStrip from './deck/CountdownStrip'
+import ScheduleCard from './deck/ScheduleCard'
 const OperationEditor = dynamic(() => import('@/components/editor/CollabEditor'), { ssr: false })
 
 interface MetaFields { title: string; department: string; date: string; loreDate: string }
@@ -115,7 +116,8 @@ export default function Page() {
     const [tab, setTab] = useEditorTab()
 
     // Mission deck (Task 8) — days-until-op countdown for the deck's strip.
-    const { daysUntil } = useOperationStatus(opID)
+    // Task 9 also consumes the timeline it builds, for the Timeline card.
+    const { timeline, daysUntil } = useOperationStatus(opID)
 
     // Mission Development
     const [missionDev, setMissionDev] = useState<MissionDevelopment | null>(null)
@@ -168,15 +170,7 @@ export default function Page() {
     const [attendanceSaving, setAttendanceSaving] = useState(false)
     const [tickNow, setTickNow] = useState(() => new Date())
 
-    // Draft state for the schedule panel — only committed on "Confirm Schedule"
-    const [draftDate, setDraftDate] = useState<Dayjs | null>(null)
-    const [draftRsvpOpenAt, setDraftRsvpOpenAt] = useState<string | null>(null)
-    const [draftRsvpCloseOffsetMins, setDraftRsvpCloseOffsetMins] = useState(90)
-    const [draftRsvpCloseMode, setDraftRsvpCloseMode] = useState<'preset' | 'custom'>('preset')
-    const [draftRsvpCloseAt, setDraftRsvpCloseAt] = useState<string | null>(null)
-    const [scheduleSaving, setScheduleSaving] = useState(false)
     const [attendanceOpen, setAttendanceOpen] = useState(true)
-    const [scheduleOpen, setScheduleOpen] = useState(true)
 
     const [attStage, setAttStage] = useState<AttendanceStage>('preparing')
     const [confirmStage, setConfirmStage] = useState<AttendanceStage | null>(null)
@@ -299,7 +293,6 @@ export default function Page() {
                 setTitle(op.title || '')
                 const opDate = op.date ? dayjs(op.date) : null
                 setDate(opDate)
-                setDraftDate(opDate)
                 const loreDateStr = op.loreDate instanceof Date ? op.loreDate.toISOString() : (op.loreDate ?? '')
                 setLoreDate(loreDateStr)
                 const parsed = loreDateStr ? dayjs(loreDateStr) : null
@@ -365,8 +358,6 @@ export default function Page() {
                 const openAt = json.rsvpOpenAt ? new Date(json.rsvpOpenAt).toISOString() : null
                 setRsvpOpenAt(openAt)
                 setRsvpCloseOffsetMins(json.rsvpCloseOffsetMins ?? 90)
-                setDraftRsvpOpenAt(openAt)
-                setDraftRsvpCloseOffsetMins(json.rsvpCloseOffsetMins ?? 90)
                 setAttStage(json.stage ?? 'preparing')
                 // If RSVP is already open when we load, mark the auto-open as already fired
                 // so the close→re-open bounce can't happen.
@@ -472,25 +463,35 @@ export default function Page() {
         }
     }
 
-    async function confirmSchedule() {
-        setScheduleSaving(true)
-        try {
-            // Save operation date if changed
-            if (draftDate && draftDate.toISOString() !== date?.toISOString()) {
-                metaHandleRef.current?.set('date', draftDate.toISOString())
-                await fetch(`/api/operations/update?id=${opID}&date=${encodeURIComponent(draftDate.toISOString())}`)
-                setDate(draftDate)
-            }
-            // Save automation settings if changed
-            const attUpdates: Parameters<typeof saveAttendanceSettings>[0] = {}
-            if (draftRsvpOpenAt !== rsvpOpenAt) attUpdates.rsvpOpenAt = draftRsvpOpenAt
-            if (draftRsvpCloseOffsetMins !== rsvpCloseOffsetMins) attUpdates.rsvpCloseOffsetMins = draftRsvpCloseOffsetMins
-            if (Object.keys(attUpdates).length > 0) await saveAttendanceSettings(attUpdates)
-            setRsvpOpenAt(draftRsvpOpenAt)
-            setRsvpCloseOffsetMins(draftRsvpCloseOffsetMins)
-        } finally {
-            setScheduleSaving(false)
+    // Timeline card handlers (Task 9) — replace the old Schedule & Automation
+    // panel's draft-then-"Confirm Schedule" flow with direct-acting controls,
+    // one per row. Same two save paths as before: the operation date goes
+    // through /api/operations/update (and the Y.doc meta handle, like every
+    // other metaSave field); the RSVP fields go through saveAttendanceSettings.
+    async function handleChangeDate(v: Dayjs | null) {
+        if (!v) return
+        metaHandleRef.current?.set('date', v.toISOString())
+        setDate(v)
+        await fetch(`/api/operations/update?id=${opID}&date=${encodeURIComponent(v.toISOString())}`)
+    }
+
+    function handleChangeRsvpMode() {
+        if (rsvpOpenAt) {
+            setRsvpOpenAt(null)
+            saveAttendanceSettings({ rsvpOpenAt: null })
+            return
         }
+        // Turning manual → scheduled needs an operation date to default from,
+        // same as the old "Scheduled" pill (see git history for the panel it replaced).
+        if (!date) return
+        const openAt = new Date(date.toDate().getTime() - 3 * 24 * 3600000).toISOString()
+        setRsvpOpenAt(openAt)
+        saveAttendanceSettings({ rsvpOpenAt: openAt })
+    }
+
+    function handleChangeCloseOffset(mins: number) {
+        setRsvpCloseOffsetMins(mins)
+        saveAttendanceSettings({ rsvpCloseOffsetMins: mins })
     }
 
     async function applyStage(newStage: AttendanceStage) {
@@ -650,8 +651,17 @@ export default function Page() {
                     <MissionDeck
                         strip={<CountdownStrip daysUntil={daysUntil} checksDone={checksDone} checksTotal={checksTotal} />}
                     >
-                        {/* Later tasks add deck cards here. */}
-                        {null}
+                        {isHQ && opID && (
+                            <ScheduleCard
+                                timeline={timeline}
+                                date={date}
+                                onChangeDate={handleChangeDate}
+                                onChangeRsvpMode={handleChangeRsvpMode}
+                                closeOffsetMins={rsvpCloseOffsetMins}
+                                onChangeCloseOffset={handleChangeCloseOffset}
+                            />
+                        )}
+                        {/* Later tasks add more deck cards here. */}
                     </MissionDeck>
                 }
             >
@@ -1424,312 +1434,6 @@ export default function Page() {
                     </div>
                 </div>
             </div>
-
-            {/* Schedule & Automation panel — HQ only */}
-            {isHQ && opID && (() => {
-                function fmtCountdown(target: Date): string | null {
-                    const diffMs = target.getTime() - tickNow.getTime()
-                    if (diffMs <= 0) return null
-                    const s = Math.floor(diffMs / 1000) % 60
-                    const m = Math.floor(diffMs / 60000) % 60
-                    const h = Math.floor(diffMs / 3600000) % 24
-                    const d = Math.floor(diffMs / 86400000)
-                    if (d > 0) return `${d}d ${h}h ${m}m`
-                    if (h > 0) return `${h}h ${m}m ${s}s`
-                    return `${m}m ${s}s`
-                }
-
-                const inDev = status === 'In Development'
-                const opDate        = draftDate?.toDate() ?? null
-                // inDev only suppresses cron/triggers — editing is always allowed
-                const rsvpCloseDate = opDate ? new Date(opDate.getTime() - draftRsvpCloseOffsetMins * 60000) : null
-                const confirmCloseDate = confirmationOpenedAt ? new Date(confirmationOpenedAt.getTime() + 24 * 3600000) : null
-
-                const scheduleDirty = (
-                    draftDate?.toISOString() !== date?.toISOString() ||
-                    draftRsvpOpenAt !== rsvpOpenAt ||
-                    draftRsvpCloseOffsetMins !== rsvpCloseOffsetMins
-                )
-
-                const RELATIVE_OPTS = [
-                    { label: '1 day before',   mins: 1440 },
-                    { label: '3 days before',  mins: 4320 },
-                    { label: '1 week before',  mins: 10080 },
-                    { label: '2 weeks before', mins: 20160 },
-                ]
-
-                const CLOSE_OPTS = [
-                    { label: '30 min before',   mins: 30 },
-                    { label: '1 hour before',   mins: 60 },
-                    { label: '1.5 hours before', mins: 90 },
-                    { label: '2 hours before',  mins: 120 },
-                    { label: '3 hours before',  mins: 180 },
-                    { label: '6 hours before',  mins: 360 },
-                    { label: '12 hours before', mins: 720 },
-                    { label: '1 day before',    mins: 1440 },
-                ]
-
-                const inputSx: React.CSSProperties = {
-                    background: 'rgba(0,0,0,0.35)',
-                    border: '1px solid rgba(255,255,255,0.1)',
-                    color: 'rgba(237,237,237,0.75)',
-                    fontSize: '0.78rem',
-                    letterSpacing: '0.04em',
-                    outline: 'none',
-                    padding: '6px 10px',
-                    cursor: 'pointer',
-                    width: '100%',
-                }
-
-                const isPreset = CLOSE_OPTS.some(o => o.mins === draftRsvpCloseOffsetMins)
-                const effectiveCloseMode = draftRsvpCloseMode === 'custom' || !isPreset ? 'custom' : 'preset'
-
-                return (
-                    <div style={{
-                        ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${c(0.5)}`),
-                        background: 'rgba(255,255,255,0.01)',
-                        marginBottom: 20,
-                    }}>
-                        <button type='button' onClick={() => setScheduleOpen(v => !v)}
-                            className='flex items-center justify-between px-4 py-3'
-                            style={sectionToggleStyle(scheduleOpen)}
-                        >
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                                <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.3)' }}>
-                                    Schedule &amp; Automation
-                                </span>
-                                {inDev && (
-                                    <span style={{ fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(237,160,0,0.7)', border: '1px solid rgba(237,160,0,0.3)', padding: '2px 8px' }}>
-                                        Automation paused — In Development
-                                    </span>
-                                )}
-                            </div>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                                {scheduleSaving && (
-                                    <span style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(219,0,29,0.65)' }}>Saving…</span>
-                                )}
-                                <span style={{ fontSize: '0.65rem', color: 'rgba(237,237,237,0.25)', fontFamily: 'monospace' }}>{scheduleOpen ? '[−]' : '[+]'}</span>
-                            </div>
-                        </button>
-
-                        {scheduleOpen && <div className='flex flex-wrap gap-6 p-4'>
-                            {/* ── Settings column ── */}
-                            <div style={{ flex: '1 1 260px', display: 'flex', flexDirection: 'column', gap: 20 }}>
-
-                                {/* Operation Date */}
-                                <div>
-                                    <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: c(0.6), marginBottom: 10, fontFamily: 'monospace' }}>
-                                        {'// OPERATION DATE'}
-                                    </div>
-                                    <LocalizationProvider dateAdapter={AdapterDayjs}>
-                                        <DateTimePicker
-                                            label='Operation Date'
-                                            value={draftDate}
-                                            format='DD/MM/YYYY HH:mm'
-                                            onChange={v => setDraftDate(v)}
-                                            slotProps={{ textField: { size: 'small', sx: { width: '100%' } } }}
-                                        />
-                                    </LocalizationProvider>
-                                </div>
-
-                                {/* RSVP Open */}
-                                <div>
-                                    <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: c(0.6), marginBottom: 10, fontFamily: 'monospace' }}>
-                                        {'// RSVP OPEN'}
-                                    </div>
-                                    <div style={{ display: 'flex', gap: 6, marginBottom: 10 }}>
-                                        <button
-                                            onClick={() => setDraftRsvpOpenAt(null)}
-                                            style={{
-                                                padding: '5px 14px', borderRadius: 999,
-                                                border: '1px solid rgba(219,0,29,0.25)',
-                                                background: !draftRsvpOpenAt ? 'rgba(219,0,29,0.3)' : 'rgba(255,255,255,0.05)',
-                                                color: !draftRsvpOpenAt ? 'rgba(237,237,237,0.9)' : 'rgba(237,237,237,0.45)',
-                                                fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.12em',
-                                                textTransform: 'uppercase', cursor: 'pointer',
-                                            }}
-                                        >Manual</button>
-                                        <button
-                                            onClick={() => {
-                                                if (!draftRsvpOpenAt && draftDate) {
-                                                    setDraftRsvpOpenAt(new Date(draftDate.toDate().getTime() - 3 * 24 * 3600000).toISOString())
-                                                }
-                                            }}
-                                            style={{
-                                                padding: '5px 14px', borderRadius: 999,
-                                                border: '1px solid rgba(219,0,29,0.25)',
-                                                background: draftRsvpOpenAt ? 'rgba(219,0,29,0.3)' : 'rgba(255,255,255,0.05)',
-                                                color: draftRsvpOpenAt ? 'rgba(237,237,237,0.9)' : 'rgba(237,237,237,0.45)',
-                                                fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.12em',
-                                                textTransform: 'uppercase', cursor: 'pointer',
-                                            }}
-                                        >Scheduled</button>
-                                    </div>
-
-                                    {draftRsvpOpenAt && (
-                                        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                                            <LocalizationProvider dateAdapter={AdapterDayjs}>
-                                                <DateTimePicker
-                                                    label='RSVP Opens At'
-                                                    value={dayjs(draftRsvpOpenAt)}
-                                                    format='DD/MM/YYYY HH:mm'
-                                                    onChange={v => { if (v) setDraftRsvpOpenAt(v.toISOString()) }}
-                                                    slotProps={{ textField: { size: 'small', sx: { width: '100%' } } }}
-                                                />
-                                            </LocalizationProvider>
-                                            <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.3)', marginTop: 2 }}>
-                                                Quick set
-                                            </div>
-                                            <select
-                                                defaultValue=''
-                                                onChange={e => {
-                                                    const mins = parseInt(e.target.value)
-                                                    if (!mins || !draftDate) return
-                                                    setDraftRsvpOpenAt(new Date(draftDate.toDate().getTime() - mins * 60000).toISOString())
-                                                    e.target.value = ''
-                                                }}
-                                                style={inputSx}
-                                            >
-                                                <option value='' disabled>Relative to op date…</option>
-                                                {RELATIVE_OPTS.map(o => (
-                                                    <option key={o.mins} value={o.mins}>{o.label}</option>
-                                                ))}
-                                            </select>
-                                        </div>
-                                    )}
-                                </div>
-
-                                {/* RSVP Close */}
-                                <div>
-                                    <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: c(0.6), marginBottom: 10, fontFamily: 'monospace' }}>
-                                        {'// RSVP CLOSE'}
-                                    </div>
-                                    <select
-                                        value={effectiveCloseMode === 'custom' ? 'custom' : draftRsvpCloseOffsetMins}
-                                        onChange={e => {
-                                            if (e.target.value === 'custom') {
-                                                setDraftRsvpCloseMode('custom')
-                                                if (!draftRsvpCloseAt && draftDate) {
-                                                    setDraftRsvpCloseAt(new Date(draftDate.toDate().getTime() - draftRsvpCloseOffsetMins * 60000).toISOString())
-                                                }
-                                            } else {
-                                                setDraftRsvpCloseMode('preset')
-                                                setDraftRsvpCloseAt(null)
-                                                setDraftRsvpCloseOffsetMins(parseInt(e.target.value))
-                                            }
-                                        }}
-                                        style={inputSx}
-                                    >
-                                        {CLOSE_OPTS.map(o => (
-                                            <option key={o.mins} value={o.mins}>{o.label}</option>
-                                        ))}
-                                        <option value='custom'>Custom…</option>
-                                    </select>
-                                    {effectiveCloseMode === 'custom' && (
-                                        <div style={{ marginTop: 8 }}>
-                                            <LocalizationProvider dateAdapter={AdapterDayjs}>
-                                                <DateTimePicker
-                                                    label='RSVP Closes At'
-                                                    value={draftRsvpCloseAt ? dayjs(draftRsvpCloseAt) : null}
-                                                    format='DD/MM/YYYY HH:mm'
-                                                    onChange={v => {
-                                                        if (!v) return
-                                                        setDraftRsvpCloseAt(v.toISOString())
-                                                        if (draftDate) {
-                                                            const offsetMins = Math.round((draftDate.toDate().getTime() - v.toDate().getTime()) / 60000)
-                                                            setDraftRsvpCloseOffsetMins(Math.max(0, offsetMins))
-                                                        }
-                                                    }}
-                                                    slotProps={{ textField: { size: 'small', sx: { width: '100%' } } }}
-                                                />
-                                            </LocalizationProvider>
-                                            {!draftDate && (
-                                                <div style={{ fontSize: '0.6rem', color: 'rgba(237,160,0,0.7)', marginTop: 5 }}>
-                                                    Set an operation date first to compute offset.
-                                                </div>
-                                            )}
-                                        </div>
-                                    )}
-                                </div>
-
-                                {/* Confirm button */}
-                                <button
-                                    disabled={!scheduleDirty || scheduleSaving}
-                                    onClick={confirmSchedule}
-                                    style={{
-                                        padding: '9px 20px',
-                                        background: scheduleDirty ? c(0.18) : 'rgba(255,255,255,0.03)',
-                                        border: `1px solid ${scheduleDirty ? c(0.6) : 'rgba(255,255,255,0.1)'}`,
-                                        color: scheduleDirty ? c(0.9) : 'rgba(237,237,237,0.2)',
-                                        fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.14em',
-                                        textTransform: 'uppercase', cursor: scheduleDirty ? 'pointer' : 'not-allowed',
-                                        transition: 'all 0.15s', alignSelf: 'flex-start',
-                                    }}
-                                >
-                                    {scheduleSaving ? 'Saving…' : scheduleDirty ? '⬆ Confirm Schedule' : '✓ Schedule Confirmed'}
-                                </button>
-                            </div>
-
-                            {/* ── Status column ── */}
-                            <div style={{ flex: '1 1 200px', display: 'flex', flexDirection: 'column', gap: 0 }}>
-                                <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.25)', marginBottom: 14, fontFamily: 'monospace' }}>
-                                    {'// STATUS'}
-                                </div>
-                                {([
-                                    {
-                                        label: 'RSVP Opens',
-                                        color: rsvpOpen || ['rsvp_closed','op_running','confirmations_open','completed'].includes(displayStage) ? 'rgba(0,210,90,0.8)'
-                                            : rsvpOpenAt && !fmtCountdown(new Date(rsvpOpenAt)) ? 'rgba(219,160,0,0.9)'
-                                            : rsvpOpenAt ? 'rgba(219,160,0,0.8)'
-                                            : 'rgba(237,237,237,0.2)',
-                                        detail: rsvpOpen ? '✓ Open'
-                                            : ['rsvp_closed','op_running','confirmations_open','completed'].includes(displayStage) ? '✓ Opened'
-                                            : rsvpOpenAt ? (fmtCountdown(new Date(rsvpOpenAt)) ?? 'Pending cron…')
-                                            : 'Manual',
-                                    },
-                                    {
-                                        label: 'RSVP Closes',
-                                        color: !rsvpOpen && rsvpCloseDate && rsvpCloseDate <= tickNow ? 'rgba(0,210,90,0.8)'
-                                            : rsvpOpen && rsvpCloseDate ? 'rgba(219,160,0,0.8)'
-                                            : 'rgba(237,237,237,0.2)',
-                                        detail: !rsvpOpen && rsvpCloseDate && rsvpCloseDate <= tickNow ? '✓ Closed'
-                                            : rsvpCloseDate ? (fmtCountdown(rsvpCloseDate) ?? 'Firing…')
-                                            : '—',
-                                    },
-                                    {
-                                        label: 'Mission Active',
-                                        color: status === 'Active' || status === 'Completed' ? 'rgba(0,210,90,0.8)'
-                                            : opDate && fmtCountdown(opDate) ? 'rgba(219,160,0,0.8)'
-                                            : 'rgba(237,237,237,0.2)',
-                                        detail: status === 'Completed' ? '✓ Completed'
-                                            : status === 'Active' ? '✓ Active'
-                                            : opDate ? (fmtCountdown(opDate) ?? 'Firing…') : '—',
-                                    },
-                                    {
-                                        label: 'Confirmations',
-                                        color: confirmationOpen ? 'rgba(219,160,0,0.8)'
-                                            : confirmationOpenedAt && !confirmationOpen ? 'rgba(0,210,90,0.8)'
-                                            : status === 'Completed' ? 'rgba(219,160,0,0.6)'
-                                            : 'rgba(237,237,237,0.2)',
-                                        detail: confirmationOpen ? `Open · closes ${confirmCloseDate ? (fmtCountdown(confirmCloseDate) ?? 'soon') : '—'}`
-                                            : confirmationOpenedAt && !confirmationOpen ? '✓ Closed'
-                                            : status === 'Completed' ? 'Pending cron…'
-                                            : 'When mission ends',
-                                    },
-                                ].map((row, i) => (
-                                    <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '8px 0', borderBottom: i < 3 ? '1px solid rgba(255,255,255,0.04)' : 'none' }}>
-                                        <span style={{ display: 'inline-block', width: 6, height: 6, borderRadius: '50%', background: row.color, flexShrink: 0, marginTop: 4 }} />
-                                        <div>
-                                            <div style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.4)', marginBottom: 1 }}>{row.label}</div>
-                                            <div style={{ fontSize: '0.72rem', color: row.color, fontWeight: row.color.includes('160') ? 700 : 400, fontFamily: 'monospace', letterSpacing: '0.03em' }}>{row.detail}</div>
-                                        </div>
-                                    </div>
-                                )))}
-                            </div>
-                        </div>}
-                    </div>
-                )
-            })()}
 
             {/* Attendance settings — HQ only */}
             {isHQ && opID && (

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -176,6 +176,10 @@ export default function Page() {
     const [attStage, setAttStage] = useState<AttendanceStage>('preparing')
     const [confirmStage, setConfirmStage] = useState<AttendanceStage | null>(null)
     const [stageAdvancing, setStageAdvancing] = useState(false)
+    // StageCard's own confirm target — kept separate from confirmStage
+    // (the old Attendance Settings stepper's confirm state, untouched below)
+    // so the two flows don't share dialog state while both remain live.
+    const [stageCardConfirmTarget, setStageCardConfirmTarget] = useState<AttendanceStage | null>(null)
 
     const [confirmDelete, setConfirmDelete] = useState(false)
     const [previewOpen, setPreviewOpen] = useState(false)
@@ -582,13 +586,15 @@ export default function Page() {
         await saveAttendanceSettings(updates)
     }
 
-    // StageCard's single Advance button (Task 10) — reuses applyStage, the
+    // StageCard's write path (Task 10, extended) — reuses applyStage, the
     // same handler the Attendance Settings stepper's node clicks call, so it
     // saves through the exact same endpoint (POST .../attendance/platoons)
-    // and payload. Guards against a double-click firing two writes, and
-    // calls refresh() so the deck's timeline (and StatusBar) pick up the
+    // and payload regardless of whether the change came from the Advance
+    // button or a progress-segment click. Guards against a double-click (or
+    // a segment click while a write is already in flight) firing two writes,
+    // and calls refresh() so the deck's timeline (and StatusBar) pick up the
     // change immediately instead of waiting on the next 30s poll.
-    async function handleAdvanceStage(to: AttendanceStage) {
+    async function commitStageChange(to: AttendanceStage) {
         if (stageAdvancing) return
         setStageAdvancing(true)
         try {
@@ -597,6 +603,30 @@ export default function Page() {
         } finally {
             setStageAdvancing(false)
         }
+    }
+
+    // Same three stages the Attendance Settings stepper's own NEEDS_CONFIRM
+    // guards (~line 1712 below, in the untouched old stepper block) — going
+    // Active, opening attendance confirmation (billet points), and closing
+    // it. Duplicated here rather than shared so that block doesn't need
+    // touching; both flows write through the same applyStage/commitStageChange
+    // path regardless.
+    const STAGE_CARD_CONFIRM_MSGS: Partial<Record<AttendanceStage, string>> = {
+        op_running:          'Mark the operation as Active? This sets it to "Op Running".',
+        confirmations_open:  `End "${title || 'this mission'}"? This marks it Completed and opens attendance confirmation.`,
+        completed:            'Close attendance confirmation? Squad leaders will no longer be able to confirm.',
+    }
+
+    // Entry point for both StageCard controls (Advance button and segment
+    // clicks). Pauses for confirmation on the three impactful stages above;
+    // everything else commits immediately.
+    function requestStageChange(to: AttendanceStage) {
+        if (stageAdvancing) return
+        if (STAGE_CARD_CONFIRM_MSGS[to]) {
+            setStageCardConfirmTarget(to)
+            return
+        }
+        commitStageChange(to)
     }
 
     const PLATOON_OPTS = [
@@ -688,6 +718,19 @@ export default function Page() {
                 onCancel={() => setConfirmDelete(false)}
             />
 
+            {/* StageCard's confirm gate (Advance button + segment clicks) — same
+                three impactful stages, same messages, as the old Attendance
+                Settings stepper's own dialog further down. */}
+            <ConfirmDialog
+                open={stageCardConfirmTarget !== null}
+                title='Change Stage'
+                message={stageCardConfirmTarget ? (STAGE_CARD_CONFIRM_MSGS[stageCardConfirmTarget] ?? `Move to "${stageCardConfirmTarget}"?`) : ''}
+                confirmLabel='Confirm'
+                danger
+                onConfirm={() => { const s = stageCardConfirmTarget!; setStageCardConfirmTarget(null); commitStageChange(s) }}
+                onCancel={() => setStageCardConfirmTarget(null)}
+            />
+
             <EditorShell
                 operationId={opID}
                 themeColor={themeColor}
@@ -750,7 +793,8 @@ export default function Page() {
                         {isHQ && opID && (
                             <StageCard
                                 stage={displayStage}
-                                onAdvance={handleAdvanceStage}
+                                onAdvance={requestStageChange}
+                                onSelect={requestStageChange}
                                 advancing={stageAdvancing}
                             />
                         )}

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -1,11 +1,12 @@
 ﻿'use client'
 
-import { useState, useEffect, useRef, type CSSProperties } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import ConfirmDialog from '@/components/confirm-dialog'
 import dayjs, { Dayjs } from 'dayjs'
 import type { HocuspocusProvider } from '@hocuspocus/provider'
 import PERMISSIONS from '@/lib/permissions'
+import { hexToRgb } from '@/lib/colour'
 import ActivityLog from './activity-log'
 import FullscreenPage from '@/components/FullscreenPage'
 import EditorShell, { useEditorTab } from './EditorShell'
@@ -34,22 +35,6 @@ type AttendanceStage = 'preparing' | 'rsvp_open' | 'rsvp_closed' | 'op_running' 
 // under the shell's own chrome now that FullscreenPage has dropped the site
 // navbar this route used to sit under (that's where the old `top: 64` came from).
 const EDITOR_CHROME_HEIGHT = 84
-
-// Mixing the `border` shorthand with a per-side longhand (`borderTop`, `borderBottom`)
-// in one style object makes React warn whenever either value updates on rerender.
-// These build the all-longhand equivalent instead.
-const sideBorders = (all: string, top: string): CSSProperties =>
-    ({ borderTop: top, borderRight: all, borderBottom: all, borderLeft: all })
-
-function hexToRgb(hex: string) {
-    const h = hex.replace('#', '')
-    return {
-        r: parseInt(h.substring(0, 2), 16),
-        g: parseInt(h.substring(2, 4), 16),
-        b: parseInt(h.substring(4, 6), 16),
-    }
-}
-
 
 export default function Page() {
     const { id: routeId } = useParams<{ id: string }>()
@@ -722,12 +707,10 @@ export default function Page() {
         }
     }
 
-    // Same three stages the Attendance Settings stepper's own NEEDS_CONFIRM
-    // guards (~line 1712 below, in the untouched old stepper block) — going
-    // Active, opening attendance confirmation (billet points), and closing
-    // it. Duplicated here rather than shared so that block doesn't need
-    // touching; both flows write through the same applyStage/commitStageChange
-    // path regardless.
+    // Same three stages the old Attendance Settings stepper's own
+    // NEEDS_CONFIRM guards used to gate (that stepper is retired — Task 12)
+    // — going Active, opening attendance confirmation (billet points), and
+    // closing it.
     const STAGE_CARD_CONFIRM_MSGS: Partial<Record<AttendanceStage, string>> = {
         op_running:          'Mark the operation as Active? This sets it to "Op Running".',
         confirmations_open:  `End "${title || 'this mission'}"? This marks it Completed and opens attendance confirmation.`,
@@ -786,7 +769,10 @@ export default function Page() {
             {/* Spinner */}
             <div style={{
                 width: 36, height: 36,
-                ...sideBorders(`2px solid rgba(219,0,29,0.12)`, `2px solid rgba(219,0,29,0.75)`),
+                borderTop: '2px solid rgba(219,0,29,0.75)',
+                borderRight: '2px solid rgba(219,0,29,0.12)',
+                borderBottom: '2px solid rgba(219,0,29,0.12)',
+                borderLeft: '2px solid rgba(219,0,29,0.12)',
                 borderRadius: '50%',
                 animation: 'edit-spin 0.8s linear infinite',
             }} />

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -31,10 +31,12 @@ interface MetaFields { title: string; department: string; date: string; loreDate
 
 type AttendanceStage = 'preparing' | 'rsvp_open' | 'rsvp_closed' | 'op_running' | 'confirmations_open' | 'completed'
 
-// Header (48px) + tab bar (36px) from shell.module.css — the drawers below dock
-// under the shell's own chrome now that FullscreenPage has dropped the site
-// navbar this route used to sit under (that's where the old `top: 64` came from).
-const EDITOR_CHROME_HEIGHT = 84
+// Header row height (Header.tsx) — back crumb, title, status pill, section
+// tabs and the save/Publish/overflow cluster all in one merged row now, no
+// separate tab bar underneath. The drawers below dock under the shell's own
+// chrome now that FullscreenPage has dropped the site navbar this route used
+// to sit under (that's where the old `top: 64` came from).
+const EDITOR_CHROME_HEIGHT = 52
 
 export default function Page() {
     const { id: routeId } = useParams<{ id: string }>()
@@ -854,6 +856,8 @@ export default function Page() {
                         onPublishClick={() => setPublishConfirmOpen(true)}
                         onPublishConfirm={confirmPublish}
                         onPublishCancel={() => setPublishConfirmOpen(false)}
+                        tab={tab}
+                        onTabChange={setTab}
                     />
                 }
                 statusBar={

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -550,6 +550,21 @@ export default function Page() {
         await fetch(`/api/operations/update?id=${opID}&ownedBy=${encodeURIComponent(id)}&ownedByName=${encodeURIComponent(displayName)}`)
     }
 
+    // Complete Mission (Task 11, ruling 1) — restores the old panel's button,
+    // which called `applyStage('confirmations_open')` directly with no
+    // confirmation step. That call writes the operation's `status` (via
+    // `fetch('/api/operations/update?...status=Completed')` + `setStatus`)
+    // and, as the same side effect it always had, the attendance `stage` —
+    // two different fields on two different documents that happen to share
+    // the word "completed". Routed through commitStageChange rather than a
+    // bare applyStage call so it picks up the same double-click guard and
+    // refresh() every other stage-changing control already has; that's an
+    // additive safety net, not a behaviour change, since the underlying
+    // write is identical either way.
+    function handleCompleteMission() {
+        commitStageChange('confirmations_open')
+    }
+
     // AttendanceCard handlers (Task 11) — same saveAttendanceSettings path
     // (with its `?? current` sibling-field fallbacks) the old Attendance
     // Settings panel's platoon checkboxes and ping toggle already used.
@@ -919,6 +934,12 @@ export default function Page() {
                                 onMapWorldChange={handleMapWorldChange}
                                 loreDateDayjs={loreDateDayjs}
                                 onLoreDateChange={handleLoreDateChange}
+                                onCompleteMission={handleCompleteMission}
+                                completingMission={stageAdvancing}
+                                coverImage={coverImage}
+                                coverUploading={coverUploading}
+                                onUploadCover={uploadCover}
+                                onRemoveCover={removeCover}
                             />
                         )}
                         {isHQ && opID && (
@@ -1448,18 +1469,16 @@ export default function Page() {
                 )
             })()}
 
-            {/* Acknowledgements + cover photo — not rehomed into a deck card
-                (Task 11). Neither fits the DetailsCard row idiom:
-                acknowledgements is a count/expand/remind list, and Task 12's
-                brief already earmarks it for the future Attendance tab;
-                cover photo is an image plus upload/replace/remove, not a
-                single data row. Left mounted here, functionally unchanged
-                from the old "Operation Details" panel, pending a ruling on
-                their permanent home — see the task-11 report. Everything
-                else that panel held (title, owner, billet points,
-                department, status, theme colour, era, map, in-game date) now
-                lives in the deck's DetailsCard. */}
-            <div style={{ marginBottom: 20, display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {/* Acknowledgements — owned by Task 12, not this one. Its proper
+                home is the Attendance tab Task 12 builds; left mounted here,
+                functionally unchanged from the old "Operation Details" panel,
+                so it isn't lost in the meantime. Do not restyle, move, or
+                delete it as part of any other task — see task-11-report.md
+                for the ruling. Everything else that old panel held (title,
+                owner, billet points, department, status, theme colour, era,
+                map, in-game date, cover photo) now lives in the deck's
+                DetailsCard. */}
+            <div style={{ marginBottom: 20 }}>
                 {status === 'Upcoming' && (
                     <div style={{ ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${c(0.5)}`), background: 'rgba(255,255,255,0.01)', padding: '12px 16px' }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: ackExpanded ? 10 : 0 }}>
@@ -1492,34 +1511,6 @@ export default function Page() {
                         )}
                     </div>
                 )}
-
-                {/* Cover image */}
-                <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                    {coverImage ? (
-                        <>
-                            <div style={{ position: 'relative', width: 140, height: 52, flexShrink: 0, border: '1px solid rgba(255,255,255,0.1)', overflow: 'hidden' }}>
-                                <img src={coverImage} alt='cover' style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
-                            </div>
-                            <button
-                                onClick={removeCover}
-                                style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: c(0.6), background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
-                            >
-                                Remove Cover
-                            </button>
-                            <label style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.35)', cursor: 'pointer' }}>
-                                Replace
-                                <input type='file' accept='image/*' style={{ display: 'none' }} onChange={e => { const f = e.target.files?.[0]; if (f) uploadCover(f) }} />
-                            </label>
-                        </>
-                    ) : (
-                        <label style={{ display: 'flex', alignItems: 'center', gap: 8, border: '1px dashed rgba(255,255,255,0.12)', padding: '10px 18px', cursor: 'pointer' }}>
-                            <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: coverUploading ? 'rgba(237,237,237,0.3)' : 'rgba(237,237,237,0.4)' }}>
-                                {coverUploading ? 'Uploading…' : '+ Cover Photo'}
-                            </span>
-                            <input type='file' accept='image/*' style={{ display: 'none' }} disabled={coverUploading} onChange={e => { const f = e.target.files?.[0]; if (f) uploadCover(f) }} />
-                        </label>
-                    )}
-                </div>
             </div>
 
             {/* Attendance settings — HQ only */}

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect, useRef, type CSSProperties } from 'react'
-import Link from 'next/link'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import ConfirmDialog from '@/components/confirm-dialog'
 import dayjs, { Dayjs } from 'dayjs'
@@ -11,6 +10,9 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import dynamic from 'next/dynamic'
 import PERMISSIONS from '@/lib/permissions'
 import ActivityLog from './activity-log'
+import EditorShell, { useEditorTab } from './EditorShell'
+import Header from './Header'
+import StatusBar from './StatusBar'
 const OperationEditor = dynamic(() => import('@/components/editor/CollabEditor'), { ssr: false })
 
 interface MetaFields { title: string; department: string; date: string; loreDate: string }
@@ -98,6 +100,10 @@ export default function Page() {
     const [initialContent, setInitialContent] = useState<any>(undefined)
     const [loaded, setLoaded] = useState(false)
     const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
+    // Timestamp of the last successful scheduleSave — status-bar display only,
+    // does not participate in the save path itself (see scheduleSave below).
+    const [savedAt, setSavedAt] = useState<Date | null>(null)
+    const [tab, setTab] = useEditorTab()
 
     // Mission Development
     const [missionDev, setMissionDev] = useState<MissionDevelopment | null>(null)
@@ -366,6 +372,7 @@ export default function Page() {
             try {
                 await fetch(`/api/operations/update?id=${opID}&${qs}`)
                 setSaveStatus('saved')
+                setSavedAt(new Date())
             } catch {
                 setSaveStatus('unsaved')
             }
@@ -397,6 +404,24 @@ export default function Page() {
     async function removeCover() {
         setCoverImage(null)
         await fetch(`/api/operations/update?id=${opID}&coverImage=`)
+    }
+
+    // Publish flow — lifted unchanged from the old inline header buttons; only
+    // the JSX moved (into Header.tsx), the fetch/state logic did not.
+    async function confirmPublish() {
+        setPublishSaving(true)
+        try {
+            const res = await fetch(`/api/operations/${opID}/publish`, { method: 'POST' })
+            if (res.ok) {
+                setStatus('Upcoming')
+                setPublishConfirmOpen(false)
+            } else {
+                const d = await res.json()
+                alert(d.error ?? 'Publish failed')
+            }
+        } finally {
+            setPublishSaving(false)
+        }
     }
 
     async function saveAttendanceSettings(updates: {
@@ -512,9 +537,6 @@ export default function Page() {
     }
     const currentStatusColor = STATUS_COLORS[status] || 'rgba(237,237,237,0.5)'
 
-    const statusColor = saveStatus === 'saved' ? 'rgba(100,220,100,0.65)' : saveStatus === 'saving' ? 'rgba(219,0,29,0.65)' : 'rgba(237,200,0,0.65)'
-    const statusLabel = saveStatus === 'saved' ? '● Saved' : saveStatus === 'saving' ? '● Saving…' : '● Unsaved'
-
     if (!loaded) return (
         <div style={{
             display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
@@ -542,6 +564,54 @@ export default function Page() {
     )
 
     return (
+        <>
+            <ConfirmDialog
+                open={confirmDelete}
+                title='Delete Mission'
+                message={`"${title || 'This mission'}" will be permanently deleted. This cannot be undone.`}
+                confirmLabel='Delete'
+                danger
+                onConfirm={handleDelete}
+                onCancel={() => setConfirmDelete(false)}
+            />
+
+            <EditorShell
+                operationId={opID}
+                themeColor={themeColor}
+                isHQ={isHQ}
+                tab={tab}
+                onTabChange={setTab}
+                header={
+                    <Header
+                        operationId={opID}
+                        fromJ2={fromJ2}
+                        title={title}
+                        status={status}
+                        saveStatus={saveStatus}
+                        isHQ={isHQ}
+                        onDelete={() => setConfirmDelete(true)}
+                        activityOpen={activityOpen}
+                        onToggleActivity={() => setActivityOpen(o => !o)}
+                        onOpenPreview={() => window.open(`/operations/${opID}`, '_blank')}
+                        publishConfirmOpen={publishConfirmOpen}
+                        publishSaving={publishSaving}
+                        onPublishClick={() => setPublishConfirmOpen(true)}
+                        onPublishConfirm={confirmPublish}
+                        onPublishCancel={() => setPublishConfirmOpen(false)}
+                    />
+                }
+                statusBar={
+                    <StatusBar
+                        connected={true}
+                        activeDocTitle={title || 'Untitled'}
+                        words={0}
+                        sections={0}
+                        savedAt={savedAt}
+                        editorCount={1}
+                        department={department}
+                    />
+                }
+            >
         <div className='w-full' style={{
             paddingRight: previewOpen ? 'clamp(360px, 40vw, 700px)' : activityOpen ? 'clamp(280px, 30vw, 460px)' : 0,
             transition: 'padding-right 0.25s ease',
@@ -555,163 +625,6 @@ export default function Page() {
                 flexShrink: 0,
                 padding: 'clamp(1.5rem, 2.5vw, 2.5rem)',
             }}>
-
-            <ConfirmDialog
-                open={confirmDelete}
-                title='Delete Mission'
-                message={`"${title || 'This mission'}" will be permanently deleted. This cannot be undone.`}
-                confirmLabel='Delete'
-                danger
-                onConfirm={handleDelete}
-                onCancel={() => setConfirmDelete(false)}
-            />
-
-            {/* Page header */}
-            <div className='flex items-center justify-between gap-4' style={{ marginBottom: 20 }}>
-                <div className='flex items-center gap-4'>
-                    <Link
-                        href={fromJ2 ? '/dashboard/j2' : '/operations'}
-                        style={{ fontSize: '0.68rem', fontWeight: 600, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.35)', textDecoration: 'none' }}
-                    >
-                        {fromJ2 ? '← J2 Operations' : '← Back'}
-                    </Link>
-                    <div style={{ width: 1, height: 14, background: 'rgba(255,255,255,0.1)' }} />
-                    <span style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.2)' }}>
-                        Mission Edit
-                    </span>
-                    {opID && (
-                        <>
-                            <div style={{ width: 1, height: 14, background: 'rgba(255,255,255,0.1)' }} />
-                            <Link
-                                href={`/operations/${opID}`}
-                                style={{ fontSize: '0.68rem', fontWeight: 600, letterSpacing: '0.14em', textTransform: 'uppercase', color: c(0.55), textDecoration: 'none' }}
-                            >
-                                View →
-                            </Link>
-                        </>
-                    )}
-                    {opID && (
-                        <>
-                            <div style={{ width: 1, height: 14, background: 'rgba(255,255,255,0.1)' }} />
-                            <Link
-                                href={`/operations/${opID}/map`}
-                                style={{
-                                    background: 'none',
-                                    padding: '2px 0',
-                                    fontSize: '0.68rem',
-                                    fontWeight: 700,
-                                    letterSpacing: '0.14em',
-                                    textTransform: 'uppercase',
-                                    color: 'rgba(237,237,237,0.3)',
-                                    textDecoration: 'none',
-                                    ...bottomBorder('2px solid transparent'),
-                                }}
-                            >
-                                Map ↗
-                            </Link>
-                        </>
-                    )}
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-                    <span style={{ fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: statusColor }}>
-                        {statusLabel}
-                    </span>
-                    {/* Publish button — visible when In Development */}
-                    {opID && isHQ && status === 'In Development' && (
-                        publishConfirmOpen ? (
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 10px', background: 'rgba(0,200,80,0.07)', border: '1px solid rgba(0,200,80,0.3)', borderRadius: 2 }}>
-                                <span style={{ fontSize: '0.6rem', color: 'rgba(0,200,80,0.75)', fontWeight: 700, letterSpacing: '0.1em' }}>Publish "{title || 'this op'}"?</span>
-                                <button type='button' disabled={publishSaving} onClick={async () => {
-                                    setPublishSaving(true)
-                                    try {
-                                        const res = await fetch(`/api/operations/${opID}/publish`, { method: 'POST' })
-                                        if (res.ok) {
-                                            setStatus('Upcoming')
-                                            setPublishConfirmOpen(false)
-                                        } else {
-                                            const d = await res.json()
-                                            alert(d.error ?? 'Publish failed')
-                                        }
-                                    } finally {
-                                        setPublishSaving(false)
-                                    }
-                                }}
-                                    style={{ padding: '4px 10px', fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', background: 'rgba(0,200,80,0.2)', border: '1px solid rgba(0,200,80,0.5)', color: 'rgba(0,200,80,0.95)', cursor: 'pointer' }}
-                                >{publishSaving ? 'Publishing…' : '✓ Confirm'}</button>
-                                <button type='button' onClick={() => setPublishConfirmOpen(false)}
-                                    style={{ padding: '4px 8px', fontSize: '0.6rem', fontWeight: 700, background: 'none', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.4)', cursor: 'pointer' }}
-                                >Cancel</button>
-                            </div>
-                        ) : (
-                            <button type='button' onClick={() => setPublishConfirmOpen(true)}
-                                style={{
-                                    padding: '6px 14px',
-                                    background: 'rgba(0,200,80,0.08)',
-                                    border: '1px solid rgba(0,200,80,0.35)',
-                                    color: 'rgba(0,200,80,0.75)',
-                                    fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
-                                    cursor: 'pointer', transition: 'all 0.15s',
-                                }}
-                                onMouseEnter={e => { const el = e.currentTarget; el.style.background = 'rgba(0,200,80,0.18)'; el.style.color = 'rgba(0,200,80,1)'; el.style.borderColor = 'rgba(0,200,80,0.65)' }}
-                                onMouseLeave={e => { const el = e.currentTarget; el.style.background = 'rgba(0,200,80,0.08)'; el.style.color = 'rgba(0,200,80,0.75)'; el.style.borderColor = 'rgba(0,200,80,0.35)' }}
-                            >
-                                ↑ Publish Operation
-                            </button>
-                        )
-                    )}
-                    {opID && (
-                        <button
-                            onClick={() => setConfirmDelete(true)}
-                            style={{
-                                padding: '6px 14px',
-                                background: 'rgba(219,0,29,0.06)',
-                                border: '1px solid rgba(219,0,29,0.3)',
-                                color: 'rgba(219,0,29,0.65)',
-                                fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
-                                cursor: 'pointer', transition: 'background 0.15s, color 0.15s, border-color 0.15s',
-                            }}
-                            onMouseEnter={e => { const el = e.currentTarget; el.style.background = 'rgba(219,0,29,0.14)'; el.style.color = 'rgba(219,0,29,1)'; el.style.borderColor = 'rgba(219,0,29,0.6)' }}
-                            onMouseLeave={e => { const el = e.currentTarget; el.style.background = 'rgba(219,0,29,0.06)'; el.style.color = 'rgba(219,0,29,0.65)'; el.style.borderColor = 'rgba(219,0,29,0.3)' }}
-                        >
-                            Delete Mission
-                        </button>
-                    )}
-                    {opID && (
-                        <button
-                            className='hidden md:block'
-                            onClick={() => setActivityOpen(o => !o)}
-                            style={{
-                                padding: '6px 14px',
-                                background: activityOpen ? 'rgba(237,237,237,0.07)' : 'rgba(237,237,237,0.03)',
-                                border: `1px solid ${activityOpen ? 'rgba(237,237,237,0.25)' : 'rgba(255,255,255,0.1)'}`,
-                                color: activityOpen ? 'rgba(237,237,237,0.8)' : 'rgba(237,237,237,0.35)',
-                                fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
-                                cursor: 'pointer', transition: 'all 0.15s',
-                            }}
-                        >
-                            Activity
-                        </button>
-                    )}
-                    {opID && (
-                        <button
-                            className='hidden md:block'
-                            onClick={() => window.open(`/operations/${opID}`, '_blank')}
-                            style={{
-                                padding: '6px 14px',
-                                background: 'rgba(237,237,237,0.03)',
-                                border: '1px solid rgba(255,255,255,0.1)',
-                                color: 'rgba(237,237,237,0.35)',
-                                fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
-                                cursor: 'pointer', transition: 'all 0.15s',
-                            }}
-                            onMouseEnter={e => { e.currentTarget.style.color = 'rgba(237,237,237,0.75)'; e.currentTarget.style.borderColor = 'rgba(255,255,255,0.2)' }}
-                            onMouseLeave={e => { e.currentTarget.style.color = 'rgba(237,237,237,0.35)'; e.currentTarget.style.borderColor = 'rgba(255,255,255,0.1)' }}
-                        >
-                            ⊡ Preview
-                        </button>
-                    )}
-                </div>
-            </div>
 
             {/* Mission Development */}
             {opID && (() => {
@@ -2176,6 +2089,8 @@ export default function Page() {
             )}
 
             </div>{/* end edit column */}
+        </div>
+            </EditorShell>
 
             {/* Activity log drawer — fixed overlay from right */}
             {opID && (
@@ -2261,8 +2176,7 @@ export default function Page() {
                     />
                 </div>
             )}
-
-        </div>
+        </>
     )
 }
 

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -10,6 +10,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import dynamic from 'next/dynamic'
 import PERMISSIONS from '@/lib/permissions'
 import ActivityLog from './activity-log'
+import FullscreenPage from '@/components/FullscreenPage'
 import EditorShell, { useEditorTab } from './EditorShell'
 import Header from './Header'
 import StatusBar from './StatusBar'
@@ -45,6 +46,11 @@ const CHECK_CONTENT: Record<'campaign' | 'single', Record<string, string[]>> = {
         w4: ['Final development check completed', 'Arsenal and loadout updates confirmed'],
     },
 }
+
+// Header (48px) + tab bar (36px) from shell.module.css — the drawers below dock
+// under the shell's own chrome now that FullscreenPage has dropped the site
+// navbar this route used to sit under (that's where the old `top: 64` came from).
+const EDITOR_CHROME_HEIGHT = 84
 
 // Mixing the `border` shorthand with a per-side longhand (`borderTop`, `borderBottom`)
 // in one style object makes React warn whenever either value updates on rerender.
@@ -565,6 +571,11 @@ export default function Page() {
 
     return (
         <>
+            {/* Drops the global site navbar/footer (styles/globals.css:31-34) — same
+                pattern as /operations/[id]/map and /maps/[name]. The shell's own back
+                crumb replaces the site nav. */}
+            <FullscreenPage />
+
             <ConfirmDialog
                 open={confirmDelete}
                 title='Delete Mission'
@@ -602,7 +613,10 @@ export default function Page() {
                 }
                 statusBar={
                     <StatusBar
-                        connected={true}
+                        // null, not true — no Hocuspocus provider is reachable from this
+                        // page (CollabEditor doesn't expose it), so the socket state is
+                        // genuinely unmeasured here, not "known connected".
+                        connected={null}
                         activeDocTitle={title || 'Untitled'}
                         words={0}
                         sections={0}
@@ -2096,7 +2110,7 @@ export default function Page() {
             {opID && (
                 <div style={{
                     position: 'fixed',
-                    top: 64,
+                    top: EDITOR_CHROME_HEIGHT,
                     right: 0,
                     bottom: 0,
                     width: 'clamp(280px, 30vw, 460px)',
@@ -2115,7 +2129,7 @@ export default function Page() {
             {opID && (
                 <div style={{
                     position: 'fixed',
-                    top: 64,
+                    top: EDITOR_CHROME_HEIGHT,
                     right: 0,
                     bottom: 0,
                     width: 'clamp(360px, 40vw, 700px)',

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -475,21 +475,50 @@ export default function Page() {
         await fetch(`/api/operations/update?id=${opID}&date=${encodeURIComponent(v.toISOString())}`)
     }
 
-    function handleChangeRsvpMode() {
-        if (rsvpOpenAt) {
-            setRsvpOpenAt(null)
-            saveAttendanceSettings({ rsvpOpenAt: null })
-            return
-        }
-        // Turning manual → scheduled needs an operation date to default from,
-        // same as the old "Scheduled" pill (see git history for the panel it replaced).
-        if (!date) return
+    // "Manual" pill — matches the old panel's Manual button (always clears it).
+    function handleSetRsvpOpenManual() {
+        if (!rsvpOpenAt) return
+        setRsvpOpenAt(null)
+        saveAttendanceSettings({ rsvpOpenAt: null })
+    }
+
+    // "Scheduled" pill — matches the old panel's Scheduled button: only
+    // defaults (3 days before the op date) if nothing's set yet and there's
+    // an op date to default from; otherwise a no-op, same as before.
+    function handleSetRsvpOpenScheduled() {
+        if (rsvpOpenAt || !date) return
         const openAt = new Date(date.toDate().getTime() - 3 * 24 * 3600000).toISOString()
         setRsvpOpenAt(openAt)
         saveAttendanceSettings({ rsvpOpenAt: openAt })
     }
 
+    // Exact RSVP-open instant picked directly off the DateTimePicker.
+    function handleChangeRsvpOpenAt(v: Dayjs | null) {
+        if (!v) return
+        const iso = v.toISOString()
+        setRsvpOpenAt(iso)
+        saveAttendanceSettings({ rsvpOpenAt: iso })
+    }
+
+    // RSVP-open quick-set relative to the op date (1 day/3 days/1 week/2 weeks before).
+    function handleQuickSetRsvpOpen(mins: number) {
+        if (!date) return
+        const iso = new Date(date.toDate().getTime() - mins * 60000).toISOString()
+        setRsvpOpenAt(iso)
+        saveAttendanceSettings({ rsvpOpenAt: iso })
+    }
+
     function handleChangeCloseOffset(mins: number) {
+        setRsvpCloseOffsetMins(mins)
+        saveAttendanceSettings({ rsvpCloseOffsetMins: mins })
+    }
+
+    // Custom RSVP-close instant — same as the old panel's "Custom…" picker:
+    // it only ever persists as the derived minutes-before-op-date, and does
+    // nothing without an op date to derive that offset from.
+    function handleChangeRsvpCloseAt(v: Dayjs | null) {
+        if (!v || !date) return
+        const mins = Math.max(0, Math.round((date.toDate().getTime() - v.toDate().getTime()) / 60000))
         setRsvpCloseOffsetMins(mins)
         saveAttendanceSettings({ rsvpCloseOffsetMins: mins })
     }
@@ -656,9 +685,13 @@ export default function Page() {
                                 timeline={timeline}
                                 date={date}
                                 onChangeDate={handleChangeDate}
-                                onChangeRsvpMode={handleChangeRsvpMode}
+                                onSetRsvpOpenManual={handleSetRsvpOpenManual}
+                                onSetRsvpOpenScheduled={handleSetRsvpOpenScheduled}
+                                onChangeRsvpOpenAt={handleChangeRsvpOpenAt}
+                                onQuickSetRsvpOpen={handleQuickSetRsvpOpen}
                                 closeOffsetMins={rsvpCloseOffsetMins}
                                 onChangeCloseOffset={handleChangeCloseOffset}
+                                onChangeRsvpCloseAt={handleChangeRsvpCloseAt}
                             />
                         )}
                         {/* Later tasks add more deck cards here. */}

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -849,7 +849,6 @@ export default function Page() {
                         onDelete={() => setConfirmDelete(true)}
                         activityOpen={activityOpen}
                         onToggleActivity={() => setActivityOpen(o => !o)}
-                        onOpenPreview={() => window.open(`/operations/${opID}`, '_blank')}
                         publishConfirmOpen={publishConfirmOpen}
                         publishSaving={publishSaving}
                         onPublishClick={() => setPublishConfirmOpen(true)}

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -19,6 +19,8 @@ import MissionDeck from './deck/MissionDeck'
 import CountdownStrip from './deck/CountdownStrip'
 import ScheduleCard from './deck/ScheduleCard'
 import StageCard from './deck/StageCard'
+import DetailsCard from './deck/DetailsCard'
+import AttendanceCard from './deck/AttendanceCard'
 const OperationEditor = dynamic(() => import('@/components/editor/CollabEditor'), { ssr: false })
 
 interface MetaFields { title: string; department: string; date: string; loreDate: string }
@@ -474,6 +476,126 @@ export default function Page() {
         }
     }
 
+    // DetailsCard handlers (Task 11) — lifted verbatim out of the old
+    // "Operation Details" panel's inline onChange/onBlur closures. Same
+    // scheduleSave keys, same endpoints, same metaHandleRef mirroring; only
+    // the JSX moved.
+    function handleTitleChange(v: string) {
+        setTitle(v)
+        metaHandleRef.current?.set('title', v)
+        scheduleSave({ title: v })
+    }
+
+    function handleDepartmentChange(v: string) {
+        setDepartment(v)
+        metaHandleRef.current?.set('department', v)
+        scheduleSave({ department: v })
+    }
+
+    function handleStatusChange(v: string) {
+        setStatus(v)
+        scheduleSave({ status: v })
+    }
+
+    function handleThemeColorChange(v: string) {
+        setThemeColor(v)
+        scheduleSave({ themeColor: v })
+    }
+
+    function handlePageThemeChange(v: string) {
+        setPageTheme(v)
+        scheduleSave({ pageTheme: v })
+    }
+
+    function handleMapWorldChange(w: string) {
+        setMapWorld(w)
+        scheduleSave({ mapWorld: w })
+    }
+
+    function handleLoreDateChange(v: Dayjs | null) {
+        setLoreDateDayjs(v)
+        const str = v?.isValid() ? v.format('DD/MM/YYYY HH:mm') : ''
+        setLoreDate(str)
+        metaHandleRef.current?.set('loreDate', str)
+        scheduleSave({ loreDate: str })
+    }
+
+    function handleBilletPointsChange(v: number) {
+        setBilletPoints(v)
+    }
+
+    // billetPoints is read from render-time closure, same as the old inline
+    // onBlur handler — fine since this is recreated every render.
+    async function handleBilletPointsBlur() {
+        await fetch(`/api/operations/update?id=${opID}&billetPoints=${billetPoints}`)
+    }
+
+    async function handleOpenOwnerPicker() {
+        if (j2Members.length === 0) {
+            const res = await fetch('/api/admin/members?department=j2')
+            const data = await res.json()
+            setJ2Members((data.members ?? []).map((m: any) => ({ id: m.discordId ?? m._id, displayName: m.displayName ?? m.name ?? 'Unknown' })))
+        }
+        setOwnerPickerOpen(true)
+    }
+
+    function handleCloseOwnerPicker() {
+        setOwnerPickerOpen(false)
+    }
+
+    async function handleSelectOwner(id: string, displayName: string) {
+        setOwnedBy(id)
+        setOwnedByName(displayName)
+        setOwnerPickerOpen(false)
+        await fetch(`/api/operations/update?id=${opID}&ownedBy=${encodeURIComponent(id)}&ownedByName=${encodeURIComponent(displayName)}`)
+    }
+
+    // AttendanceCard handlers (Task 11) — same saveAttendanceSettings path
+    // (with its `?? current` sibling-field fallbacks) the old Attendance
+    // Settings panel's platoon checkboxes and ping toggle already used.
+    function handleTogglePlatoon(id: string) {
+        const updated = assignedPlatoons.includes(id)
+            ? assignedPlatoons.filter(p => p !== id)
+            : [...assignedPlatoons, id]
+        setAssignedPlatoons(updated)
+        saveAttendanceSettings({ assignedPlatoons: updated })
+    }
+
+    function handleTogglePing() {
+        const next = !discordPingEnabled
+        setDiscordPingEnabled(next)
+        saveAttendanceSettings({ discordPingEnabled: next })
+    }
+
+    // Custom-unit add/remove for AttendanceCard's "+ Custom Unit" chip — same
+    // endpoint the (untouched) Custom Attendance Units panel below uses, kept
+    // as separate functions rather than reusing that panel's inline handlers
+    // so this task doesn't touch code a later task owns.
+    async function addCustomUnit(name: string, color?: string) {
+        setCustomUnitsSaving(true)
+        try {
+            const res = await fetch(`/api/operations/${opID}/attendance/custom-units`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, color }),
+            })
+            const data = await res.json()
+            if (data.unit) setCustomUnits(prev => [...prev, data.unit])
+        } finally {
+            setCustomUnitsSaving(false)
+        }
+    }
+
+    async function removeCustomUnit(id: string) {
+        setCustomUnitsSaving(true)
+        try {
+            await fetch(`/api/operations/${opID}/attendance/custom-units?unitId=${id}`, { method: 'DELETE' })
+            setCustomUnits(prev => prev.filter(u => u.id !== id))
+        } finally {
+            setCustomUnitsSaving(false)
+        }
+    }
+
     // Timeline card handlers (Task 9, fixed up per review) — direct-acting
     // controls, one per row.
     //
@@ -652,14 +774,6 @@ export default function Page() {
         return attStage === 'rsvp_closed' ? 'rsvp_closed' : 'preparing'
     })()
 
-    const STATUS_COLORS: Record<string, string> = {
-        'Active':         'rgba(0,200,80,0.9)',
-        'Upcoming':       'rgba(219,160,0,0.9)',
-        'Completed':      'rgba(100,150,237,0.8)',
-        'In Development': 'rgba(219,0,29,0.75)',
-    }
-    const currentStatusColor = STATUS_COLORS[status] || 'rgba(237,237,237,0.5)'
-
     if (!loaded) return (
         <div style={{
             display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
@@ -774,6 +888,39 @@ export default function Page() {
                     <MissionDeck
                         strip={<CountdownStrip daysUntil={daysUntil} checksDone={checksDone} checksTotal={checksTotal} />}
                     >
+                        {opID && (
+                            <DetailsCard
+                                title={title}
+                                onTitleChange={handleTitleChange}
+                                ownedBy={ownedBy}
+                                ownedByName={ownedByName}
+                                canPickOwner={isJ2Lead || isJ4Admin}
+                                ownerPickerOpen={ownerPickerOpen}
+                                j2Members={j2Members}
+                                onOpenOwnerPicker={handleOpenOwnerPicker}
+                                onCloseOwnerPicker={handleCloseOwnerPicker}
+                                onSelectOwner={handleSelectOwner}
+                                canSeeBilletPoints={isJ2Lead || isJ4Admin}
+                                billetPoints={billetPoints}
+                                onBilletPointsChange={handleBilletPointsChange}
+                                onBilletPointsBlur={handleBilletPointsBlur}
+                                department={department}
+                                onDepartmentChange={handleDepartmentChange}
+                                status={status}
+                                isHQ={isHQ}
+                                onStatusChange={handleStatusChange}
+                                themeColor={themeColor}
+                                onThemeColorChange={handleThemeColorChange}
+                                pageTheme={pageTheme}
+                                eraOptions={eraOptions}
+                                onPageThemeChange={handlePageThemeChange}
+                                mapWorld={mapWorld}
+                                availableWorlds={availableWorlds}
+                                onMapWorldChange={handleMapWorldChange}
+                                loreDateDayjs={loreDateDayjs}
+                                onLoreDateChange={handleLoreDateChange}
+                            />
+                        )}
                         {isHQ && opID && (
                             <ScheduleCard
                                 timeline={timeline}
@@ -796,6 +943,20 @@ export default function Page() {
                                 onAdvance={requestStageChange}
                                 onSelect={requestStageChange}
                                 advancing={stageAdvancing}
+                            />
+                        )}
+                        {/* Gated by not rendering at all (spec §1) — not by disabling. */}
+                        {isHQ && opID && (
+                            <AttendanceCard
+                                platoons={PLATOON_OPTS}
+                                selected={assignedPlatoons}
+                                onToggle={handleTogglePlatoon}
+                                customUnits={customUnits}
+                                onAddCustomUnit={addCustomUnit}
+                                onRemoveCustomUnit={removeCustomUnit}
+                                customUnitsSaving={customUnitsSaving}
+                                pingEnabled={discordPingEnabled}
+                                onTogglePing={handleTogglePing}
                             />
                         )}
                         {/* Later tasks add more deck cards here. */}
@@ -1287,288 +1448,77 @@ export default function Page() {
                 )
             })()}
 
-            {/* Metadata card */}
-            <div style={{ ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${c(1)}`), background: 'rgba(255,255,255,0.01)', marginBottom: 20 }}>
-                <div className='flex items-center px-4 py-3' style={{ borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
-                    <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.3)' }}>
-                        Operation Details
-                    </span>
-                </div>
-                <div className='flex flex-col gap-4 p-4'>
-                    {/* Title */}
-                    <input
-                        value={title}
-                        placeholder='Operation Name'
-                        onChange={e => { setTitle(e.target.value); metaHandleRef.current?.set('title', e.target.value); scheduleSave({ title: e.target.value }) }}
-                        style={{
-                            background: 'transparent',
-                            ...bottomBorder('1px solid rgba(255,255,255,0.1)'),
-                            color: 'rgba(237,237,237,0.9)',
-                            fontSize: '1.5rem',
-                            fontWeight: 700,
-                            letterSpacing: '0.1em',
-                            textTransform: 'uppercase',
-                            outline: 'none',
-                            width: '100%',
-                            padding: '4px 0',
-                        }}
-                    />
-                    {/* Owner row */}
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, fontSize: '0.68rem' }}>
-                        <span style={{ fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: c(0.55), flexShrink: 0 }}>Mission Owner</span>
-                        {ownerPickerOpen && (isJ2Lead || isJ4Admin) ? (
-                            <div style={{ display: 'flex', gap: 6, flex: 1 }}>
-                                <select
-                                    defaultValue={ownedBy}
-                                    onChange={async e => {
-                                        const sel = j2Members.find(m => m.id === e.target.value)
-                                        if (!sel) return
-                                        setOwnedBy(sel.id)
-                                        setOwnedByName(sel.displayName)
-                                        setOwnerPickerOpen(false)
-                                        await fetch(`/api/operations/update?id=${opID}&ownedBy=${encodeURIComponent(sel.id)}&ownedByName=${encodeURIComponent(sel.displayName)}`)
-                                    }}
-                                    style={{ flex: 1, background: 'rgba(0,0,0,0.4)', border: `1px solid ${c(0.3)}`, color: 'rgba(237,237,237,0.8)', fontSize: '0.75rem', padding: '5px 8px', outline: 'none' }}
-                                >
-                                    <option value=''>— Select member —</option>
-                                    {j2Members.map(m => <option key={m.id} value={m.id}>{m.displayName}</option>)}
-                                </select>
-                                <button type='button' onClick={() => setOwnerPickerOpen(false)} style={{ fontSize: '0.6rem', fontWeight: 700, background: 'none', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.35)', padding: '3px 8px', cursor: 'pointer' }}>Cancel</button>
-                            </div>
-                        ) : (
-                            <>
-                                <span style={{ color: ownedByName ? 'rgba(237,237,237,0.7)' : 'rgba(237,237,237,0.25)', fontStyle: ownedByName ? 'normal' : 'italic' }}>
-                                    {ownedByName || 'Unassigned'}
-                                </span>
-                                {(isJ2Lead || isJ4Admin) && (
-                                    <button type='button' onClick={async () => {
-                                        if (j2Members.length === 0) {
-                                            const res = await fetch('/api/admin/members?department=j2')
-                                            const data = await res.json()
-                                            setJ2Members((data.members ?? []).map((m: any) => ({ id: m.discordId ?? m._id, displayName: m.displayName ?? m.name ?? 'Unknown' })))
-                                        }
-                                        setOwnerPickerOpen(true)
-                                    }}
-                                        style={{ fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.1em', background: 'none', border: `1px solid ${c(0.25)}`, color: c(0.6), padding: '2px 8px', cursor: 'pointer' }}
-                                    >Change</button>
-                                )}
-                            </>
-                        )}
-                    </div>
-
-                    {/* Billet points — J2 leads + J4 admin only */}
-                    {(isJ2Lead || isJ4Admin) && opID && (
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 12, fontSize: '0.68rem' }}>
-                            <span style={{ fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: c(0.55), flexShrink: 0 }}>Billet Points</span>
-                            <input
-                                type='number'
-                                min={0}
-                                step={1}
-                                value={billetPoints}
-                                onChange={e => setBilletPoints(Math.max(0, parseInt(e.target.value) || 0))}
-                                onBlur={async () => {
-                                    await fetch(`/api/operations/update?id=${opID}&billetPoints=${billetPoints}`)
-                                }}
-                                style={{ width: 52, background: 'rgba(0,0,0,0.4)', border: `1px solid ${c(0.25)}`, color: 'rgba(237,237,237,0.8)', fontSize: '0.75rem', padding: '3px 6px', outline: 'none', textAlign: 'center' }}
-                            />
-                            <span style={{ color: c(0.35), fontStyle: 'italic' }}>awarded to owner on completion</span>
-                        </div>
-                    )}
-
-                    {/* Acknowledgements panel — shown for Upcoming ops */}
-                    {status === 'Upcoming' && (
-                        <div style={{ borderTop: '1px solid rgba(255,255,255,0.06)', paddingTop: 12 }}>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: ackExpanded ? 10 : 0 }}>
-                                <span style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: c(0.55) }}>Orders Acknowledged</span>
-                                <span style={{ fontSize: '0.65rem', fontWeight: 700, color: ackCount > 0 ? 'rgba(0,200,80,0.8)' : 'rgba(237,237,237,0.3)' }}>{ackCount} staff</span>
-                                <button type='button' onClick={() => setAckExpanded(v => !v)} style={{ fontSize: '0.58rem', background: 'none', border: 'none', color: 'rgba(237,237,237,0.3)', cursor: 'pointer', padding: '0 4px' }}>{ackExpanded ? '▲ Hide' : '▼ Show'}</button>
-                                <button type='button' disabled={remindSaving} onClick={async () => {
-                                    setRemindSaving(true)
-                                    try {
-                                        const res = await fetch(`/api/operations/${opID}/remind`, { method: 'POST' })
-                                        if (res.ok) { const d = await res.json(); setRemindSent(d.sent ?? 0) }
-                                    } finally { setRemindSaving(false) }
-                                }}
-                                    style={{ marginLeft: 'auto', fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.1em', padding: '3px 10px', background: remindSaving ? 'rgba(255,255,255,0.03)' : 'rgba(100,150,237,0.1)', border: '1px solid rgba(100,150,237,0.3)', color: remindSaving ? 'rgba(237,237,237,0.25)' : 'rgba(100,150,237,0.75)', cursor: remindSaving ? 'not-allowed' : 'pointer' }}
-                                >
-                                    {remindSaving ? 'Sending…' : remindSent !== null ? `Sent (${remindSent})` : 'Remind Unacknowledged'}
-                                </button>
-                            </div>
-                            {ackExpanded && ackList.length > 0 && (
-                                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                                    {ackList.map(a => (
-                                        <div key={a.userId} style={{ fontSize: '0.58rem', padding: '3px 8px', background: 'rgba(0,200,80,0.06)', border: '1px solid rgba(0,200,80,0.18)', color: 'rgba(0,200,80,0.7)' }}>
-                                            {a.userName} <span style={{ opacity: 0.5 }}>{new Date(a.acknowledgedAt).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}</span>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                            {ackExpanded && ackList.length === 0 && (
-                                <div style={{ fontSize: '0.6rem', color: 'rgba(237,237,237,0.25)', fontStyle: 'italic' }}>No staff have acknowledged yet.</div>
-                            )}
-                        </div>
-                    )}
-
-                    {/* Sub-fields row 1 */}
-                    <div className='flex flex-wrap gap-4'>
-                        <input
-                            value={department}
-                            placeholder='Department'
-                            onChange={e => { setDepartment(e.target.value); metaHandleRef.current?.set('department', e.target.value); scheduleSave({ department: e.target.value }) }}
-                            style={{
-                                background: 'transparent',
-                                border: '1px solid rgba(255,255,255,0.1)',
-                                color: 'rgba(237,237,237,0.75)',
-                                fontSize: '0.8rem',
-                                letterSpacing: '0.06em',
-                                outline: 'none',
-                                padding: '8px 12px',
-                                flex: 1,
-                                minWidth: 160,
+            {/* Acknowledgements + cover photo — not rehomed into a deck card
+                (Task 11). Neither fits the DetailsCard row idiom:
+                acknowledgements is a count/expand/remind list, and Task 12's
+                brief already earmarks it for the future Attendance tab;
+                cover photo is an image plus upload/replace/remove, not a
+                single data row. Left mounted here, functionally unchanged
+                from the old "Operation Details" panel, pending a ruling on
+                their permanent home — see the task-11 report. Everything
+                else that panel held (title, owner, billet points,
+                department, status, theme colour, era, map, in-game date) now
+                lives in the deck's DetailsCard. */}
+            <div style={{ marginBottom: 20, display: 'flex', flexDirection: 'column', gap: 16 }}>
+                {status === 'Upcoming' && (
+                    <div style={{ ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${c(0.5)}`), background: 'rgba(255,255,255,0.01)', padding: '12px 16px' }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: ackExpanded ? 10 : 0 }}>
+                            <span style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: c(0.55) }}>Orders Acknowledged</span>
+                            <span style={{ fontSize: '0.65rem', fontWeight: 700, color: ackCount > 0 ? 'rgba(0,200,80,0.8)' : 'rgba(237,237,237,0.3)' }}>{ackCount} staff</span>
+                            <button type='button' onClick={() => setAckExpanded(v => !v)} style={{ fontSize: '0.58rem', background: 'none', border: 'none', color: 'rgba(237,237,237,0.3)', cursor: 'pointer', padding: '0 4px' }}>{ackExpanded ? '▲ Hide' : '▼ Show'}</button>
+                            <button type='button' disabled={remindSaving} onClick={async () => {
+                                setRemindSaving(true)
+                                try {
+                                    const res = await fetch(`/api/operations/${opID}/remind`, { method: 'POST' })
+                                    if (res.ok) { const d = await res.json(); setRemindSent(d.sent ?? 0) }
+                                } finally { setRemindSaving(false) }
                             }}
-                        />
-                        {/* Status */}
-                        <select
-                            value={status}
-                            onChange={e => { setStatus(e.target.value); scheduleSave({ status: e.target.value }) }}
-                            style={{
-                                background: 'rgba(0,0,0,0.4)',
-                                border: `1px solid ${currentStatusColor}`,
-                                color: currentStatusColor,
-                                fontSize: '0.8rem',
-                                letterSpacing: '0.06em',
-                                outline: 'none',
-                                padding: '8px 12px',
-                                minWidth: 160,
-                                cursor: 'pointer',
-                                fontWeight: 700,
-                            }}
-                        >
-                            <option value='Upcoming' style={{ background: 'rgb(18,18,18)', color: 'rgba(219,160,0,0.9)' }}>Upcoming</option>
-                            <option value='Active' style={{ background: 'rgb(18,18,18)', color: 'rgba(0,200,80,0.9)' }}>Active</option>
-                            <option value='Completed' style={{ background: 'rgb(18,18,18)', color: 'rgba(100,150,237,0.8)' }}>Completed</option>
-                            {isHQ && <option value='In Development' style={{ background: 'rgb(18,18,18)', color: 'rgba(219,0,29,0.75)' }}>In Development</option>}
-                        </select>
-                        {/* Complete Mission button — visible when op is Active */}
-                        {isHQ && status === 'Active' && (
-                            <button
-                                onClick={() => applyStage('confirmations_open')}
-                                style={{
-                                    background: 'rgba(219,0,29,0.15)',
-                                    border: '1px solid rgba(219,0,29,0.6)',
-                                    color: 'rgba(219,0,29,0.9)',
-                                    fontSize: '0.75rem',
-                                    fontWeight: 700,
-                                    letterSpacing: '0.1em',
-                                    textTransform: 'uppercase',
-                                    padding: '8px 16px',
-                                    cursor: 'pointer',
-                                    whiteSpace: 'nowrap',
-                                }}
+                                style={{ marginLeft: 'auto', fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.1em', padding: '3px 10px', background: remindSaving ? 'rgba(255,255,255,0.03)' : 'rgba(100,150,237,0.1)', border: '1px solid rgba(100,150,237,0.3)', color: remindSaving ? 'rgba(237,237,237,0.25)' : 'rgba(100,150,237,0.75)', cursor: remindSaving ? 'not-allowed' : 'pointer' }}
                             >
-                                Complete Mission
+                                {remindSaving ? 'Sending…' : remindSent !== null ? `Sent (${remindSent})` : 'Remind Unacknowledged'}
                             </button>
+                        </div>
+                        {ackExpanded && ackList.length > 0 && (
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                                {ackList.map(a => (
+                                    <div key={a.userId} style={{ fontSize: '0.58rem', padding: '3px 8px', background: 'rgba(0,200,80,0.06)', border: '1px solid rgba(0,200,80,0.18)', color: 'rgba(0,200,80,0.7)' }}>
+                                        {a.userName} <span style={{ opacity: 0.5 }}>{new Date(a.acknowledgedAt).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}</span>
+                                    </div>
+                                ))}
+                            </div>
                         )}
-                        {/* Theme color picker */}
-                        <label style={{ display: 'flex', alignItems: 'center', gap: 8, border: '1px solid rgba(255,255,255,0.1)', padding: '6px 12px', cursor: 'pointer', userSelect: 'none' }}>
-                            <input
-                                type='color'
-                                value={themeColor}
-                                onChange={e => { setThemeColor(e.target.value); scheduleSave({ themeColor: e.target.value }) }}
-                                style={{ width: 22, height: 22, border: 'none', padding: 0, background: 'transparent', cursor: 'pointer' }}
-                            />
-                            <span style={{ fontSize: '0.75rem', letterSpacing: '0.06em', color: 'rgba(237,237,237,0.55)', whiteSpace: 'nowrap' }}>Theme Color</span>
-                        </label>
-                        {/* ERA / Page Theme */}
-                        <select
-                            value={pageTheme ?? 'modern'}
-                            onChange={e => {
-                                setPageTheme(e.target.value)
-                                scheduleSave({ pageTheme: e.target.value })
-                            }}
-                            style={{
-                                background: 'rgba(0,0,0,0.4)',
-                                border: `1px solid ${c(0.35)}`,
-                                color: c(0.8),
-                                fontSize: '0.8rem',
-                                letterSpacing: '0.06em',
-                                outline: 'none',
-                                padding: '8px 12px',
-                                minWidth: 150,
-                                cursor: 'pointer',
-                                fontWeight: 700,
-                            }}
-                        >
-                            {eraOptions.length > 0
-                                ? eraOptions.map(opt => (
-                                    <option key={opt.value} value={opt.value} style={{ background: 'rgb(18,18,18)', color: 'rgba(237,237,237,0.8)' }}>
-                                        {opt.name}
-                                    </option>
-                                ))
-                                : (
-                                    <>
-                                        <option value='modern'  style={{ background: 'rgb(18,18,18)', color: 'rgba(237,237,237,0.8)' }}>Modern</option>
-                                        <option value='wwii'    style={{ background: 'rgb(18,18,18)', color: 'rgba(237,237,237,0.8)' }}>WWII</option>
-                                        <option value='vietnam' style={{ background: 'rgb(18,18,18)', color: 'rgba(237,237,237,0.8)' }}>Vietnam</option>
-                                        <option value='coldwar' style={{ background: 'rgb(18,18,18)', color: 'rgba(237,237,237,0.8)' }}>Cold War</option>
-                                        <option value='fantasy' style={{ background: 'rgb(18,18,18)', color: 'rgba(237,237,237,0.8)' }}>Fantasy</option>
-                                        <option value='scifi'   style={{ background: 'rgb(18,18,18)', color: 'rgba(237,237,237,0.8)' }}>Sci-Fi</option>
-                                    </>
-                                )
-                            }
-                        </select>
-                        {/* Map World */}
-                        <MapWorldPicker
-                            value={mapWorld}
-                            worlds={availableWorlds}
-                            onChange={w => { setMapWorld(w); scheduleSave({ mapWorld: w }) }}
-                            themeColor={themeColor}
-                        />
+                        {ackExpanded && ackList.length === 0 && (
+                            <div style={{ fontSize: '0.6rem', color: 'rgba(237,237,237,0.25)', fontStyle: 'italic' }}>No staff have acknowledged yet.</div>
+                        )}
                     </div>
-                    {/* In-Game date/time — datetime picker */}
-                    <LocalizationProvider dateAdapter={AdapterDayjs}>
-                        <DateTimePicker
-                            label='In-Game Date & Time'
-                            value={loreDateDayjs}
-                            format='DD/MM/YYYY HH:mm'
-                            onChange={v => {
-                                setLoreDateDayjs(v)
-                                const str = v?.isValid() ? v.format('DD/MM/YYYY HH:mm') : ''
-                                setLoreDate(str)
-                                metaHandleRef.current?.set('loreDate', str)
-                                scheduleSave({ loreDate: str })
-                            }}
-                            slotProps={{ textField: { size: 'small', sx: { width: '100%' } } }}
-                        />
-                    </LocalizationProvider>
+                )}
 
-                    {/* Cover image */}
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                        {coverImage ? (
-                            <>
-                                <div style={{ position: 'relative', width: 140, height: 52, flexShrink: 0, border: '1px solid rgba(255,255,255,0.1)', overflow: 'hidden' }}>
-                                    <img src={coverImage} alt='cover' style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
-                                </div>
-                                <button
-                                    onClick={removeCover}
-                                    style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: c(0.6), background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
-                                >
-                                    Remove Cover
-                                </button>
-                                <label style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.35)', cursor: 'pointer' }}>
-                                    Replace
-                                    <input type='file' accept='image/*' style={{ display: 'none' }} onChange={e => { const f = e.target.files?.[0]; if (f) uploadCover(f) }} />
-                                </label>
-                            </>
-                        ) : (
-                            <label style={{ display: 'flex', alignItems: 'center', gap: 8, border: '1px dashed rgba(255,255,255,0.12)', padding: '10px 18px', cursor: 'pointer' }}>
-                                <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: coverUploading ? 'rgba(237,237,237,0.3)' : 'rgba(237,237,237,0.4)' }}>
-                                    {coverUploading ? 'Uploading…' : '+ Cover Photo'}
-                                </span>
-                                <input type='file' accept='image/*' style={{ display: 'none' }} disabled={coverUploading} onChange={e => { const f = e.target.files?.[0]; if (f) uploadCover(f) }} />
+                {/* Cover image */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                    {coverImage ? (
+                        <>
+                            <div style={{ position: 'relative', width: 140, height: 52, flexShrink: 0, border: '1px solid rgba(255,255,255,0.1)', overflow: 'hidden' }}>
+                                <img src={coverImage} alt='cover' style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+                            </div>
+                            <button
+                                onClick={removeCover}
+                                style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: c(0.6), background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                            >
+                                Remove Cover
+                            </button>
+                            <label style={{ fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.35)', cursor: 'pointer' }}>
+                                Replace
+                                <input type='file' accept='image/*' style={{ display: 'none' }} onChange={e => { const f = e.target.files?.[0]; if (f) uploadCover(f) }} />
                             </label>
-                        )}
-                    </div>
+                        </>
+                    ) : (
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 8, border: '1px dashed rgba(255,255,255,0.12)', padding: '10px 18px', cursor: 'pointer' }}>
+                            <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: coverUploading ? 'rgba(237,237,237,0.3)' : 'rgba(237,237,237,0.4)' }}>
+                                {coverUploading ? 'Uploading…' : '+ Cover Photo'}
+                            </span>
+                            <input type='file' accept='image/*' style={{ display: 'none' }} disabled={coverUploading} onChange={e => { const f = e.target.files?.[0]; if (f) uploadCover(f) }} />
+                        </label>
+                    )}
                 </div>
             </div>
 
@@ -2061,215 +2011,5 @@ export default function Page() {
                 </div>
             )}
         </>
-    )
-}
-
-// ─── Popular Arma 3 maps (shown when not in maps system) ─────────────────────
-
-const POPULAR_MAPS: { name: string; displayName: string }[] = [
-    { name: 'altis', displayName: 'Altis' },
-    { name: 'stratis', displayName: 'Stratis' },
-    { name: 'tanoa', displayName: 'Tanoa' },
-    { name: 'malden', displayName: 'Malden' },
-    { name: 'livonia', displayName: 'Livonia' },
-    { name: 'chernarus', displayName: 'Chernarus' },
-    { name: 'takistan', displayName: 'Takistan' },
-    { name: 'sahrani', displayName: 'Sahrani' },
-    { name: 'panthera', displayName: 'Panthera' },
-    { name: 'lingor', displayName: 'Lingor' },
-    { name: 'namalsk', displayName: 'Namalsk' },
-    { name: 'fallujah', displayName: 'Fallujah' },
-    { name: 'clafghan', displayName: 'Clafghan' },
-    { name: 'porto', displayName: 'Porto' },
-    { name: 'utes', displayName: 'Utes' },
-    { name: 'zargabad', displayName: 'Zargabad' },
-    { name: 'desert_e', displayName: 'Desert (IRL)' },
-]
-
-// ─── Map World Picker ─────────────────────────────────────────────────────────
-
-function MapWorldPicker({
-    value,
-    worlds,
-    onChange,
-    themeColor,
-}: {
-    value: string
-    worlds: { name: string; displayName: string; hasPreview: boolean }[]
-    onChange: (name: string) => void
-    themeColor: string
-}) {
-    const [open, setOpen] = useState(false)
-    const [search, setSearch] = useState('')
-    const [customValue, setCustomValue] = useState('')
-    const [showCustom, setShowCustom] = useState(false)
-    const ref = useRef<HTMLDivElement>(null)
-    const searchRef = useRef<HTMLInputElement>(null)
-
-    const selected = worlds.find(w => w.name === value)
-        ?? POPULAR_MAPS.find(m => m.name === value)
-        ?? (value ? { name: value, displayName: value } : null)
-
-    useEffect(() => {
-        if (!open) { setSearch(''); setShowCustom(false) }
-        else setTimeout(() => searchRef.current?.focus(), 50)
-    }, [open])
-
-    useEffect(() => {
-        if (!open) return
-        const close = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) setOpen(false) }
-        document.addEventListener('mousedown', close)
-        return () => document.removeEventListener('mousedown', close)
-    }, [open])
-
-    // Merge maps-system worlds with popular maps (deduplicate by name)
-    const systemNames = new Set(worlds.map(w => w.name))
-    const popularFiltered = POPULAR_MAPS.filter(m => !systemNames.has(m.name))
-
-    const allMaps: { name: string; displayName: string; hasPreview: boolean; isSystem?: boolean }[] = [
-        ...worlds.map(w => ({ ...w, isSystem: true })),
-        ...popularFiltered.map(m => ({ ...m, hasPreview: false, isSystem: false })),
-    ]
-
-    const q = search.toLowerCase()
-    const filtered = q
-        ? allMaps.filter(m => m.displayName.toLowerCase().includes(q) || m.name.toLowerCase().includes(q))
-        : allMaps
-
-    const systemMaps = filtered.filter(m => m.isSystem)
-    const popularMaps = filtered.filter(m => !m.isSystem)
-
-    function MapItem({ w }: { w: typeof allMaps[number] }) {
-        const isActive = w.name === value
-        return (
-            <div
-                className='mwp-item'
-                onClick={() => { onChange(w.name); setOpen(false) }}
-                style={{
-                    position: 'relative',
-                    display: 'flex', alignItems: 'center', gap: 10,
-                    padding: '7px 12px', cursor: 'pointer',
-                    background: isActive ? 'rgba(255,255,255,0.07)' : 'transparent',
-                    borderLeft: isActive ? `2px solid ${themeColor}` : '2px solid transparent',
-                    fontSize: '0.78rem', color: isActive ? 'rgba(237,237,237,0.95)' : 'rgba(237,237,237,0.6)',
-                }}
-            >
-                {!isActive && <div className='mwp-hover' style={{ position: 'absolute', inset: 0, background: 'rgba(255,255,255,0.04)', opacity: 0, transition: 'opacity 0.1s ease', pointerEvents: 'none', willChange: 'opacity' }} />}
-                {w.hasPreview ? (
-                    <img src={`/map-assets/${w.name}/preview.jpg`} alt='' loading='lazy' style={{ width: 40, height: 28, objectFit: 'cover', flexShrink: 0, border: `1px solid ${isActive ? 'rgba(255,255,255,0.2)' : 'rgba(255,255,255,0.08)'}` }} />
-                ) : (
-                    <div style={{ width: 40, height: 28, background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                        <span style={{ fontSize: 9, color: 'rgba(255,255,255,0.15)' }}>MAP</span>
-                    </div>
-                )}
-                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{w.displayName}</span>
-                {w.isSystem && <span style={{ fontSize: '0.55rem', color: 'rgba(34,197,94,0.6)', flexShrink: 0, letterSpacing: '0.08em' }}>SYSTEM</span>}
-            </div>
-        )
-    }
-
-    return (
-        <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
-            <button
-                type='button'
-                onClick={() => setOpen(v => !v)}
-                style={{
-                    display: 'flex', alignItems: 'center', gap: 8,
-                    background: 'rgba(0,0,0,0.4)',
-                    border: `1px solid ${open ? 'rgba(255,255,255,0.2)' : 'rgba(255,255,255,0.1)'}`,
-                    color: selected ? 'rgba(237,237,237,0.85)' : 'rgba(237,237,237,0.3)',
-                    fontSize: '0.8rem', letterSpacing: '0.06em',
-                    padding: '6px 10px', cursor: 'pointer', minWidth: 160,
-                    transition: 'border-color 0.15s',
-                }}
-            >
-                {selected && worlds.find(w => w.name === value)?.hasPreview && (
-                    <img src={`/map-assets/${value}/preview.jpg`} alt='' style={{ width: 28, height: 20, objectFit: 'cover', flexShrink: 0, border: '1px solid rgba(255,255,255,0.1)' }} />
-                )}
-                <span style={{ flex: 1, textAlign: 'left' }}>{selected?.displayName ?? 'No Map'}</span>
-                <span style={{ fontSize: '0.6rem', opacity: 0.4 }}>▾</span>
-            </button>
-
-            {open && (
-                <div style={{
-                    position: 'absolute', top: '100%', left: 0, marginTop: 4, zIndex: 400,
-                    background: 'rgb(14,14,14)', border: '1px solid rgba(255,255,255,0.12)',
-                    minWidth: 260, maxHeight: 380,
-                    boxShadow: '0 8px 24px rgba(0,0,0,0.7)',
-                    display: 'flex', flexDirection: 'column',
-                }}>
-                    <style>{`.mwp-item:hover .mwp-hover{opacity:1!important}`}</style>
-
-                    {/* Search */}
-                    <div style={{ padding: '8px 10px', borderBottom: '1px solid rgba(255,255,255,0.07)', flexShrink: 0 }}>
-                        <input
-                            ref={searchRef}
-                            value={search}
-                            onChange={e => setSearch(e.target.value)}
-                            placeholder='Search maps…'
-                            style={{ width: '100%', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.85)', fontSize: '0.75rem', padding: '5px 8px', outline: 'none', fontFamily: 'inherit' }}
-                        />
-                    </div>
-
-                    {/* Custom map option */}
-                    {!showCustom ? (
-                        <button
-                            type='button'
-                            onClick={() => setShowCustom(true)}
-                            style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', background: 'rgba(219,0,29,0.05)', ...bottomBorder('1px solid rgba(255,255,255,0.06)'), cursor: 'pointer', color: 'rgba(219,0,29,0.7)', fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.06em', textAlign: 'left' }}
-                        >
-                            + Custom Map…
-                        </button>
-                    ) : (
-                        <div style={{ flexShrink: 0, display: 'flex', gap: 4, padding: '6px 10px', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
-                            <input
-                                autoFocus
-                                value={customValue}
-                                onChange={e => setCustomValue(e.target.value)}
-                                placeholder='Enter map name…'
-                                onKeyDown={e => {
-                                    if (e.key === 'Enter' && customValue.trim()) { onChange(customValue.trim()); setOpen(false) }
-                                    if (e.key === 'Escape') setShowCustom(false)
-                                }}
-                                style={{ flex: 1, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(219,0,29,0.3)', color: 'rgba(237,237,237,0.85)', fontSize: '0.75rem', padding: '4px 8px', outline: 'none', fontFamily: 'inherit' }}
-                            />
-                            <button type='button' onClick={() => { if (customValue.trim()) { onChange(customValue.trim()); setOpen(false) } }} style={{ background: 'rgba(219,0,29,0.15)', border: '1px solid rgba(219,0,29,0.35)', color: 'rgba(219,0,29,0.8)', fontSize: '0.68rem', fontWeight: 700, padding: '4px 10px', cursor: 'pointer' }}>OK</button>
-                        </div>
-                    )}
-
-                    <div style={{ overflowY: 'auto', flex: 1 }}>
-                        {/* No map option */}
-                        <div className='mwp-item' onClick={() => { onChange(''); setOpen(false) }}
-                            style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 10, padding: '7px 12px', cursor: 'pointer', background: !value ? 'rgba(255,255,255,0.06)' : 'transparent', borderBottom: '1px solid rgba(255,255,255,0.06)', fontSize: '0.78rem', color: 'rgba(237,237,237,0.35)' }}>
-                            <div className='mwp-hover' style={{ position: 'absolute', inset: 0, background: 'rgba(255,255,255,0.04)', opacity: 0, transition: 'opacity 0.1s ease', pointerEvents: 'none', willChange: 'opacity' }} />
-                            <div style={{ width: 40, height: 28, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                                <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.2)' }}>—</span>
-                            </div>
-                            No Map
-                        </div>
-
-                        {/* Maps system maps */}
-                        {systemMaps.length > 0 && (
-                            <>
-                                <div style={{ padding: '5px 12px 3px', fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'rgba(34,197,94,0.5)' }}>Maps System</div>
-                                {systemMaps.map(w => <MapItem key={w.name} w={w} />)}
-                            </>
-                        )}
-
-                        {/* Popular Arma 3 maps */}
-                        {popularMaps.length > 0 && (
-                            <>
-                                <div style={{ padding: '5px 12px 3px', fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.2)' }}>Arma 3 Maps</div>
-                                {popularMaps.map(w => <MapItem key={w.name} w={w} />)}
-                            </>
-                        )}
-
-                        {filtered.length === 0 && q && (
-                            <div style={{ padding: '16px', textAlign: 'center', fontSize: '0.72rem', color: 'rgba(237,237,237,0.2)', fontStyle: 'italic' }}>No maps matching "{search}"</div>
-                        )}
-                    </div>
-                </div>
-            )}
-        </div>
     )
 }

--- a/apps/web/app/operations/[id]/edit/page.tsx
+++ b/apps/web/app/operations/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, type CSSProperties } from 'react'
 import Link from 'next/link'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import ConfirmDialog from '@/components/confirm-dialog'
@@ -43,6 +43,24 @@ const CHECK_CONTENT: Record<'campaign' | 'single', Record<string, string[]>> = {
         w4: ['Final development check completed', 'Arsenal and loadout updates confirmed'],
     },
 }
+
+// Mixing the `border` shorthand with a per-side longhand (`borderTop`, `borderBottom`)
+// in one style object makes React warn whenever either value updates on rerender.
+// These build the all-longhand equivalent instead.
+const sideBorders = (all: string, top: string): CSSProperties =>
+    ({ borderTop: top, borderRight: all, borderBottom: all, borderLeft: all })
+
+const bottomBorder = (bottom: string): CSSProperties =>
+    ({ borderTop: 'none', borderRight: 'none', borderBottom: bottom, borderLeft: 'none' })
+
+// Shared style for the collapsible section header buttons.
+const sectionToggleStyle = (open: boolean): CSSProperties => ({
+    ...bottomBorder(open ? '1px solid rgba(255,255,255,0.05)' : 'none'),
+    width: '100%',
+    background: 'none',
+    cursor: 'pointer',
+    textAlign: 'left',
+})
 
 function hexToRgb(hex: string) {
     const h = hex.replace('#', '')
@@ -509,8 +527,7 @@ export default function Page() {
             {/* Spinner */}
             <div style={{
                 width: 36, height: 36,
-                border: `2px solid rgba(219,0,29,0.12)`,
-                borderTop: `2px solid rgba(219,0,29,0.75)`,
+                ...sideBorders(`2px solid rgba(219,0,29,0.12)`, `2px solid rgba(219,0,29,0.75)`),
                 borderRadius: '50%',
                 animation: 'edit-spin 0.8s linear infinite',
             }} />
@@ -580,7 +597,6 @@ export default function Page() {
                                 href={`/operations/${opID}/map`}
                                 style={{
                                     background: 'none',
-                                    border: 'none',
                                     padding: '2px 0',
                                     fontSize: '0.68rem',
                                     fontWeight: 700,
@@ -588,7 +604,7 @@ export default function Page() {
                                     textTransform: 'uppercase',
                                     color: 'rgba(237,237,237,0.3)',
                                     textDecoration: 'none',
-                                    borderBottom: '2px solid transparent',
+                                    ...bottomBorder('2px solid transparent'),
                                 }}
                             >
                                 Map ↗
@@ -769,10 +785,10 @@ export default function Page() {
 
                 return (
                     <>
-                        <div style={{ border: `1px solid ${c(0.15)}`, borderTop: `2px solid ${allDone ? 'rgba(0,200,80,0.6)' : c(0.5)}`, background: 'rgba(255,255,255,0.01)', marginBottom: 20 }}>
+                        <div style={{ ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${allDone ? 'rgba(0,200,80,0.6)' : c(0.5)}`), background: 'rgba(255,255,255,0.01)', marginBottom: 20 }}>
                             <button type='button' onClick={() => setMissionDevOpen(v => !v)}
                                 className='flex items-center justify-between px-4 py-3'
-                                style={{ borderBottom: missionDevOpen ? '1px solid rgba(255,255,255,0.05)' : 'none', width: '100%', background: 'none', border: 'none', cursor: 'pointer', textAlign: 'left' }}
+                                style={sectionToggleStyle(missionDevOpen)}
                             >
                                 <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                                     <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: allDone ? 'rgba(0,200,80,0.6)' : 'rgba(237,237,237,0.3)' }}>
@@ -997,7 +1013,7 @@ export default function Page() {
                                 <div style={{ position: 'fixed', inset: 0, zIndex: 9999, background: 'rgba(0,0,0,0.8)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                                     onClick={e => { if (e.target === e.currentTarget) setCompletingCheckId(null) }}
                                 >
-                                    <div style={{ background: '#0f0f10', border: `1px solid ${c(0.35)}`, borderTop: `2px solid rgba(0,200,80,0.7)`, padding: '24px 28px', maxWidth: 500, width: '90%', display: 'flex', flexDirection: 'column', gap: 16 }}>
+                                    <div style={{ background: '#0f0f10', ...sideBorders(`1px solid ${c(0.35)}`, `2px solid rgba(0,200,80,0.7)`), padding: '24px 28px', maxWidth: 500, width: '90%', display: 'flex', flexDirection: 'column', gap: 16 }}>
                                         <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'rgba(0,200,80,0.5)', fontFamily: 'monospace' }}>
                                             {'// COMPLETE CHECK'}
                                         </div>
@@ -1078,7 +1094,7 @@ export default function Page() {
                                 onClick={e => { if (e.target === e.currentTarget) setOrdersCheckModal(false) }}
                             >
                                 <LocalizationProvider dateAdapter={AdapterDayjs}>
-                                    <div style={{ background: '#0f0f10', border: `1px solid rgba(100,150,237,0.35)`, borderTop: `2px solid rgba(100,150,237,0.8)`, padding: '24px 28px', maxWidth: 440, width: '90%', display: 'flex', flexDirection: 'column', gap: 16 }}>
+                                    <div style={{ background: '#0f0f10', ...sideBorders(`1px solid rgba(100,150,237,0.35)`, `2px solid rgba(100,150,237,0.8)`), padding: '24px 28px', maxWidth: 440, width: '90%', display: 'flex', flexDirection: 'column', gap: 16 }}>
                                         <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'rgba(100,150,237,0.5)', fontFamily: 'monospace' }}>
                                             {'// REQUEST ORDERS CHECK'}
                                         </div>
@@ -1169,7 +1185,7 @@ export default function Page() {
             })()}
 
             {/* Metadata card */}
-            <div style={{ border: `1px solid ${c(0.15)}`, borderTop: `2px solid ${c(1)}`, background: 'rgba(255,255,255,0.01)', marginBottom: 20 }}>
+            <div style={{ ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${c(1)}`), background: 'rgba(255,255,255,0.01)', marginBottom: 20 }}>
                 <div className='flex items-center px-4 py-3' style={{ borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
                     <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.3)' }}>
                         Operation Details
@@ -1183,8 +1199,7 @@ export default function Page() {
                         onChange={e => { setTitle(e.target.value); metaHandleRef.current?.set('title', e.target.value); scheduleSave({ title: e.target.value }) }}
                         style={{
                             background: 'transparent',
-                            border: 'none',
-                            borderBottom: '1px solid rgba(255,255,255,0.1)',
+                            ...bottomBorder('1px solid rgba(255,255,255,0.1)'),
                             color: 'rgba(237,237,237,0.9)',
                             fontSize: '1.5rem',
                             fontWeight: 700,
@@ -1515,14 +1530,13 @@ export default function Page() {
 
                 return (
                     <div style={{
-                        border: `1px solid ${c(0.15)}`,
-                        borderTop: `2px solid ${c(0.5)}`,
+                        ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${c(0.5)}`),
                         background: 'rgba(255,255,255,0.01)',
                         marginBottom: 20,
                     }}>
                         <button type='button' onClick={() => setScheduleOpen(v => !v)}
                             className='flex items-center justify-between px-4 py-3'
-                            style={{ borderBottom: scheduleOpen ? '1px solid rgba(255,255,255,0.05)' : 'none', width: '100%', background: 'none', border: 'none', cursor: 'pointer', textAlign: 'left' }}
+                            style={sectionToggleStyle(scheduleOpen)}
                         >
                             <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                                 <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.3)' }}>
@@ -1763,10 +1777,10 @@ export default function Page() {
 
             {/* Attendance settings — HQ only */}
             {isHQ && opID && (
-                <div style={{ border: `1px solid ${c(0.15)}`, borderTop: `2px solid ${c(0.5)}`, background: 'rgba(255,255,255,0.01)', marginBottom: 20 }}>
+                <div style={{ ...sideBorders(`1px solid ${c(0.15)}`, `2px solid ${c(0.5)}`), background: 'rgba(255,255,255,0.01)', marginBottom: 20 }}>
                     <button type='button' onClick={() => setAttendanceOpen(v => !v)}
                         className='flex items-center justify-between px-4 py-3'
-                        style={{ borderBottom: attendanceOpen ? '1px solid rgba(255,255,255,0.05)' : 'none', width: '100%', background: 'none', border: 'none', cursor: 'pointer', textAlign: 'left' }}
+                        style={sectionToggleStyle(attendanceOpen)}
                     >
                         <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.3)' }}>
                             Attendance Settings
@@ -1969,8 +1983,7 @@ export default function Page() {
             {/* Custom Attendance Units — HQ only */}
             {isHQ && opID && (
                 <div style={{
-                    border: `1px solid ${c(0.12)}`,
-                    borderTop: `2px solid rgba(251,191,36,0.35)`,
+                    ...sideBorders(`1px solid ${c(0.12)}`, `2px solid rgba(251,191,36,0.35)`),
                     marginBottom: 20,
                     background: 'rgba(0,0,0,0.22)',
                 }}>
@@ -2140,7 +2153,7 @@ export default function Page() {
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
                     <style>{`@keyframes op-pulse{0%,100%{opacity:.35}50%{opacity:.75}}.op-pulse{animation:op-pulse 1.8s ease-in-out infinite}`}</style>
                     {[1, 0.6].map((opacity, i) => (
-                        <div key={i} style={{ border: `1px solid ${c(0.1)}`, borderTop: `2px solid ${c(0.25)}`, opacity }}>
+                        <div key={i} style={{ ...sideBorders(`1px solid ${c(0.1)}`, `2px solid ${c(0.25)}`), opacity }}>
                             <div style={{ background: 'rgba(0,0,0,0.35)', padding: '9px 16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
                                 <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                                     <div className='op-pulse' style={{ width: 6, height: 6, background: c(0.35), flexShrink: 0 }} />
@@ -2405,7 +2418,7 @@ function MapWorldPicker({
                         <button
                             type='button'
                             onClick={() => setShowCustom(true)}
-                            style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', background: 'rgba(219,0,29,0.05)', border: 'none', borderBottom: '1px solid rgba(255,255,255,0.06)', cursor: 'pointer', color: 'rgba(219,0,29,0.7)', fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.06em', textAlign: 'left' }}
+                            style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', background: 'rgba(219,0,29,0.05)', ...bottomBorder('1px solid rgba(255,255,255,0.06)'), cursor: 'pointer', color: 'rgba(219,0,29,0.7)', fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.06em', textAlign: 'left' }}
                         >
                             + Custom Map…
                         </button>

--- a/apps/web/app/operations/[id]/edit/shell.module.css
+++ b/apps/web/app/operations/[id]/edit/shell.module.css
@@ -1,0 +1,66 @@
+/*
+ * Grid regions for the editor shell. Colour comes entirely from the
+ * `.command` tokens (styles/command.css) plus the per-operation --acc/--acc-rgb
+ * injected inline by EditorShell — nothing here hardcodes a colour.
+ */
+.shell {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    overflow: hidden;
+}
+.body { display: flex; flex: 1; min-height: 0; }
+.main { flex: 1; min-width: 0; display: flex; flex-direction: column; position: relative; }
+.deck { width: 340px; flex-shrink: 0; border-left: 1px solid var(--line); overflow-y: auto; }
+.deckCollapsed { width: 44px; }
+
+@media (max-width: 1279px) { .deck { position: absolute; right: 0; top: 0; bottom: 0; z-index: 20; } }
+@media (max-width: 1023px) { .deck { width: 300px; } }
+
+/* The scrollable pane inside .main — .main itself is a plain flex column with
+   no overflow rule (see the block above), so without this the tab content
+   would be clipped by .shell's overflow:hidden instead of scrolling. */
+.mainScroll { flex: 1; min-height: 0; overflow-y: auto; }
+
+.tabbar {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0 16px;
+    height: 36px;
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--line);
+    background: var(--s1);
+}
+
+.tab {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--ink-3);
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    padding: 0 10px;
+    height: 100%;
+    cursor: pointer;
+}
+.tab:hover { color: var(--ink-2); }
+.tabOn { color: var(--ink); border-bottom-color: var(--acc); }
+
+.tabPlaceholder {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ink-3);
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}

--- a/apps/web/app/operations/[id]/edit/shell.module.css
+++ b/apps/web/app/operations/[id]/edit/shell.module.css
@@ -12,13 +12,17 @@
     font-family: var(--sans);
     overflow: hidden;
 }
-.body { display: flex; flex: 1; min-height: 0; }
+/*
+ * position: relative so MissionDeck (deck/MissionDeck.tsx) can go
+ * `position: absolute` against this box, not the viewport, when it turns
+ * itself into an overlay below 1280px — see that file's own doc comment.
+ * .body has no other layout role here; MissionDeck fully owns its own
+ * width/border/background for both the pushed (>=1280px) and overlay
+ * (<1280px) cases, same as it always has (see EditorShell's doc comment
+ * on why `deck` is rendered with no wrapping div).
+ */
+.body { display: flex; flex: 1; min-height: 0; position: relative; }
 .main { flex: 1; min-width: 0; display: flex; flex-direction: column; position: relative; }
-.deck { width: 340px; flex-shrink: 0; border-left: 1px solid var(--line); overflow-y: auto; }
-.deckCollapsed { width: 44px; }
-
-@media (max-width: 1279px) { .deck { position: absolute; right: 0; top: 0; bottom: 0; z-index: 20; } }
-@media (max-width: 1023px) { .deck { width: 300px; } }
 
 /* The scrollable pane inside .main — .main itself is a plain flex column with
    no overflow rule (see the block above), so without this the tab content
@@ -36,6 +40,13 @@
     background: var(--s1);
 }
 
+/* Below 1024px the tab strip scrolls horizontally instead of compressing —
+   four tabs still fit above that width, so the rule is scoped narrow rather
+   than applied unconditionally. */
+@media (max-width: 1023px) {
+    .tabbar { overflow-x: auto; scrollbar-width: thin; }
+}
+
 .tab {
     background: none;
     border: none;
@@ -49,6 +60,27 @@
     padding: 0 10px;
     height: 100%;
     cursor: pointer;
+    flex-shrink: 0;
 }
 .tab:hover { color: var(--ink-2); }
 .tabOn { color: var(--ink); border-bottom-color: var(--acc); }
+
+/*
+ * StatusBar cells (§8). Cells drop left-to-right by priority as width falls;
+ * "Live/Offline" (connected) and "Saved HH:MM" (savedAt) carry no class
+ * here and so never drop — they're the two pieces of state spec §8 calls
+ * out to keep longest. Thresholds line up with the shell's own breakpoints
+ * (1600/1280/1024) plus one narrower step for the doc-editor headcount,
+ * since that cell matters least once the deck (which already shows
+ * presence) has collapsed to a rail anyway.
+ */
+.sbDoc      { }
+.sbWords    { }
+.sbSections { }
+.sbEditors  { }
+.sbDept     { }
+
+@media (max-width: 1599px) { .sbDoc      { display: none; } }
+@media (max-width: 1279px) { .sbWords    { display: none; } }
+@media (max-width: 1023px) { .sbSections { display: none; } .sbDept { display: none; } }
+@media (max-width: 767px)  { .sbEditors  { display: none; } }

--- a/apps/web/app/operations/[id]/edit/shell.module.css
+++ b/apps/web/app/operations/[id]/edit/shell.module.css
@@ -65,7 +65,9 @@
     flex-shrink: 1;
     min-width: 0;
     overflow-x: auto;
-    scrollbar-width: thin;
+    /* Thin fading overlay scrollbar rules live on the shared `.thin-scroll`
+       class (styles/globals.css) applied alongside this one in Header.tsx —
+       including the Firefox scrollbar-width/-color fallback. */
 }
 
 .tab {

--- a/apps/web/app/operations/[id]/edit/shell.module.css
+++ b/apps/web/app/operations/[id]/edit/shell.module.css
@@ -52,22 +52,20 @@
 }
 .previewBtn:hover { color: var(--ink); border-color: var(--acc); }
 
-.tabbar {
+/* The tab links, inline in Header's single merged row (spec §3) rather than
+   a separate bar underneath it. `min-width: 0` lets it shrink below its
+   content's natural width instead of forcing the row wider than its
+   container; `overflow-x: auto` then lets the strip itself scroll instead of
+   wrapping to a second line once it's been squeezed that far. */
+.tabsRow {
     display: flex;
     align-items: center;
     gap: 4px;
-    padding: 0 16px;
-    height: 36px;
-    flex-shrink: 0;
-    border-bottom: 1px solid var(--line);
-    background: var(--s1);
-}
-
-/* Below 1024px the tab strip scrolls horizontally instead of compressing —
-   four tabs still fit above that width, so the rule is scoped narrow rather
-   than applied unconditionally. */
-@media (max-width: 1023px) {
-    .tabbar { overflow-x: auto; scrollbar-width: thin; }
+    height: 100%;
+    flex-shrink: 1;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: thin;
 }
 
 .tab {

--- a/apps/web/app/operations/[id]/edit/shell.module.css
+++ b/apps/web/app/operations/[id]/edit/shell.module.css
@@ -29,6 +29,29 @@
    would be clipped by .shell's overflow:hidden instead of scrolling. */
 .mainScroll { flex: 1; min-height: 0; overflow-y: auto; }
 
+/* Preview — pinned to .main's own bottom-right corner (.main is
+   position:relative, above), immediately left of the mission deck rather
+   than the far edge of the viewport. See EditorShell's doc comment on the
+   button itself. */
+.previewBtn {
+    position: absolute;
+    right: 24px;
+    bottom: 24px;
+    padding: 7px 14px;
+    background: var(--s2);
+    border: 1px solid var(--line-2);
+    border-radius: var(--r);
+    color: var(--ink-2);
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    cursor: pointer;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.35);
+}
+.previewBtn:hover { color: var(--ink); border-color: var(--acc); }
+
 .tabbar {
     display: flex;
     align-items: center;

--- a/apps/web/app/operations/[id]/edit/shell.module.css
+++ b/apps/web/app/operations/[id]/edit/shell.module.css
@@ -52,15 +52,3 @@
 }
 .tab:hover { color: var(--ink-2); }
 .tabOn { color: var(--ink); border-bottom-color: var(--acc); }
-
-.tabPlaceholder {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--ink-3);
-    font-family: var(--mono);
-    font-size: 12px;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-}

--- a/apps/web/app/operations/[id]/edit/tabs/AttendanceTab.tsx
+++ b/apps/web/app/operations/[id]/edit/tabs/AttendanceTab.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useState, type CSSProperties } from 'react'
+
+interface AckEntry { userId: string; userName: string; acknowledgedAt: string }
+
+interface Props {
+    opID: string
+    status: string
+    discordPingEnabled: boolean
+    discordPingRoles: string[]
+    onChangeDiscordPingRoles: (roles: string[]) => void
+    ackCount: number
+    ackList: AckEntry[]
+}
+
+const PING_ROLE_OPTS = [
+    { id: '@everyone', label: '@everyone' },
+    { id: '@here', label: '@here' },
+    { id: '@friend of unit', label: '@friend of unit' },
+    { id: '@veteran member', label: '@veteran member' },
+]
+
+const panelStyle: CSSProperties = {
+    position: 'relative',
+    border: '1px solid var(--line)',
+    borderRadius: 'var(--r)',
+    background: 'linear-gradient(180deg, var(--s1) 0%, var(--bg) 100%)',
+}
+
+const tickStyle: CSSProperties = {
+    position: 'absolute', top: 0, left: 0, width: 36, height: 2, background: 'var(--acc)', opacity: 0.75,
+}
+
+const panelHeaderStyle: CSSProperties = {
+    display: 'flex', alignItems: 'center', gap: 12,
+    padding: '14px 18px', borderBottom: '1px solid var(--line)',
+    fontSize: 11, letterSpacing: '0.22em', textTransform: 'uppercase', fontWeight: 700, color: 'var(--ink)',
+}
+
+function chipStyle(selected: boolean): CSSProperties {
+    return {
+        display: 'inline-flex', alignItems: 'center', gap: 7,
+        border: `1px solid ${selected ? 'rgba(var(--acc-rgb), 0.42)' : 'var(--line-2)'}`,
+        background: 'var(--s2)', borderRadius: 'var(--r)', padding: '6px 10px',
+        fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase',
+        color: selected ? 'var(--ink)' : 'var(--ink-2)', cursor: 'pointer',
+    }
+}
+
+/**
+ * Who attends is already covered by the deck's AttendanceCard (platoon +
+ * custom-unit chips, Discord ping on/off) — see task-12-report.md for the
+ * inventory. What's left, and what this tab holds: the per-role Discord ping
+ * targets AttendanceCard deliberately doesn't duplicate, and the orders
+ * acknowledgement block that's been sitting in a residual page.tsx wrapper
+ * since Task 11 waiting for this tab to exist.
+ *
+ * `isHQ` gating is the caller's job (page.tsx / EditorShell) — this component
+ * assumes it's safe to render.
+ */
+export default function AttendanceTab({
+    opID, status, discordPingEnabled, discordPingRoles, onChangeDiscordPingRoles, ackCount, ackList,
+}: Props) {
+    const [ackExpanded, setAckExpanded] = useState(false)
+    const [remindSaving, setRemindSaving] = useState(false)
+    const [remindSent, setRemindSent] = useState<number | null>(null)
+
+    function toggleRole(id: string) {
+        const updated = discordPingRoles.includes(id)
+            ? discordPingRoles.filter(r => r !== id)
+            : [...discordPingRoles, id]
+        onChangeDiscordPingRoles(updated)
+    }
+
+    return (
+        <div style={{ width: '100%', maxWidth: 1220, margin: '0 auto', padding: 'clamp(1.5rem, 2.5vw, 2.5rem)', display: 'flex', flexDirection: 'column', gap: 20 }}>
+            <div style={panelStyle}>
+                <div style={tickStyle} />
+                <div style={panelHeaderStyle}>Notifications</div>
+                <div style={{ padding: 16 }}>
+                    <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--ink-3)', marginBottom: 10 }}>
+                        Discord Ping Roles
+                    </div>
+                    {discordPingEnabled ? (
+                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                            {PING_ROLE_OPTS.map(role => {
+                                const checked = discordPingRoles.includes(role.id)
+                                return (
+                                    <button key={role.id} type='button' onClick={() => toggleRole(role.id)} style={chipStyle(checked)}>
+                                        {checked && (
+                                            <svg width='11' height='11' viewBox='0 0 12 12' fill='none'>
+                                                <path d='M2 6l3 3 5-5' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
+                                            </svg>
+                                        )}
+                                        {role.label}
+                                    </button>
+                                )
+                            })}
+                        </div>
+                    ) : (
+                        <div style={{ fontSize: '0.72rem', color: 'var(--ink-3)', fontStyle: 'italic' }}>
+                            Discord ping is disabled — enable it from the Attendance card to choose roles.
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {status === 'Upcoming' && (
+                <div style={panelStyle}>
+                    <div style={tickStyle} />
+                    <div style={panelHeaderStyle}>Acknowledgements</div>
+                    <div style={{ padding: 16 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: ackExpanded ? 10 : 0 }}>
+                            <span style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-2)' }}>Orders Acknowledged</span>
+                            <span style={{ fontSize: '0.65rem', fontWeight: 700, color: ackCount > 0 ? 'var(--good)' : 'var(--ink-3)' }}>{ackCount} staff</span>
+                            <button type='button' onClick={() => setAckExpanded(v => !v)} style={{ fontSize: '0.58rem', background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer', padding: '0 4px' }}>{ackExpanded ? '▲ Hide' : '▼ Show'}</button>
+                            <button type='button' disabled={remindSaving} onClick={async () => {
+                                setRemindSaving(true)
+                                try {
+                                    const res = await fetch(`/api/operations/${opID}/remind`, { method: 'POST' })
+                                    if (res.ok) { const d = await res.json(); setRemindSent(d.sent ?? 0) }
+                                } finally { setRemindSaving(false) }
+                            }}
+                                style={{ marginLeft: 'auto', fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.1em', padding: '3px 10px', borderRadius: 'var(--r)', background: remindSaving ? 'var(--s1)' : 'var(--s2)', border: '1px solid var(--acc)', color: remindSaving ? 'var(--ink-3)' : 'var(--acc)', cursor: remindSaving ? 'not-allowed' : 'pointer' }}
+                            >
+                                {remindSaving ? 'Sending…' : remindSent !== null ? `Sent (${remindSent})` : 'Remind Unacknowledged'}
+                            </button>
+                        </div>
+                        {ackExpanded && ackList.length > 0 && (
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                                {ackList.map(a => (
+                                    <div key={a.userId} style={{ fontSize: '0.58rem', padding: '3px 8px', borderRadius: 'var(--r)', background: 'var(--s2)', border: '1px solid var(--good)', color: 'var(--good)' }}>
+                                        {a.userName} <span style={{ opacity: 0.6 }}>{new Date(a.acknowledgedAt).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                        {ackExpanded && ackList.length === 0 && (
+                            <div style={{ fontSize: '0.6rem', color: 'var(--ink-3)', fontStyle: 'italic' }}>No staff have acknowledged yet.</div>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/tabs/BriefTab.tsx
+++ b/apps/web/app/operations/[id]/edit/tabs/BriefTab.tsx
@@ -24,10 +24,15 @@ interface Props {
 /**
  * Documents rail + collaborative editor. `CollabEditor` (imported here as
  * `OperationEditor`, matching the name page.tsx used before this split)
- * already renders `PageSidebar` internally as its own documents rail — see
- * the design doc's non-goal on not rewriting `CollabEditor.tsx` beyond the
- * one permitted `onProviderReady` prop, so that internal structure is
- * untouched.
+ * already renders `PageSidebar` internally as its own documents rail.
+ *
+ * No padding/max-width wrapper here (unlike the old card-based design):
+ * the documents rail must sit flush against the shell's own left edge, full
+ * height, with no gap above or beside it (visual-fixes spec §1) — a padded,
+ * centred wrapper around the whole thing would reintroduce exactly that
+ * gap. `CollabEditor` now owns its own layout: the rail renders flush left,
+ * and its own content column applies the padding/max-width centering
+ * (spec §2) to just the document body, not the rail.
  *
  * The old panel's `loaded ? <OperationEditor/> : <skeleton/>` branch is
  * dropped: page.tsx already returns its own full-page loading state before
@@ -40,7 +45,7 @@ export default function BriefTab({
     onMetaChange, metaHandleRef, onSaveStatusChange, onProviderReady,
 }: Props) {
     return (
-        <div style={{ width: '100%', maxWidth: 1220, margin: '0 auto', padding: 'clamp(1.5rem, 2.5vw, 2.5rem)' }}>
+        <div style={{ width: '100%', height: '100%' }}>
             <OperationEditor
                 documentId={opID}
                 uploadUrl='/api/operations/upload'

--- a/apps/web/app/operations/[id]/edit/tabs/BriefTab.tsx
+++ b/apps/web/app/operations/[id]/edit/tabs/BriefTab.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import type { HocuspocusProvider } from '@hocuspocus/provider'
+
+const OperationEditor = dynamic(() => import('@/components/editor/CollabEditor'), { ssr: false })
+
+interface Props {
+    opID: string
+    initialContent: any
+    themeColor: string
+    title: string
+    department: string
+    date: string
+    loreDate: string
+    onMetaChange: (fields: Record<string, string>) => void
+    metaHandleRef: React.MutableRefObject<{ set: (key: string, value: string) => void } | null>
+    onSaveStatusChange: (status: 'saved' | 'saving' | 'unsaved') => void
+    /** Wired to `usePresence`/`useDocStats` in page.tsx for the status bar —
+     * see the ruling on CollabEditor's one permitted new prop. */
+    onProviderReady: (provider: HocuspocusProvider) => void
+}
+
+/**
+ * Documents rail + collaborative editor. `CollabEditor` (imported here as
+ * `OperationEditor`, matching the name page.tsx used before this split)
+ * already renders `PageSidebar` internally as its own documents rail — see
+ * the design doc's non-goal on not rewriting `CollabEditor.tsx` beyond the
+ * one permitted `onProviderReady` prop, so that internal structure is
+ * untouched.
+ *
+ * The old panel's `loaded ? <OperationEditor/> : <skeleton/>` branch is
+ * dropped: page.tsx already returns its own full-page loading state before
+ * `EditorShell` (and therefore this tab) ever mounts, so `loaded` was always
+ * `true` by the time that skeleton could render — dead code, not a moved
+ * capability.
+ */
+export default function BriefTab({
+    opID, initialContent, themeColor, title, department, date, loreDate,
+    onMetaChange, metaHandleRef, onSaveStatusChange, onProviderReady,
+}: Props) {
+    return (
+        <div style={{ width: '100%', maxWidth: 1220, margin: '0 auto', padding: 'clamp(1.5rem, 2.5vw, 2.5rem)' }}>
+            <OperationEditor
+                documentId={opID}
+                uploadUrl='/api/operations/upload'
+                defaultSectionTitle='Situation'
+                initialContent={initialContent}
+                themeColor={themeColor}
+                initialMeta={{ title, department, date, loreDate }}
+                onMetaChange={onMetaChange}
+                metaHandleRef={metaHandleRef}
+                onSaveStatusChange={onSaveStatusChange}
+                onProviderReady={onProviderReady}
+            />
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/tabs/DevelopmentTab.tsx
+++ b/apps/web/app/operations/[id]/edit/tabs/DevelopmentTab.tsx
@@ -1,0 +1,554 @@
+'use client'
+
+import { useState, type CSSProperties } from 'react'
+import type { Dayjs } from 'dayjs'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
+
+type OrdersCheckTask = {
+    _id?: string
+    status: string
+    ordersCheckAt?: string
+    ordersCheckStatus?: string
+    ordersCheckProposedAt?: string
+    ordersCheckProposedBy?: string
+}
+
+interface Props {
+    opID: string
+    isJ2Lead: boolean
+    title: string
+    date: Dayjs | null
+    isCampaignOp: boolean
+    campaignStartDate: string | null
+    /** Shared with the deck's CountdownStrip (page.tsx computes `checksDone`/
+     * `checksTotal` off the same field) — lifted rather than owned locally so
+     * the two stay in sync without a second fetch. */
+    missionDev: MissionDevelopment | null
+    setMissionDev: React.Dispatch<React.SetStateAction<MissionDevelopment | null>>
+    /** Initialised from page.tsx's own load effect (`GET .../orders-check`),
+     * so it's lifted the same way `missionDev` is rather than re-fetched here. */
+    ordersCheckTask: OrdersCheckTask | null
+    setOrdersCheckTask: React.Dispatch<React.SetStateAction<OrdersCheckTask | null>>
+}
+
+const CHECK_CONTENT: Record<'campaign' | 'single', Record<string, string[]>> = {
+    campaign: {
+        w16: ['Mission concept/idea submitted to J2', 'Initial discussion completed with team leads'],
+        w12: ['Confirmed mission development has started', 'Initial planning document created', 'First mission scenario and orders started', 'J2 lead briefed on mission concept'],
+        w10: ['Core framework and fundamentals established', 'First mission scenario and orders complete', 'Second and third missions started'],
+        w8: ['Second and third missions complete', 'All subsequent missions started', 'All mission orders finalised'],
+        w6: ['Final checks and revisions completed', 'Bug fixing pass completed', 'Server loadout and mission tested', 'Weekly Monday reminder sent (if any items incomplete)'],
+        w4: ['Final development check completed', 'Arsenal and loadout updates confirmed'],
+    },
+    single: {
+        w12: ['Mission concept/idea submitted to J2'],
+        w10: ['Confirmed mission development has started', 'Mission scenario and orders started', 'J2 lead briefed on mission concept'],
+        w8: ['Mission scenario and orders complete', 'Replacement mission arranged if not complete'],
+        w6: ['Final checks and bug fixing completed', 'Server mission tested', 'Weekly Monday reminder sent (if any items incomplete)'],
+        w4: ['Final development check completed', 'Arsenal and loadout updates confirmed'],
+    },
+}
+
+const fieldStyle: CSSProperties = {
+    width: '100%', background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)',
+    color: 'var(--ink)', fontSize: '0.8rem', padding: '8px 10px', outline: 'none', boxSizing: 'border-box',
+}
+
+const pickerSx = {
+    '& .MuiInputBase-root': { background: 'var(--s2)', borderRadius: 'var(--r)', fontSize: '0.75rem' },
+    '& .MuiOutlinedInput-notchedOutline': { border: '1px solid var(--line-2)' },
+    '& .MuiInputBase-input': { color: 'var(--ink-2)', padding: '4px 8px' },
+    '& .MuiSvgIcon-root': { color: 'var(--ink-3)', fontSize: 16 },
+}
+
+/**
+ * Mission development gate timeline + its completion modal, and the Orders
+ * Check Request block that lived inside the same collapsible panel — moved
+ * out of page.tsx verbatim (Task 12): same endpoints, same fields, same
+ * `isJ2Lead` gate, same collapsible-panel toggle. Only the colours changed,
+ * from raw `rgba()` literals to the `--acc`/`--good`/`--warn`/token palette
+ * every other file in this redesign uses.
+ *
+ * The six-step Mission Stage stepper that used to sit in the *other*
+ * collapsible panel (Attendance Settings) is not here — it was already
+ * superseded by the deck's StageCard (Task 10) and is retired outright, not
+ * rehomed, per the design doc §9.
+ */
+export default function DevelopmentTab({
+    opID, isJ2Lead, title, date, isCampaignOp, campaignStartDate,
+    missionDev, setMissionDev, ordersCheckTask, setOrdersCheckTask,
+}: Props) {
+    const [open, setOpen] = useState(true)
+    const [saving, setSaving] = useState(false)
+
+    const [completingCheckId, setCompletingCheckId] = useState<string | null>(null)
+    const [reviewerName, setReviewerName] = useState('')
+    const [comments, setComments] = useState('')
+    const [outcome, setOutcome] = useState('')
+
+    const [ordersCheckModal, setOrdersCheckModal] = useState(false)
+    const [ordersCheckPreferredAt, setOrdersCheckPreferredAt] = useState<Dayjs | null>(null)
+    const [ordersCheckComments, setOrdersCheckComments] = useState('')
+    const [ordersCheckSaving, setOrdersCheckSaving] = useState(false)
+    const [ordersCheckCancelling, setOrdersCheckCancelling] = useState(false)
+    const [ordersCheckReminderAt, setOrdersCheckReminderAt] = useState<Dayjs | null>(null)
+    const [ordersCheckReminderSaving, setOrdersCheckReminderSaving] = useState(false)
+    const [ordersCheckReminderSet, setOrdersCheckReminderSet] = useState(false)
+
+    const baseDate = isCampaignOp && campaignStartDate
+        ? new Date(campaignStartDate)
+        : date?.toDate() ?? null
+    if (!opID || !baseDate) return null
+
+    const weeksList = isCampaignOp ? [16, 12, 10, 8, 6, 4] : [12, 10, 8, 6, 4]
+    const now = new Date()
+    const checks = weeksList.map(weeks => {
+        const dueDate = new Date(baseDate.getTime() - weeks * 7 * 24 * 3600000)
+        const completion = missionDev?.completions?.[`w${weeks}`]
+        return {
+            id: `w${weeks}`,
+            label: `${weeks}W`,
+            weeks,
+            dueDate,
+            isOverdue: now > dueDate && !completion,
+            isCompleted: !!completion,
+            completion,
+        }
+    })
+    const allDone = checks.every(ch => ch.isCompleted)
+    const fmtDate = (d: Date) => d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit' })
+
+    async function saveCompletion(checkId: string) {
+        setSaving(true)
+        try {
+            const res = await fetch(`/api/operations/${opID}/mission-development`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    checkId,
+                    reviewerName: reviewerName.trim() || undefined,
+                    comments: comments.trim() || undefined,
+                    outcome: outcome.trim() || undefined,
+                }),
+            })
+            const data = await res.json()
+            if (data.ok) {
+                setMissionDev(prev => ({
+                    completions: { ...(prev?.completions ?? {}), [checkId]: data.completion },
+                    lastUpdatedAt: new Date().toISOString(),
+                }))
+                setCompletingCheckId(null)
+                setReviewerName('')
+                setComments('')
+                setOutcome('')
+            }
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    async function removeCompletion(checkId: string) {
+        setSaving(true)
+        try {
+            await fetch(`/api/operations/${opID}/mission-development?checkId=${checkId}`, { method: 'DELETE' })
+            setMissionDev(prev => {
+                if (!prev) return prev
+                const next = { ...prev, completions: { ...prev.completions } }
+                delete next.completions[checkId]
+                return next
+            })
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    return (
+        <div style={{ width: '100%', maxWidth: 1220, margin: '0 auto', padding: 'clamp(1.5rem, 2.5vw, 2.5rem)' }}>
+            <div style={{
+                border: '1px solid var(--line)', borderTop: `2px solid ${allDone ? 'var(--good)' : 'rgba(var(--acc-rgb), 0.5)'}`,
+                borderRadius: 'var(--r)', background: 'var(--s1)',
+            }}>
+                <button type='button' onClick={() => setOpen(v => !v)}
+                    className='flex items-center justify-between px-4 py-3'
+                    style={{
+                        borderBottom: open ? '1px solid var(--line)' : 'none',
+                        width: '100%', background: 'none', cursor: 'pointer', textAlign: 'left',
+                    }}
+                >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: allDone ? 'var(--good)' : 'var(--ink-3)' }}>
+                            Mission Development
+                        </span>
+                        {allDone && <span style={{ fontSize: '0.6rem', fontWeight: 700, color: 'var(--good)', letterSpacing: '0.1em' }}>✓ All Checks Complete</span>}
+                        {!allDone && checks.some(ch => ch.isOverdue) && (
+                            <span style={{ fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--warn)', border: '1px solid var(--warn)', borderRadius: 'var(--r)', padding: '2px 8px' }}>
+                                {checks.filter(ch => ch.isOverdue).length} Overdue
+                            </span>
+                        )}
+                        {saving && <span style={{ fontSize: '0.6rem', color: 'var(--acc)', fontWeight: 700 }}>Saving…</span>}
+                    </div>
+                    <span style={{ fontSize: '0.65rem', color: 'var(--ink-3)', fontFamily: 'var(--mono)' }}>{open ? '[−]' : '[+]'}</span>
+                </button>
+
+                {open && (
+                    <div style={{ padding: '20px 16px 16px' }}>
+                        <div style={{ display: 'flex', alignItems: 'flex-start', marginBottom: 16 }}>
+                            {checks.map((ch, i) => {
+                                const nodeColor = ch.isCompleted ? 'var(--good)' : ch.isOverdue ? 'var(--warn)' : 'var(--s3)'
+                                const borderClr = ch.isCompleted ? 'var(--good)' : ch.isOverdue ? 'var(--warn)' : 'var(--line-2)'
+                                const labelClr = ch.isCompleted ? 'var(--good)' : ch.isOverdue ? 'var(--warn)' : 'var(--ink-3)'
+                                const connectorColor = ch.isCompleted && checks[i + 1]?.isCompleted ? 'var(--good)' : 'var(--line)'
+                                return (
+                                    <div key={ch.id} style={{ display: 'flex', alignItems: 'flex-start', flex: i < checks.length - 1 ? 1 : undefined }}>
+                                        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 5, minWidth: 52 }}>
+                                            <button
+                                                type='button'
+                                                disabled={!isJ2Lead || saving}
+                                                onClick={() => {
+                                                    if (!isJ2Lead) return
+                                                    if (ch.isCompleted) {
+                                                        if (confirm(`Remove completion for ${ch.label} check?`)) removeCompletion(ch.id)
+                                                    } else {
+                                                        setCompletingCheckId(ch.id)
+                                                        setReviewerName('')
+                                                        setComments('')
+                                                        setOutcome('')
+                                                    }
+                                                }}
+                                                title={isJ2Lead ? (ch.isCompleted ? 'Click to remove completion' : 'Click to complete this check') : 'J2 leads only'}
+                                                style={{
+                                                    width: 22, height: 22, borderRadius: '50%', flexShrink: 0,
+                                                    background: nodeColor, border: `2px solid ${borderClr}`,
+                                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                                    cursor: isJ2Lead ? 'pointer' : 'default',
+                                                    padding: 0, transition: 'all 0.2s',
+                                                }}
+                                            >
+                                                {ch.isCompleted && <span style={{ fontSize: 9, color: 'var(--bg)', lineHeight: 1 }}>✓</span>}
+                                                {ch.isOverdue && !ch.isCompleted && <span style={{ fontSize: 9, color: 'var(--bg)', lineHeight: 1 }}>!</span>}
+                                            </button>
+                                            <div style={{ textAlign: 'center', lineHeight: 1.3 }}>
+                                                <div style={{ fontSize: '0.52rem', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: labelClr }}>{ch.label}</div>
+                                                <div style={{ fontSize: '0.48rem', color: 'var(--ink-3)', letterSpacing: '0.04em' }}>{fmtDate(ch.dueDate)}</div>
+                                            </div>
+                                            {ch.completion && (
+                                                <div style={{ fontSize: '0.44rem', color: 'var(--good)', textAlign: 'center', lineHeight: 1.3, maxWidth: 50 }}>
+                                                    {ch.completion.reviewerName}
+                                                </div>
+                                            )}
+                                        </div>
+                                        {i < checks.length - 1 && (
+                                            <div style={{ flex: 1, height: 2, marginTop: 10, background: connectorColor }} />
+                                        )}
+                                    </div>
+                                )
+                            })}
+                        </div>
+
+                        {/* Legend */}
+                        <div style={{ display: 'flex', gap: 16, fontSize: '0.55rem', color: 'var(--ink-3)' }}>
+                            <span><span style={{ color: 'var(--good)' }}>●</span> Completed</span>
+                            <span><span style={{ color: 'var(--warn)' }}>●</span> Overdue</span>
+                            <span><span style={{ color: 'var(--line-2)' }}>●</span> Pending</span>
+                            {!isJ2Lead && <span style={{ color: 'var(--ink-3)', fontStyle: 'italic' }}>J2 leads can complete checks</span>}
+                            <span style={{ marginLeft: 'auto', color: 'var(--ink-3)' }}>
+                                {isCampaignOp ? 'Campaign — 6 checks from campaign start' : 'Single mission — 5 checks from op date'}
+                            </span>
+                        </div>
+
+                        {/* Per-check detail rows for completed checks */}
+                        {checks.filter(ch => ch.completion).length > 0 && (
+                            <div style={{ marginTop: 14, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                                {checks.filter(ch => ch.completion).map(ch => (
+                                    <div key={ch.id} style={{ padding: '8px 12px', background: 'var(--s2)', border: '1px solid var(--line)', borderRadius: 'var(--r)', display: 'flex', flexDirection: 'column', gap: 3 }}>
+                                        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                                            <span style={{ fontSize: '0.6rem', fontWeight: 700, color: 'var(--good)', letterSpacing: '0.08em' }}>{ch.label}</span>
+                                            <span style={{ fontSize: '0.58rem', color: 'var(--ink-2)' }}>Reviewed by {ch.completion!.reviewerName}</span>
+                                            <span style={{ fontSize: '0.55rem', color: 'var(--ink-3)', marginLeft: 'auto' }}>
+                                                {new Date(ch.completion!.completedAt).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit', hour: '2-digit', minute: '2-digit' })}
+                                            </span>
+                                        </div>
+                                        {ch.completion!.comments && (
+                                            <div style={{ fontSize: '0.58rem', color: 'var(--ink-2)', paddingLeft: 2 }}>{ch.completion!.comments}</div>
+                                        )}
+                                        {ch.completion!.outcome && (
+                                            <div style={{ fontSize: '0.58rem', color: 'var(--warn)', paddingLeft: 2 }}>Outcome: {ch.completion!.outcome}</div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+
+                        {/* Orders Check Request */}
+                        <div style={{ marginTop: 16, borderTop: '1px solid var(--line)', paddingTop: 14 }}>
+                            {ordersCheckTask ? (
+                                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 12px', background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)' }}>
+                                        <div style={{ flex: 1 }}>
+                                            <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--acc)', marginBottom: 3 }}>
+                                                Orders Check {ordersCheckTask.ordersCheckStatus === 'confirmed' ? '✓ Confirmed' : ordersCheckTask.ordersCheckStatus === 'proposed' ? '— Alternative Proposed' : '— Requested'}
+                                            </div>
+                                            {ordersCheckTask.ordersCheckAt && (
+                                                <div style={{ fontSize: '0.68rem', color: 'var(--ink-2)' }}>
+                                                    Requested: {new Date(ordersCheckTask.ordersCheckAt).toLocaleString('en-AU', { dateStyle: 'medium', timeStyle: 'short' })}
+                                                </div>
+                                            )}
+                                            {ordersCheckTask.ordersCheckStatus === 'proposed' && ordersCheckTask.ordersCheckProposedAt && (
+                                                <div style={{ fontSize: '0.65rem', color: 'var(--warn)', marginTop: 2 }}>
+                                                    Alternative by {ordersCheckTask.ordersCheckProposedBy}: {new Date(ordersCheckTask.ordersCheckProposedAt).toLocaleString('en-AU', { dateStyle: 'medium', timeStyle: 'short' })}
+                                                </div>
+                                            )}
+                                        </div>
+                                        {ordersCheckTask.ordersCheckStatus !== 'confirmed' && ordersCheckTask._id && (
+                                            <button
+                                                type='button'
+                                                disabled={ordersCheckCancelling}
+                                                onClick={async () => {
+                                                    if (!confirm('Cancel this orders check request?')) return
+                                                    setOrdersCheckCancelling(true)
+                                                    try {
+                                                        const res = await fetch(`/api/operations/${opID}/orders-check?taskId=${ordersCheckTask._id}`, { method: 'DELETE' })
+                                                        if (res.ok) {
+                                                            setOrdersCheckTask(null)
+                                                            setOrdersCheckReminderSet(false)
+                                                        } else {
+                                                            const d = await res.json()
+                                                            alert(d.error ?? 'Failed to cancel.')
+                                                        }
+                                                    } finally {
+                                                        setOrdersCheckCancelling(false)
+                                                    }
+                                                }}
+                                                style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '4px 10px', borderRadius: 'var(--r)', background: 'none', border: '1px solid var(--crit)', color: 'var(--crit)', cursor: 'pointer', flexShrink: 0 }}
+                                            >
+                                                {ordersCheckCancelling ? '…' : 'Cancel Request'}
+                                            </button>
+                                        )}
+                                    </div>
+
+                                    {/* Reminder — shown after confirmation */}
+                                    {ordersCheckTask.ordersCheckStatus === 'confirmed' && ordersCheckTask._id && (
+                                        <LocalizationProvider dateAdapter={AdapterDayjs}>
+                                            <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 12px', background: 'var(--s1)', border: '1px solid var(--line)', borderRadius: 'var(--r)' }}>
+                                                <span style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink-3)', flexShrink: 0 }}>Remind me:</span>
+                                                <DateTimePicker
+                                                    value={ordersCheckReminderAt}
+                                                    onChange={v => setOrdersCheckReminderAt(v)}
+                                                    slotProps={{
+                                                        textField: { size: 'small', sx: pickerSx },
+                                                        popper: { sx: { zIndex: 19999 } },
+                                                    }}
+                                                />
+                                                <button
+                                                    type='button'
+                                                    disabled={!ordersCheckReminderAt || ordersCheckReminderSaving}
+                                                    onClick={async () => {
+                                                        if (!ordersCheckReminderAt) return
+                                                        setOrdersCheckReminderSaving(true)
+                                                        try {
+                                                            const res = await fetch(`/api/operations/${opID}/orders-check`, {
+                                                                method: 'PATCH',
+                                                                headers: { 'Content-Type': 'application/json' },
+                                                                body: JSON.stringify({ taskId: ordersCheckTask._id, action: 'set_reminder', proposedAt: ordersCheckReminderAt.toISOString() }),
+                                                            })
+                                                            if (res.ok) { setOrdersCheckReminderSet(true) }
+                                                            else { const d = await res.json(); alert(d.error ?? 'Failed.') }
+                                                        } finally {
+                                                            setOrdersCheckReminderSaving(false)
+                                                        }
+                                                    }}
+                                                    style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', padding: '4px 10px', borderRadius: 'var(--r)', background: ordersCheckReminderSet ? 'var(--s3)' : 'var(--s2)', border: `1px solid ${ordersCheckReminderSet ? 'var(--good)' : 'var(--acc)'}`, color: ordersCheckReminderSet ? 'var(--good)' : 'var(--acc)', cursor: 'pointer', flexShrink: 0 }}
+                                                >
+                                                    {ordersCheckReminderSet ? '✓ Set' : 'Set Reminder'}
+                                                </button>
+                                            </div>
+                                        </LocalizationProvider>
+                                    )}
+                                </div>
+                            ) : (
+                                <button type='button' onClick={() => setOrdersCheckModal(true)}
+                                    style={{
+                                        fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase',
+                                        padding: '7px 16px', borderRadius: 'var(--r)', background: 'var(--s2)', border: '1px solid var(--acc)',
+                                        color: 'var(--acc)', cursor: 'pointer',
+                                    }}
+                                >
+                                    + Request Orders Check
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            {/* Completion modal */}
+            {completingCheckId && (() => {
+                const ch = checks.find(c => c.id === completingCheckId)
+                if (!ch) return null
+                return (
+                    <div style={{ position: 'fixed', inset: 0, zIndex: 9999, background: 'rgba(0,0,0,0.8)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                        onClick={e => { if (e.target === e.currentTarget) setCompletingCheckId(null) }}
+                    >
+                        <div style={{ background: 'var(--bg)', border: '1px solid var(--line)', borderTop: '2px solid var(--good)', borderRadius: 'var(--r)', padding: '24px 28px', maxWidth: 500, width: '90%', display: 'flex', flexDirection: 'column', gap: 16 }}>
+                            <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--good)', fontFamily: 'var(--mono)' }}>
+                                {'// COMPLETE CHECK'}
+                            </div>
+                            <div style={{ fontSize: '0.88rem', fontWeight: 700, textTransform: 'uppercase', color: 'var(--ink)' }}>
+                                {ch.label} Development Check
+                            </div>
+                            <div style={{ fontSize: '0.65rem', color: 'var(--ink-2)' }}>
+                                Due: {ch.dueDate.toLocaleDateString('en-GB', { weekday: 'short', day: '2-digit', month: 'long', year: 'numeric' })}
+                                {ch.isOverdue && <span style={{ color: 'var(--warn)', marginLeft: 8 }}>● Overdue</span>}
+                            </div>
+
+                            {(() => {
+                                const items = CHECK_CONTENT[isCampaignOp ? 'campaign' : 'single'][ch.id] ?? []
+                                if (!items.length) return null
+                                return (
+                                    <div style={{ background: 'var(--s1)', border: '1px solid var(--line)', borderRadius: 'var(--r)', padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+                                        <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--good)', marginBottom: 4, fontFamily: 'var(--mono)' }}>
+                                            Stage Checklist
+                                        </div>
+                                        {items.map((item, i) => (
+                                            <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+                                                <span style={{ fontSize: '0.6rem', color: 'var(--good)', marginTop: 1, flexShrink: 0 }}>◻</span>
+                                                <span style={{ fontSize: '0.7rem', color: 'var(--ink-2)', lineHeight: 1.45 }}>{item}</span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )
+                            })()}
+
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                                <div>
+                                    <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-2)', marginBottom: 6 }}>Reviewer Name</div>
+                                    <input
+                                        value={reviewerName}
+                                        onChange={e => setReviewerName(e.target.value)}
+                                        placeholder='Your name or assigned reviewer…'
+                                        style={fieldStyle}
+                                    />
+                                </div>
+                                <div>
+                                    <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-2)', marginBottom: 6 }}>Comments</div>
+                                    <textarea
+                                        value={comments}
+                                        onChange={e => setComments(e.target.value)}
+                                        placeholder='Review notes, observations…'
+                                        rows={3}
+                                        style={{ ...fieldStyle, resize: 'vertical' }}
+                                    />
+                                </div>
+                                <div>
+                                    <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-2)', marginBottom: 6 }}>Outcome / Notes</div>
+                                    <textarea
+                                        value={outcome}
+                                        onChange={e => setOutcome(e.target.value)}
+                                        placeholder='Outcome, decisions made, action items…'
+                                        rows={2}
+                                        style={{ ...fieldStyle, resize: 'vertical' }}
+                                    />
+                                </div>
+                            </div>
+
+                            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 4 }}>
+                                <button type='button' onClick={() => setCompletingCheckId(null)}
+                                    style={{ padding: '7px 18px', fontSize: '0.7rem', fontWeight: 700, borderRadius: 'var(--r)', background: 'none', border: '1px solid var(--line-2)', color: 'var(--ink-3)', cursor: 'pointer' }}
+                                >CANCEL</button>
+                                <button type='button' disabled={saving} onClick={() => saveCompletion(completingCheckId)}
+                                    style={{ padding: '7px 18px', fontSize: '0.7rem', fontWeight: 700, borderRadius: 'var(--r)', background: 'var(--s2)', border: '1px solid var(--good)', color: 'var(--good)', cursor: 'pointer' }}
+                                >{saving ? 'Saving…' : '✓ Mark Complete'}</button>
+                            </div>
+                        </div>
+                    </div>
+                )
+            })()}
+
+            {/* Orders Check modal */}
+            {ordersCheckModal && (
+                <div style={{ position: 'fixed', inset: 0, zIndex: 9999, background: 'rgba(0,0,0,0.8)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                    onClick={e => { if (e.target === e.currentTarget) setOrdersCheckModal(false) }}
+                >
+                    <LocalizationProvider dateAdapter={AdapterDayjs}>
+                        <div style={{ background: 'var(--bg)', border: '1px solid var(--line)', borderTop: '2px solid var(--acc)', borderRadius: 'var(--r)', padding: '24px 28px', maxWidth: 440, width: '90%', display: 'flex', flexDirection: 'column', gap: 16 }}>
+                            <div style={{ fontSize: '0.55rem', fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--acc)', fontFamily: 'var(--mono)' }}>
+                                {'// REQUEST ORDERS CHECK'}
+                            </div>
+                            <div style={{ fontSize: '0.88rem', fontWeight: 700, color: 'var(--ink)' }}>
+                                {title || 'This Operation'}
+                            </div>
+                            <div style={{ fontSize: '0.7rem', color: 'var(--ink-2)', lineHeight: 1.5 }}>
+                                Select a preferred date and time for your orders check. A task will be created for J2 leads to review and confirm.
+                            </div>
+
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                                <div>
+                                    <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-3)', marginBottom: 8 }}>
+                                        Preferred Date &amp; Time
+                                    </div>
+                                    <DateTimePicker
+                                        value={ordersCheckPreferredAt}
+                                        onChange={v => setOrdersCheckPreferredAt(v)}
+                                        slotProps={{
+                                            textField: { size: 'small', fullWidth: true, sx: pickerSx },
+                                            popper: { sx: { zIndex: 19999 } },
+                                        }}
+                                    />
+                                </div>
+                                <div>
+                                    <div style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-3)', marginBottom: 8 }}>
+                                        Comments (optional)
+                                    </div>
+                                    <textarea
+                                        value={ordersCheckComments}
+                                        onChange={e => setOrdersCheckComments(e.target.value)}
+                                        placeholder='Any notes or context for J2 leads…'
+                                        rows={3}
+                                        style={{ ...fieldStyle, resize: 'vertical' }}
+                                    />
+                                </div>
+                            </div>
+
+                            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 4 }}>
+                                <button type='button' onClick={() => setOrdersCheckModal(false)}
+                                    style={{ padding: '7px 18px', fontSize: '0.7rem', fontWeight: 700, borderRadius: 'var(--r)', background: 'none', border: '1px solid var(--line-2)', color: 'var(--ink-3)', cursor: 'pointer' }}
+                                >CANCEL</button>
+                                <button type='button'
+                                    disabled={!ordersCheckPreferredAt || ordersCheckSaving}
+                                    onClick={async () => {
+                                        if (!ordersCheckPreferredAt) return
+                                        setOrdersCheckSaving(true)
+                                        try {
+                                            const res = await fetch(`/api/operations/${opID}/orders-check`, {
+                                                method: 'POST',
+                                                headers: { 'Content-Type': 'application/json' },
+                                                body: JSON.stringify({
+                                                    preferredAt: ordersCheckPreferredAt.toISOString(),
+                                                    comments: ordersCheckComments.trim() || undefined,
+                                                }),
+                                            })
+                                            if (res.ok) {
+                                                setOrdersCheckTask({ status: 'pending', ordersCheckAt: ordersCheckPreferredAt.toISOString(), ordersCheckStatus: 'pending' })
+                                                setOrdersCheckModal(false)
+                                                setOrdersCheckComments('')
+                                                setOrdersCheckPreferredAt(null)
+                                            } else {
+                                                const d = await res.json()
+                                                alert(d.error ?? 'Failed to submit orders check request.')
+                                            }
+                                        } finally {
+                                            setOrdersCheckSaving(false)
+                                        }
+                                    }}
+                                    style={{ padding: '7px 18px', fontSize: '0.7rem', fontWeight: 700, borderRadius: 'var(--r)', background: ordersCheckPreferredAt && !ordersCheckSaving ? 'var(--s2)' : 'var(--s1)', border: '1px solid var(--acc)', color: ordersCheckPreferredAt && !ordersCheckSaving ? 'var(--acc)' : 'var(--ink-3)', cursor: ordersCheckPreferredAt ? 'pointer' : 'not-allowed' }}
+                                >{ordersCheckSaving ? 'Submitting…' : 'Submit Request'}</button>
+                            </div>
+                        </div>
+                    </LocalizationProvider>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/edit/tabs/MapTab.tsx
+++ b/apps/web/app/operations/[id]/edit/tabs/MapTab.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import MapSection from '@/components/operations/map/MapSection'
+import type { MapWorld } from '@/components/operations/map/types'
+
+interface Props {
+    operationId: string
+    canEdit: boolean
+    world: MapWorld | null
+}
+
+/**
+ * Embeds the same `MapSection` the standalone `/operations/[id]/map` route
+ * renders (that route is unchanged and stays as the fullscreen entry point —
+ * see the design doc's non-goal on it). `MapSection` owns its own Y.js state
+ * via `useMapYjs`, which is why EditorShell keeps this tab mounted with
+ * `display: none` rather than unmounting it on tab switch.
+ */
+export default function MapTab({ operationId, canEdit, world }: Props) {
+    return (
+        <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+                <MapSection operationId={operationId} canEdit={canEdit} world={world} />
+            </div>
+        </div>
+    )
+}

--- a/apps/web/components/editor/CollabEditor.tsx
+++ b/apps/web/components/editor/CollabEditor.tsx
@@ -44,6 +44,11 @@ interface Props {
     themeColor?: string
     readOnly?: boolean
     allowedTypes?: string[]
+    /** Fired once the Hocuspocus provider exists, so a caller (the status bar's
+     * presence/connection state) can reach it without this component needing
+     * to expose anything else. See task-12's ruling: this is the only prop
+     * CollabEditor may gain. */
+    onProviderReady?: (provider: HocuspocusProvider) => void
 }
 
 function hexToRgb(hex: string) {
@@ -112,6 +117,7 @@ export default function CollabEditor({
     themeColor = '#db001d',
     readOnly = false,
     allowedTypes,
+    onProviderReady,
 }: Props) {
     const [ydoc] = useState(() => new Y.Doc())
     const [ready, setReady] = useState<ReadyState | null>(null)
@@ -159,7 +165,10 @@ export default function CollabEditor({
                         if (status === 'disconnected') setTimeout(() => onSaveStatusChange?.('unsaved'), 0)
                     },
                 })
-                if (!destroyed) setReady({ provider: p, ydoc, user })
+                if (!destroyed) {
+                    setReady({ provider: p, ydoc, user })
+                    onProviderReady?.(p)
+                }
             })
 
         return () => {

--- a/apps/web/components/editor/CollabEditor.tsx
+++ b/apps/web/components/editor/CollabEditor.tsx
@@ -1297,7 +1297,7 @@ function ToolbarDropdown({ value, options, onSelect, disabled, title, minWidth =
                 <IconChevronDown />
             </button>
             <PortalMenu open={open} onClose={() => setOpen(false)} triggerRef={triggerRef} align='left' minWidth={Math.max(minWidth, 120)}>
-                <div style={{ padding: 4, display: 'flex', flexDirection: 'column', maxHeight: 280, overflowY: 'auto' }}>
+                <div className='thin-scroll' style={{ padding: 4, display: 'flex', flexDirection: 'column', maxHeight: 280, overflowY: 'auto' }}>
                     {options.map(o => (
                         <button key={o.value} type='button'
                             onMouseDown={e => e.preventDefault()}

--- a/apps/web/components/editor/CollabEditor.tsx
+++ b/apps/web/components/editor/CollabEditor.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, { useContext, useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import { useEditor, EditorContent, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
 import type { Editor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
@@ -180,34 +181,43 @@ export default function CollabEditor({
     }, [documentId, ydoc])
 
     if (!ready) {
-        const { r: sr, g: sg, b: sb } = hexToRgb(themeColor)
-        const sc = (a: number) => `rgba(${sr},${sg},${sb},${a})`
+        // Token-only, full-bleed "connecting" state (visual-fixes FIX 5) —
+        // fills CollabEditor's own root exactly the way the ready-state
+        // editor column does (EditorShell's wrapper around `brief` already
+        // gives this a definite `height: 100%` to fill), centred both axes,
+        // no red. The skeleton lines echo the real document's own shape —
+        // eyebrow, title, three body lines — rather than arbitrary bars.
         return (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-                <style>{`@keyframes op-pulse{0%,100%{opacity:.35}50%{opacity:.75}}.op-pulse{animation:op-pulse 1.8s ease-in-out infinite}`}</style>
-                <div style={{ fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: sc(0.28), textAlign: 'center', paddingBottom: 4 }}>
-                    Connecting to collaboration server…
-                </div>
-                {[1, 0.6].map((opacity, i) => (
-                    <div key={i} style={{ border: `1px solid ${sc(0.1)}`, borderTop: `2px solid ${sc(0.25)}`, opacity }}>
-                        <div style={{ background: 'rgba(0,0,0,0.35)', padding: '9px 16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                                <div className='op-pulse' style={{ width: 6, height: 6, background: sc(0.35), flexShrink: 0 }} />
-                                <div className='op-pulse' style={{ height: 7, width: 110 + i * 30, background: sc(0.18), borderRadius: 2 }} />
-                            </div>
-                            <div style={{ display: 'flex', gap: 6 }}>
-                                {[28, 28, 28, 28, 28].map((w, j) => (
-                                    <div key={j} className='op-pulse' style={{ width: w, height: 24, background: 'rgba(255,255,255,0.04)', borderRadius: 2 }} />
-                                ))}
-                            </div>
-                        </div>
-                        <div style={{ padding: '20px 24px', display: 'flex', flexDirection: 'column', gap: 11 }}>
-                            {[88, 72, 80, 52].map((w, j) => (
-                                <div key={j} className='op-pulse' style={{ height: 8, width: `${w}%`, background: 'rgba(237,237,237,0.055)', borderRadius: 2, animationDelay: `${j * 0.12}s` }} />
-                            ))}
-                        </div>
+            <div style={{ height: '100%', width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--bg)' }}>
+                <style>{`
+                    @keyframes op-conn-pulse { 0%, 100% { opacity: .4; transform: scale(0.8); } 50% { opacity: 1; transform: scale(1); } }
+                    @keyframes op-conn-shimmer { 0% { background-position: -200px 0; } 100% { background-position: 200px 0; } }
+                    .op-conn-dot { animation: op-conn-pulse 1.4s ease-in-out infinite; }
+                    .op-conn-skel {
+                        background-image: linear-gradient(90deg, var(--s1) 0%, var(--s2) 50%, var(--s1) 100%);
+                        background-size: 240px 100%;
+                        background-repeat: no-repeat;
+                        animation: op-conn-shimmer 1.6s ease-in-out infinite;
+                    }
+                `}</style>
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 24, width: 'min(360px, 80%)' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <span className='op-conn-dot' style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--acc)', flexShrink: 0 }} />
+                        <span style={{ fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--ink-3)' }}>
+                            Connecting to collaboration server
+                        </span>
                     </div>
-                ))}
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, width: '100%' }}>
+                        {/* Eyebrow */}
+                        <div className='op-conn-skel' style={{ height: 7, width: '32%', borderRadius: 2 }} />
+                        {/* Title */}
+                        <div className='op-conn-skel' style={{ height: 15, width: '68%', borderRadius: 2, marginTop: 2, animationDelay: '0.1s' }} />
+                        {/* Body lines */}
+                        <div className='op-conn-skel' style={{ height: 9, width: '100%', borderRadius: 2, marginTop: 12, animationDelay: '0.2s' }} />
+                        <div className='op-conn-skel' style={{ height: 9, width: '91%', borderRadius: 2, animationDelay: '0.3s' }} />
+                        <div className='op-conn-skel' style={{ height: 9, width: '76%', borderRadius: 2, animationDelay: '0.4s' }} />
+                    </div>
+                </div>
             </div>
         )
     }
@@ -585,7 +595,22 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
         <ThemeContext.Provider value={themeColor}>
             <div style={{
                 display: 'flex', flexDirection: isMobile ? 'column' : 'row',
-                minHeight: '100%',
+                // `height`, not `minHeight` (visual-fixes FIX 3 regression fix):
+                // a box whose own `height` CSS property is unset (only
+                // `min-height` was) never counts as a "definite" containing
+                // block for a descendant's percentage height, even once the
+                // min-height constraint has forced its rendered box to fill
+                // the parent — so PageSidebar's own `height: 100%` a few
+                // levels down was resolving to `auto` (its own content
+                // height) instead of this row's height, which is why the
+                // rail stopped a quarter of the way down the viewport. Only
+                // an explicit `height` here — resolved against EditorShell's
+                // own definite wrapper — makes that chain actually definite.
+                // A long document still scrolls: nothing here clips
+                // overflow, so content taller than this row's own box still
+                // extends past it and is picked up by `.mainScroll`'s own
+                // `overflow-y: auto` exactly as before.
+                height: '100%',
                 // The rail (PageSidebar, orientation='sidebar') must sit flush
                 // against the shell's own left edge with no gap beside it
                 // (visual-fixes spec §1) — so no padding/gap here on desktop.
@@ -1057,33 +1082,153 @@ function EditorToolbar({ editor, uploadUrl, containerRef }: EditorToolbarProps) 
 }
 
 /**
+ * Shared positioning for every portalled toolbar menu (visual-fixes FIX 1
+ * regression fix): the TEXT/SIZE dropdowns and the "⋯" overflow popover used
+ * to render as a `position: absolute` child right next to their trigger,
+ * which worked until the toolbar picked up overflow handling — whatever
+ * ancestor now clips that overflow also clips an absolutely-positioned
+ * descendant, so the menus were getting cut off at the toolbar's own bottom
+ * edge and forcing an inner scrollbar onto the 44px bar itself.
+ *
+ * The fix is to portal the menu to `document.body` and position it with
+ * `position: fixed` computed from the trigger's own `getBoundingClientRect()`
+ * — nothing above `document.body` can clip it. This hook owns exactly that:
+ * measuring the trigger (and, once mounted, the menu itself, to decide
+ * whether to flip above when there's no room below), re-measuring on scroll
+ * (capture-phase, so `.mainScroll` scrolling underneath still repositions
+ * it) and window resize, and closing on outside click / Escape.
+ */
+function usePortalMenuPosition(
+    open: boolean,
+    triggerRef: React.RefObject<HTMLElement | null>,
+    menuRef: React.RefObject<HTMLElement | null>,
+    onClose: () => void,
+    align: 'left' | 'right' = 'left',
+) {
+    const [pos, setPos] = useState<{ top: number; left: number } | null>(null)
+
+    const recompute = useCallback(() => {
+        const trigger = triggerRef.current
+        if (!trigger) return
+        const rect = trigger.getBoundingClientRect()
+        const menuEl = menuRef.current
+        const menuW = menuEl?.offsetWidth ?? 0
+        const menuH = menuEl?.offsetHeight ?? 0
+        const spaceBelow = window.innerHeight - rect.bottom
+        // Flip above the trigger only when there's genuinely more room up
+        // there — never flip into negative space just because below is tight.
+        const flip = menuH > 0 && spaceBelow < menuH + 8 && rect.top > menuH + 8
+        const top = flip ? rect.top - 4 - menuH : rect.bottom + 4
+        let left = align === 'right' ? rect.right - menuW : rect.left
+        left = Math.min(Math.max(4, left), window.innerWidth - menuW - 4)
+        setPos({ top, left })
+    }, [triggerRef, menuRef, align])
+
+    // Runs after the portalled menu is committed to the DOM but before the
+    // browser paints, so `menuRef.current.offsetHeight` is already real by
+    // the time `recompute` reads it — no visible flash at the wrong spot.
+    useLayoutEffect(() => {
+        if (!open) { setPos(null); return }
+        recompute()
+    }, [open, recompute])
+
+    useEffect(() => {
+        if (!open) return
+        const onScroll = () => recompute()
+        const onResize = () => recompute()
+        window.addEventListener('scroll', onScroll, true)
+        window.addEventListener('resize', onResize)
+        return () => {
+            window.removeEventListener('scroll', onScroll, true)
+            window.removeEventListener('resize', onResize)
+        }
+    }, [open, recompute])
+
+    useEffect(() => {
+        if (!open) return
+        const closeOnOutside = (e: MouseEvent) => {
+            const target = e.target as Node
+            if (triggerRef.current?.contains(target)) return
+            if (menuRef.current?.contains(target)) return
+            onClose()
+        }
+        const closeOnEscape = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+        document.addEventListener('mousedown', closeOnOutside)
+        document.addEventListener('keydown', closeOnEscape)
+        return () => {
+            document.removeEventListener('mousedown', closeOnOutside)
+            document.removeEventListener('keydown', closeOnEscape)
+        }
+    }, [open, onClose, triggerRef, menuRef])
+
+    return pos
+}
+
+/**
+ * Portal wrapper shared by `ToolbarDropdown` and `ToolbarOverflowMenu` — see
+ * `usePortalMenuPosition` above for why this exists. `onMouseDown` on the
+ * portalled root still stops propagation (belt-and-suspenders alongside the
+ * containment check in the hook's outside-click listener), and every actual
+ * control rendered inside (`children`) is still responsible for its own
+ * `onMouseDown={e => e.preventDefault()}` — this wrapper doesn't add or
+ * remove any of that, it only relocates the DOM.
+ */
+function PortalMenu({ open, onClose, triggerRef, align = 'left', minWidth, children }: {
+    open: boolean
+    onClose: () => void
+    triggerRef: React.RefObject<HTMLElement | null>
+    align?: 'left' | 'right'
+    minWidth?: number
+    children: React.ReactNode
+}) {
+    const menuRef = useRef<HTMLDivElement>(null)
+    const pos = usePortalMenuPosition(open, triggerRef, menuRef, onClose, align)
+
+    if (!open) return null
+
+    return createPortal(
+        <div
+            ref={menuRef}
+            onMouseDown={e => e.stopPropagation()}
+            style={{
+                position: 'fixed',
+                top: pos ? pos.top : -9999,
+                left: pos ? pos.left : -9999,
+                visibility: pos ? 'visible' : 'hidden',
+                zIndex: 10000,
+                minWidth,
+                background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)',
+                boxShadow: '0 4px 20px rgba(0,0,0,0.6)',
+            }}
+        >
+            {children}
+        </div>,
+        document.body,
+    )
+}
+
+/**
  * The "⋯" overflow trigger + popover (visual-fixes FIX 1) — holds whichever
  * trailing groups `useToolbarOverflow` decided don't fit on the bar, in the
  * same fixed order they'd otherwise appear in. Every control inside still
  * goes through TIconBtn/TLabel/ToolbarDropdown, so the mousedown
  * preventDefault that keeps focus in the document (and this trigger button
- * itself, via TIconBtn) is never reintroduced as a regression here.
+ * itself, via TIconBtn) is never reintroduced as a regression here. The
+ * popover itself is portalled (see `PortalMenu`) — it used to render as a
+ * `position: absolute` sibling of the trigger, which is what let it get
+ * clipped once the toolbar picked up overflow handling.
  */
 function ToolbarOverflowMenu({ groups }: { groups: { key: string; node: React.ReactNode }[] }) {
     const [open, setOpen] = useState(false)
-    const ref = useRef<HTMLDivElement>(null)
-
-    useEffect(() => {
-        if (!open) return
-        const close = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) setOpen(false) }
-        document.addEventListener('mousedown', close)
-        return () => document.removeEventListener('mousedown', close)
-    }, [open])
+    const triggerRef = useRef<HTMLDivElement>(null)
 
     return (
-        <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
+        <div ref={triggerRef} style={{ position: 'relative', flexShrink: 0 }}>
             <TIconBtn title='More formatting options' active={open} onClick={() => setOpen(v => !v)}>
                 <IconMoreHoriz />
             </TIconBtn>
-            {open && (
-                <div onMouseDown={e => e.stopPropagation()}
-                    style={{ position: 'absolute', top: '110%', right: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: 6, display: 'flex', flexDirection: 'column', gap: 6, minWidth: 160, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
-                >
+            <PortalMenu open={open} onClose={() => setOpen(false)} triggerRef={triggerRef} align='right' minWidth={160}>
+                <div style={{ padding: 6, display: 'flex', flexDirection: 'column', gap: 6 }}>
                     {groups.map((g, i) => (
                         <React.Fragment key={g.key}>
                             {i > 0 && <div style={{ height: 1, background: 'var(--line)' }} />}
@@ -1093,7 +1238,7 @@ function ToolbarOverflowMenu({ groups }: { groups: { key: string; node: React.Re
                         </React.Fragment>
                     ))}
                 </div>
-            )}
+            </PortalMenu>
         </div>
     )
 }
@@ -1117,7 +1262,9 @@ const FONT_SIZE_OPTIONS = [
  * other control here gets — converting it to this component instead keeps
  * the block-type and text-size controls on the same interaction model (and
  * the same token-based styling) as everything else, rather than carving out
- * a focus-and-reapply special case just for these two.
+ * a focus-and-reapply special case just for these two. The option list is
+ * portalled (see `PortalMenu`) so it's never clipped by the toolbar's own
+ * box regardless of how many groups have been measured into the "⋯" popover.
  */
 function ToolbarDropdown({ value, options, onSelect, disabled, title, minWidth = 80 }: {
     value: string
@@ -1128,20 +1275,13 @@ function ToolbarDropdown({ value, options, onSelect, disabled, title, minWidth =
     minWidth?: number
 }) {
     const [open, setOpen] = useState(false)
-    const ref = useRef<HTMLDivElement>(null)
-
-    useEffect(() => {
-        if (!open) return
-        const close = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) setOpen(false) }
-        document.addEventListener('mousedown', close)
-        return () => document.removeEventListener('mousedown', close)
-    }, [open])
+    const triggerRef = useRef<HTMLButtonElement>(null)
 
     const current = options.find(o => o.value === value) || options[0]
 
     return (
-        <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
-            <button type='button' title={title} disabled={disabled}
+        <div style={{ position: 'relative', flexShrink: 0 }}>
+            <button ref={triggerRef} type='button' title={title} disabled={disabled}
                 onMouseDown={e => e.preventDefault()}
                 onClick={() => setOpen(v => !v)}
                 style={{
@@ -1156,10 +1296,8 @@ function ToolbarDropdown({ value, options, onSelect, disabled, title, minWidth =
                 <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{current.label}</span>
                 <IconChevronDown />
             </button>
-            {open && (
-                <div onMouseDown={e => e.stopPropagation()}
-                    style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: 4, display: 'flex', flexDirection: 'column', minWidth: Math.max(minWidth, 120), maxHeight: 280, overflowY: 'auto', boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
-                >
+            <PortalMenu open={open} onClose={() => setOpen(false)} triggerRef={triggerRef} align='left' minWidth={Math.max(minWidth, 120)}>
+                <div style={{ padding: 4, display: 'flex', flexDirection: 'column', maxHeight: 280, overflowY: 'auto' }}>
                     {options.map(o => (
                         <button key={o.value} type='button'
                             onMouseDown={e => e.preventDefault()}
@@ -1174,7 +1312,7 @@ function ToolbarDropdown({ value, options, onSelect, disabled, title, minWidth =
                         >{o.label}</button>
                     ))}
                 </div>
-            )}
+            </PortalMenu>
         </div>
     )
 }
@@ -1229,6 +1367,16 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
     const [isPublic, setIsPublic] = useState(true)
     const [sectionBorderColor, setSectionBorderColor] = useState<string | null>(null)
     const [sectionMinHeight, setSectionMinHeight] = useState(80)
+    // Eyebrow rename (visual-fixes FIX 4) — click to edit, commit on blur/
+    // Enter, cancel on Escape. Writes through the exact same field
+    // PageSidebar's own rename (`commitRename`) does: `pmeta-{pageId}`'s
+    // `title` key. No second write path — PageSidebar's rail and this
+    // eyebrow both end up reading/writing the one Y.Map, so a rename from
+    // either place shows up in the other via the normal Yjs observer
+    // ActiveEditor already has on that map (the `pageTitle` prop below is
+    // that same state, just handed down).
+    const [editingEyebrow, setEditingEyebrow] = useState(false)
+    const [eyebrowValue, setEyebrowValue] = useState('')
 
     const effectiveBorderColor = sectionBorderColor || themeColor
     // Accent tint via the operation's own --acc/--acc-rgb tokens (set on the
@@ -1301,6 +1449,22 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
             if (updates.borderColor !== undefined) smeta.set('borderColor', updates.borderColor)
             if (updates.minHeight !== undefined) smeta.set('minHeight', updates.minHeight)
         })
+    }
+
+    function startEyebrowEdit() {
+        if (readOnly) return
+        setEyebrowValue(pageTitle || '')
+        setEditingEyebrow(true)
+    }
+
+    // Same write path as PageSidebar.commitRename: the `pmeta-{pageId}` map's
+    // `title` key, same fallback rule for an emptied-out value.
+    function commitEyebrow() {
+        const docId = pageId || 'main'
+        const fallback = docId === 'main' ? 'CHQ Orders' : 'Untitled'
+        const trimmed = eyebrowValue.trim() || fallback
+        ydoc.getMap<string>('pmeta-' + docId).set('title', trimmed)
+        setEditingEyebrow(false)
     }
 
     const editor = useEditor({
@@ -1439,12 +1603,29 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
             <div style={{
                 display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12,
                 marginBottom: 18, padding: '6px 2px 14px', borderBottom: '1px solid var(--line)',
-                background: 'rgba(var(--acc-rgb), 0.02)',
             }}>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--ink-3)', marginBottom: 6 }}>
-                        {pageTitle}
-                    </div>
+                    {!readOnly && editingEyebrow ? (
+                        <input
+                            value={eyebrowValue}
+                            onChange={e => setEyebrowValue(e.target.value)}
+                            onBlur={commitEyebrow}
+                            onKeyDown={e => {
+                                if (e.key === 'Enter') { e.preventDefault(); commitEyebrow() }
+                                if (e.key === 'Escape') { e.preventDefault(); setEditingEyebrow(false) }
+                            }}
+                            autoFocus
+                            style={{ display: 'block', width: '100%', background: 'transparent', border: 'none', outline: 'none', padding: 0, fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--ink-3)', marginBottom: 6 }}
+                        />
+                    ) : (
+                        <div
+                            onClick={startEyebrowEdit}
+                            title={readOnly ? undefined : 'Click to rename document'}
+                            style={{ fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--ink-3)', marginBottom: 6, cursor: readOnly ? 'default' : 'text' }}
+                        >
+                            {pageTitle}
+                        </div>
+                    )}
                     {readOnly ? (
                         <div style={{ fontSize: 26, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink)' }}>{title}</div>
                     ) : (

--- a/apps/web/components/editor/CollabEditor.tsx
+++ b/apps/web/components/editor/CollabEditor.tsx
@@ -21,11 +21,10 @@ import PageSidebar from './PageSidebar'
 import IntelPackageEditor from './intel-package/IntelPackageEditor'
 import ImageLibraryModal from './ImageLibraryModal'
 import {
-    Undo, Redo,
-    FormatBold, FormatItalic, FormatUnderlined, StrikethroughS,
-    FormatListBulleted, FormatListNumbered,
+    Undo, Redo, StrikethroughS,
+    FormatListNumbered,
     FormatAlignLeft, FormatAlignCenter, FormatAlignRight,
-    FormatQuote, HorizontalRule, AddPhotoAlternate, FormatClear, FormatColorFill,
+    FormatQuote, HorizontalRule, FormatClear, FormatColorFill,
     InsertLink, LinkOff, Delete, Lock, LockOpen,
 } from '@mui/icons-material'
 
@@ -450,11 +449,9 @@ interface ActiveEditorProps {
 }
 
 function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSectionTitle, initialContent, onSaveStatusChange, themeColor = '#db001d', readOnly = false, synced = false, allowedTypes }: ActiveEditorProps) {
-    const { r, g, b } = hexToRgb(themeColor)
-    const c = (a: number) => `rgba(${r},${g},${b},${a})`
-
     const [activePage, setActivePage] = useState<string>('main')
     const [activePageType, setActivePageType] = useState<string>('orders')
+    const [activePageTitle, setActivePageTitle] = useState<string>('')
     const [sectionIds, setSectionIds] = useState<string[]>([])
     const [seedSectionId, setSeedSectionId] = useState<string | null>(null)
     const [peers, setPeers] = useState<Peer[]>([])
@@ -480,7 +477,13 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
 
     useEffect(() => {
         const pmeta = ydoc.getMap<string>('pmeta-' + activePage)
-        const read = () => setActivePageType(pmeta.get('pageType') || (activePage === 'main' ? 'orders' : 'orders'))
+        const read = () => {
+            setActivePageType(pmeta.get('pageType') || (activePage === 'main' ? 'orders' : 'orders'))
+            // Section eyebrow (visual-fixes spec §2) — the document's own
+            // title, read straight off the same pmeta map PageSidebar uses,
+            // not a new field.
+            setActivePageTitle(pmeta.get('title') || (activePage === 'main' ? 'CHQ Orders' : 'Untitled'))
+        }
         pmeta.observe(read)
         read()
         return () => pmeta.unobserve(read)
@@ -566,7 +569,17 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
 
     return (
         <ThemeContext.Provider value={themeColor}>
-            <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 20, alignItems: 'flex-start' }}>
+            <div style={{
+                display: 'flex', flexDirection: isMobile ? 'column' : 'row',
+                minHeight: '100%',
+                // The rail (PageSidebar, orientation='sidebar') must sit flush
+                // against the shell's own left edge with no gap beside it
+                // (visual-fixes spec §1) — so no padding/gap here on desktop.
+                // Mobile's 'top' orientation never had that flush-rail
+                // requirement, so it keeps the old padded/gapped treatment.
+                padding: isMobile ? 'clamp(1.5rem, 2.5vw, 2.5rem)' : 0,
+                gap: isMobile ? 16 : 0,
+            }}>
                 <PageSidebar
                     ydoc={ydoc}
                     activePage={activePage}
@@ -576,58 +589,64 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
                     synced={synced}
                     allowedTypes={allowedTypes}
                 />
-                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 16 }}>
-                    {activePageType !== 'intel' && (
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'flex-end' }}>
-                            <span style={{ fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.2)', marginRight: 2 }}>
-                                {readOnly ? 'Viewing' : 'Editing'}
-                            </span>
-                            <PresenceAvatar key='self' peer={{ clientId: -1, ...user }} self />
-                            {peers.map(peer => (
-                                <PresenceAvatar key={peer.clientId} peer={peer} />
-                            ))}
-                        </div>
-                    )}
+                <div style={{
+                    flex: 1, minWidth: 0,
+                    padding: isMobile ? 0 : 'clamp(1.5rem, 2.5vw, 2.5rem)',
+                }}>
+                    <div style={{ maxWidth: 740, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16 }}>
+                        {activePageType !== 'intel' && (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'flex-end' }}>
+                                <span style={{ fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-3)', marginRight: 2 }}>
+                                    {readOnly ? 'Viewing' : 'Editing'}
+                                </span>
+                                <PresenceAvatar key='self' peer={{ clientId: -1, ...user }} self />
+                                {peers.map(peer => (
+                                    <PresenceAvatar key={peer.clientId} peer={peer} />
+                                ))}
+                            </div>
+                        )}
 
-                    {activePageType === 'intel' ? (
-                        <IntelPackageEditor
-                            key={activePage}
-                            operationId={operationId}
-                            readOnly={readOnly}
-                            themeColor={themeColor}
-                        />
-                    ) : (
-                        <>
-                            {sectionIds.map((id, idx) => (
-                                <SectionEditor
-                                    key={`${activePage}-${id}`}
-                                    ydoc={ydoc}
-                                    sectionId={id}
-                                    pageId={activePage}
-                                    provider={provider}
-                                    user={user}
-                                    uploadUrl={uploadUrl}
-                                    onRemove={() => removeSection(id)}
-                                    onMoveUp={() => moveSection(id, 'up')}
-                                    onMoveDown={() => moveSection(id, 'down')}
-                                    canMoveUp={idx > 0}
-                                    canMoveDown={idx < sectionIds.length - 1}
-                                    themeColor={themeColor}
-                                    readOnly={readOnly}
-                                    seedContent={activePage === 'main' && id === seedSectionId ? initialContent : undefined}
-                                />
-                            ))}
-                            {!readOnly && (
-                                <button type='button' onClick={addSection}
-                                    style={{ alignSelf: 'flex-start', padding: '7px 16px', background: 'transparent', border: `1px dashed ${c(0.3)}`, color: c(0.55), fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', cursor: 'pointer', transition: 'all 0.15s' }}
-                                    onMouseEnter={e => { e.currentTarget.style.borderColor = c(0.7); e.currentTarget.style.color = c(0.9) }}
-                                    onMouseLeave={e => { e.currentTarget.style.borderColor = c(0.3); e.currentTarget.style.color = c(0.55) }}
-                                >
-                                    + Add Section
-                                </button>
-                            )}
-                        </>
-                    )}
+                        {activePageType === 'intel' ? (
+                            <IntelPackageEditor
+                                key={activePage}
+                                operationId={operationId}
+                                readOnly={readOnly}
+                                themeColor={themeColor}
+                            />
+                        ) : (
+                            <>
+                                {sectionIds.map((id, idx) => (
+                                    <SectionEditor
+                                        key={`${activePage}-${id}`}
+                                        ydoc={ydoc}
+                                        sectionId={id}
+                                        pageId={activePage}
+                                        pageTitle={activePageTitle}
+                                        provider={provider}
+                                        user={user}
+                                        uploadUrl={uploadUrl}
+                                        onRemove={() => removeSection(id)}
+                                        onMoveUp={() => moveSection(id, 'up')}
+                                        onMoveDown={() => moveSection(id, 'down')}
+                                        canMoveUp={idx > 0}
+                                        canMoveDown={idx < sectionIds.length - 1}
+                                        themeColor={themeColor}
+                                        readOnly={readOnly}
+                                        seedContent={activePage === 'main' && id === seedSectionId ? initialContent : undefined}
+                                    />
+                                ))}
+                                {!readOnly && (
+                                    <button type='button' onClick={addSection}
+                                        style={{ alignSelf: 'flex-start', padding: '6px 2px', background: 'transparent', border: 'none', color: 'var(--ink-3)', fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', cursor: 'pointer', transition: 'color 0.15s' }}
+                                        onMouseEnter={e => { e.currentTarget.style.color = 'var(--ink)' }}
+                                        onMouseLeave={e => { e.currentTarget.style.color = 'var(--ink-3)' }}
+                                    >
+                                        + Add Section
+                                    </button>
+                                )}
+                            </>
+                        )}
+                    </div>
                 </div>
             </div>
         </ThemeContext.Provider>
@@ -640,6 +659,10 @@ interface SectionEditorProps {
     ydoc: Y.Doc
     sectionId: string
     pageId?: string
+    /** The active document's own title — the section's eyebrow label (visual-
+     * fixes spec §2). Read once in ActiveEditor off the same `pmeta` map
+     * PageSidebar already uses, not a new field. */
+    pageTitle?: string
     provider: HocuspocusProvider
     user: PresenceUser
     uploadUrl: string
@@ -653,10 +676,7 @@ interface SectionEditorProps {
     seedContent?: any
 }
 
-function SectionEditor({ ydoc, sectionId, pageId, provider, user, uploadUrl, onRemove, onMoveUp, onMoveDown, canMoveUp, canMoveDown, themeColor = '#db001d', readOnly = false, seedContent }: SectionEditorProps) {
-    const { r, g, b } = hexToRgb(themeColor)
-    const c = (a: number) => `rgba(${r},${g},${b},${a})`
-
+function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, uploadUrl, onRemove, onMoveUp, onMoveDown, canMoveUp, canMoveDown, themeColor = '#db001d', readOnly = false, seedContent }: SectionEditorProps) {
     const isNonMain = pageId && pageId !== 'main'
     const metaKey = isNonMain ? `smeta-${pageId}-${sectionId}` : `smeta-${sectionId}`
     const contentKey = isNonMain ? `scontent-${pageId}-${sectionId}` : `scontent-${sectionId}`
@@ -667,19 +687,37 @@ function SectionEditor({ ydoc, sectionId, pageId, provider, user, uploadUrl, onR
     const [sectionMinHeight, setSectionMinHeight] = useState(80)
 
     const effectiveBorderColor = sectionBorderColor || themeColor
+    // Accent tint via the operation's own --acc/--acc-rgb tokens (set on the
+    // shell root — EditorShell.tsx) rather than a themeColor-derived rgba()
+    // helper: same colour, token-backed per the visual-fixes design tokens
+    // rule. blockquote/hr/mark/list-marker rules restyled for spec §2 (quote
+    // → card-style callout with a corner tick, bullets → accent squares);
+    // h1/h2/a keep the same tint treatment they always had.
     const themeCSS = `
         .op-editor-${sectionId} { min-height: ${sectionMinHeight}px; }
-        .op-editor-${sectionId} h1 { border-left-color: ${c(0.75)}; background: ${c(0.045)}; }
-        .op-editor-${sectionId} h2 { color: ${c(0.88)}; }
-        .op-editor-${sectionId} h2::before { color: ${c(0.65)}; }
-        .op-editor-${sectionId} ul li::marker { color: ${c(0.6)}; }
-        .op-editor-${sectionId} ol li::marker { color: ${c(0.6)}; }
-        .op-editor-${sectionId} blockquote { border-left-color: ${c(0.5)}; background: ${c(0.04)}; }
-        .op-editor-${sectionId} hr { border-top-color: ${c(0.2)}; }
-        .op-editor-${sectionId} mark { background: ${c(0.2)}; }
-        .op-editor-${sectionId} a { color: ${c(0.85)}; }
+        .op-editor-${sectionId} h1 { border-left-color: rgba(var(--acc-rgb), 0.75); background: rgba(var(--acc-rgb), 0.045); }
+        .op-editor-${sectionId} h2 { color: rgba(var(--acc-rgb), 0.88); }
+        .op-editor-${sectionId} h2::before { color: rgba(var(--acc-rgb), 0.65); }
+        .op-editor-${sectionId} ul { list-style: none; padding-left: 1.2em; }
+        .op-editor-${sectionId} ul li { position: relative; }
+        .op-editor-${sectionId} ul li::before { content: ''; position: absolute; left: -1.1em; top: 0.6em; width: 5px; height: 5px; background: var(--acc); }
+        .op-editor-${sectionId} ol li::marker { color: rgba(var(--acc-rgb), 0.6); }
+        .op-editor-${sectionId} blockquote {
+            position: relative; margin: 1.2em 0; padding: 14px 18px;
+            border: 1px solid var(--line); border-radius: var(--r);
+            background: linear-gradient(180deg, var(--s1), var(--bg));
+        }
+        .op-editor-${sectionId} blockquote::before {
+            content: ''; position: absolute; top: 0; left: 0; width: 36px; height: 2px;
+            background: var(--acc); opacity: 0.75;
+        }
+        .op-editor-${sectionId} hr { border-top-color: var(--line-2); }
+        .op-editor-${sectionId} mark { background: rgba(var(--acc-rgb), 0.2); }
+        .op-editor-${sectionId} a { color: rgba(var(--acc-rgb), 0.85); }
     `
     const [confirmingRemove, setConfirmingRemove] = useState(false)
+    const [hovered, setHovered] = useState(false)
+    const [toolbarOverflowOpen, setToolbarOverflowOpen] = useState(false)
     const [imagePopoverOpen, setImagePopoverOpen] = useState(false)
     const [showImageLibrary, setShowImageLibrary] = useState(false)
     const seededRef = useRef(false)
@@ -842,182 +880,225 @@ function SectionEditor({ ydoc, sectionId, pageId, provider, user, uploadUrl, onR
 
     if (!editor) return null
 
+    // Drives the toolbar's block-style select — 0 means "plain paragraph",
+    // matching whichever of H1/H2/H3 (if any) the cursor is currently in.
+    const currentHeadingLevel = ([1, 2, 3] as const).find(l => editor.isActive('heading', { level: l })) ?? 0
+    const chromeVisible = hovered || confirmingRemove
+
     return (
-        <div style={{ border: `1px solid ${c(0.15)}`, borderTop: `3px solid ${effectiveBorderColor}`, background: 'rgba(255,255,255,0.01)', position: 'relative' }}>
+        <div style={{ position: 'relative' }}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => { setHovered(false); setToolbarOverflowOpen(false) }}
+        >
             <style>{themeCSS}</style>
 
-            {/* Section header */}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 12px', borderBottom: '1px solid rgba(255,255,255,0.05)', background: 'rgba(0,0,0,0.25)' }}>
-                {readOnly ? (
-                    <span style={{ flex: 1, color: 'rgba(237,237,237,0.7)', fontSize: '0.78rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase' }}>{title}</span>
-                ) : (
-                    <input
-                        value={title}
-                        onChange={e => updateMeta({ title: e.target.value })}
-                        placeholder='Section Title'
-                        style={{ flex: 1, background: 'transparent', border: 'none', borderBottom: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.85)', fontSize: '0.78rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', outline: 'none', padding: '2px 0' }}
-                    />
-                )}
-                {!readOnly && (<>
-                    {/* Border color picker */}
-                    <div style={{ position: 'relative', flexShrink: 0 }}>
-                        <input ref={borderColorInputRef} type='color'
-                            value={sectionBorderColor || themeColor}
-                            onChange={e => updateMeta({ borderColor: e.target.value })}
-                            style={{ position: 'absolute', opacity: 0, width: 0, height: 0, pointerEvents: 'none' }}
-                        />
-                        <button type='button' title='Section border colour' onClick={() => borderColorInputRef.current?.click()}
-                            style={{ width: 16, height: 16, borderRadius: 2, background: effectiveBorderColor, border: '1px solid rgba(255,255,255,0.25)', cursor: 'pointer', display: 'block', flexShrink: 0 }}
-                        />
+            {/* Eyebrow (document name) + section title + accent rule — the
+                section's chrome (colour/visibility/reorder/delete) is a
+                hover-revealed row alongside it rather than a permanent bar
+                (visual-fixes spec §2). */}
+            <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: 10 }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--ink-3)', marginBottom: 6 }}>
+                        {pageTitle}
                     </div>
-                    <button type='button'
-                        title={isPublic ? 'Publicly visible — click to make private' : 'Members only — click to make public'}
-                        onClick={() => updateMeta({ isPublic: !isPublic })}
-                        style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 10px', background: isPublic ? 'rgba(100,220,100,0.07)' : 'rgba(219,180,0,0.07)', border: `1px solid ${isPublic ? 'rgba(100,220,100,0.25)' : 'rgba(219,180,0,0.3)'}`, color: isPublic ? 'rgba(100,220,100,0.8)' : 'rgba(219,180,0,0.8)', fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', cursor: 'pointer', flexShrink: 0, transition: 'all 0.15s' }}
-                    >
-                        {isPublic ? <><LockOpen style={{ fontSize: 12 }} /> Public</> : <><Lock style={{ fontSize: 12 }} /> Members Only</>}
-                    </button>
-                    <div style={{ display: 'flex', gap: 2, flexShrink: 0 }}>
+                    {readOnly ? (
+                        <div style={{ fontSize: 26, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink)' }}>{title}</div>
+                    ) : (
+                        <input
+                            value={title}
+                            onChange={e => updateMeta({ title: e.target.value })}
+                            placeholder='Section Title'
+                            style={{ width: '100%', background: 'transparent', border: 'none', outline: 'none', fontSize: 26, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink)', padding: 0 }}
+                        />
+                    )}
+                    <div style={{ width: 36, height: 2, background: 'var(--acc)', opacity: 0.75, marginTop: 10 }} />
+                </div>
+
+                {!readOnly && (
+                    <div style={{
+                        display: 'flex', alignItems: 'center', gap: 3, flexShrink: 0, paddingTop: 2,
+                        opacity: chromeVisible ? 1 : 0, pointerEvents: chromeVisible ? 'auto' : 'none', transition: 'opacity 0.12s',
+                    }}>
+                        {/* Section accent colour picker */}
+                        <div style={{ position: 'relative', flexShrink: 0 }}>
+                            <input ref={borderColorInputRef} type='color'
+                                value={sectionBorderColor || themeColor}
+                                onChange={e => updateMeta({ borderColor: e.target.value })}
+                                style={{ position: 'absolute', opacity: 0, width: 0, height: 0, pointerEvents: 'none' }}
+                            />
+                            <button type='button' title='Section accent colour' onClick={() => borderColorInputRef.current?.click()}
+                                style={{ width: 14, height: 14, borderRadius: 2, background: effectiveBorderColor, border: '1px solid var(--line-2)', cursor: 'pointer', display: 'block' }}
+                            />
+                        </div>
+                        <button type='button'
+                            title={isPublic ? 'Publicly visible — click to make private' : 'Members only — click to make public'}
+                            onClick={() => updateMeta({ isPublic: !isPublic })}
+                            style={{ display: 'flex', alignItems: 'center', background: 'none', border: 'none', color: isPublic ? 'var(--good)' : 'var(--warn)', cursor: 'pointer', padding: 3 }}
+                        >
+                            {isPublic ? <LockOpen style={{ fontSize: 13 }} /> : <Lock style={{ fontSize: 13 }} />}
+                        </button>
                         <button type='button' title='Move section up' onClick={onMoveUp} disabled={!canMoveUp}
-                            style={{ display: 'flex', alignItems: 'center', background: 'none', border: 'none', color: canMoveUp ? 'rgba(237,237,237,0.3)' : 'rgba(237,237,237,0.08)', cursor: canMoveUp ? 'pointer' : 'default', padding: '2px 4px', fontSize: '0.75rem', lineHeight: 1, transition: 'color 0.15s' }}
-                            onMouseEnter={e => { if (canMoveUp) e.currentTarget.style.color = 'rgba(237,237,237,0.8)' }}
-                            onMouseLeave={e => { if (canMoveUp) e.currentTarget.style.color = 'rgba(237,237,237,0.3)' }}
+                            style={{ display: 'flex', alignItems: 'center', background: 'none', border: 'none', color: canMoveUp ? 'var(--ink-3)' : 'var(--line-2)', cursor: canMoveUp ? 'pointer' : 'default', padding: '3px 2px', fontSize: '0.7rem', lineHeight: 1 }}
                         >▲</button>
                         <button type='button' title='Move section down' onClick={onMoveDown} disabled={!canMoveDown}
-                            style={{ display: 'flex', alignItems: 'center', background: 'none', border: 'none', color: canMoveDown ? 'rgba(237,237,237,0.3)' : 'rgba(237,237,237,0.08)', cursor: canMoveDown ? 'pointer' : 'default', padding: '2px 4px', fontSize: '0.75rem', lineHeight: 1, transition: 'color 0.15s' }}
-                            onMouseEnter={e => { if (canMoveDown) e.currentTarget.style.color = 'rgba(237,237,237,0.8)' }}
-                            onMouseLeave={e => { if (canMoveDown) e.currentTarget.style.color = 'rgba(237,237,237,0.3)' }}
+                            style={{ display: 'flex', alignItems: 'center', background: 'none', border: 'none', color: canMoveDown ? 'var(--ink-3)' : 'var(--line-2)', cursor: canMoveDown ? 'pointer' : 'default', padding: '3px 2px', fontSize: '0.7rem', lineHeight: 1 }}
                         >▼</button>
+                        {confirmingRemove ? (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                                <button type='button' onClick={onRemove} style={{ fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#fff', background: 'var(--crit)', border: '1px solid var(--crit)', padding: '2px 6px', cursor: 'pointer', borderRadius: 'var(--r)' }}>Yes</button>
+                                <button type='button' onClick={() => setConfirmingRemove(false)} style={{ fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--ink-3)', background: 'none', border: '1px solid var(--line-2)', padding: '2px 6px', cursor: 'pointer', borderRadius: 'var(--r)' }}>No</button>
+                            </div>
+                        ) : (
+                            <button type='button' title='Remove section' onClick={() => setConfirmingRemove(true)}
+                                style={{ display: 'flex', alignItems: 'center', background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer', padding: 3 }}
+                                onMouseEnter={e => (e.currentTarget.style.color = 'var(--crit)')}
+                                onMouseLeave={e => (e.currentTarget.style.color = 'var(--ink-3)')}
+                            >
+                                <Delete style={{ fontSize: 14 }} />
+                            </button>
+                        )}
                     </div>
-                    {confirmingRemove ? (
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
-                            <span style={{ fontSize: '0.6rem', color: 'rgba(219,0,29,0.7)', letterSpacing: '0.08em' }}>Remove section?</span>
-                            <button type='button' onClick={onRemove} style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'rgba(219,0,29,0.9)', background: 'rgba(219,0,29,0.1)', border: '1px solid rgba(219,0,29,0.3)', padding: '3px 8px', cursor: 'pointer' }}>Yes</button>
-                            <button type='button' onClick={() => setConfirmingRemove(false)} style={{ fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.4)', background: 'none', border: '1px solid rgba(255,255,255,0.1)', padding: '3px 8px', cursor: 'pointer' }}>No</button>
-                        </div>
-                    ) : (
-                        <button type='button' title='Remove section' onClick={() => setConfirmingRemove(true)}
-                            style={{ display: 'flex', alignItems: 'center', background: 'none', border: 'none', color: 'rgba(237,237,237,0.2)', cursor: 'pointer', padding: 4, flexShrink: 0, transition: 'color 0.15s' }}
-                            onMouseEnter={e => (e.currentTarget.style.color = 'rgba(219,0,29,0.7)')}
-                            onMouseLeave={e => (e.currentTarget.style.color = 'rgba(237,237,237,0.2)')}
-                        >
-                            <Delete style={{ fontSize: 16 }} />
-                        </button>
-                    )}
-                </>)}
+                )}
             </div>
 
-            {/* Toolbar */}
-            <div style={{ display: readOnly ? 'none' : 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 2, padding: '7px 10px', background: 'rgb(10,10,10)', borderBottom: '1px solid rgba(255,255,255,0.08)', boxShadow: '0 2px 8px rgba(0,0,0,0.6)', position: 'sticky', top: 0, zIndex: 20 }}>
-                <TBtn title='Undo' onClick={() => editor.chain().focus().undo().run()}><Undo style={{ fontSize: 16 }} /></TBtn>
-                <TBtn title='Redo' onClick={() => editor.chain().focus().redo().run()}><Redo style={{ fontSize: 16 }} /></TBtn>
-                <TDivider />
-                {([1, 2, 3] as const).map(level => (
-                    <TBtn key={level} title={`Heading ${level}`} active={editor.isActive('heading', { level })} onClick={() => editor.chain().focus().toggleHeading({ level }).run()}>
-                        <span style={{ fontSize: '0.65rem', fontWeight: 800, letterSpacing: '0.05em' }}>H{level}</span>
-                    </TBtn>
-                ))}
+            {/* Toolbar — one slim row: block style, B/I/U, list, image, and an
+                overflow menu for everything else (visual-fixes spec §2). */}
+            <div style={{ display: readOnly ? 'none' : 'flex', alignItems: 'center', gap: 2, height: 44, borderBottom: '1px solid var(--line)', marginBottom: 18 }}>
                 <select
-                    value={(editor.getAttributes('textStyle').fontSize as string | undefined) || ''}
+                    value={String(currentHeadingLevel)}
                     onChange={e => {
-                        if (e.target.value) (editor.chain().focus() as any).setFontSize(e.target.value).run()
-                        else (editor.chain().focus() as any).unsetFontSize().run()
+                        const lvl = Number(e.target.value)
+                        if (lvl === 0) editor.chain().focus().setParagraph().run()
+                        else editor.chain().focus().setHeading({ level: lvl as 1 | 2 | 3 }).run()
                     }}
-                    title='Font size'
-                    style={{ background: 'rgba(0,0,0,0.4)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(237,237,237,0.6)', fontSize: '0.65rem', padding: '0 4px', cursor: 'pointer', height: 28, outline: 'none', minWidth: 52 }}>
-                    <option value=''>Size</option>
-                    {[10, 11, 12, 13, 14, 16, 18, 20, 24, 28, 32, 36, 48].map(s => (
-                        <option key={s} value={`${s}px`}>{s}</option>
-                    ))}
+                    title='Block style'
+                    style={{ background: 'none', border: 'none', color: 'var(--ink-2)', fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', padding: '4px 6px', cursor: 'pointer', outline: 'none' }}
+                >
+                    <option value='0'>Text</option>
+                    <option value='1'>Heading 1</option>
+                    <option value='2'>Heading 2</option>
+                    <option value='3'>Heading 3</option>
                 </select>
-                <TDivider />
-                <TBtn title='Bold' active={editor.isActive('bold')} onClick={() => editor.chain().focus().toggleBold().run()}><FormatBold style={{ fontSize: 17 }} /></TBtn>
-                <TBtn title='Italic' active={editor.isActive('italic')} onClick={() => editor.chain().focus().toggleItalic().run()}><FormatItalic style={{ fontSize: 17 }} /></TBtn>
-                <TBtn title='Underline' active={editor.isActive('underline')} onClick={() => editor.chain().focus().toggleUnderline().run()}><FormatUnderlined style={{ fontSize: 17 }} /></TBtn>
-                <TBtn title='Strikethrough' active={editor.isActive('strike')} onClick={() => editor.chain().focus().toggleStrike().run()}><StrikethroughS style={{ fontSize: 17 }} /></TBtn>
-                <TBtn title='Highlight' active={editor.isActive('highlight')} onClick={() => editor.chain().focus().toggleHighlight().run()}><FormatColorFill style={{ fontSize: 17 }} /></TBtn>
-                <TDivider />
-                <TBtn title='Align Left' active={editor.isActive({ textAlign: 'left' })} onClick={() => editor.chain().focus().setTextAlign('left').run()}><FormatAlignLeft style={{ fontSize: 17 }} /></TBtn>
-                <TBtn title='Align Centre' active={editor.isActive({ textAlign: 'center' })} onClick={() => editor.chain().focus().setTextAlign('center').run()}><FormatAlignCenter style={{ fontSize: 17 }} /></TBtn>
-                <TBtn title='Align Right' active={editor.isActive({ textAlign: 'right' })} onClick={() => editor.chain().focus().setTextAlign('right').run()}><FormatAlignRight style={{ fontSize: 17 }} /></TBtn>
-                <TDivider />
-                <TBtn title='Bullet List' active={editor.isActive('bulletList')} onClick={() => editor.chain().focus().toggleBulletList().run()}><FormatListBulleted style={{ fontSize: 17 }} /></TBtn>
-                <TBtn title='Numbered List' active={editor.isActive('orderedList')} onClick={() => editor.chain().focus().toggleOrderedList().run()}><FormatListNumbered style={{ fontSize: 17 }} /></TBtn>
-                <TDivider />
-                <TBtn title='Quote' active={editor.isActive('blockquote')} onClick={() => editor.chain().focus().toggleBlockquote().run()}><FormatQuote style={{ fontSize: 17 }} /></TBtn>
-                <TBtn title='Section Divider' onClick={() => editor.chain().focus().setHorizontalRule().run()}><HorizontalRule style={{ fontSize: 17 }} /></TBtn>
-                <TDivider />
+                <TLabel title='Bold' active={editor.isActive('bold')} onClick={() => editor.chain().focus().toggleBold().run()}>B</TLabel>
+                <TLabel title='Italic' active={editor.isActive('italic')} onClick={() => editor.chain().focus().toggleItalic().run()}>I</TLabel>
+                <TLabel title='Underline' active={editor.isActive('underline')} onClick={() => editor.chain().focus().toggleUnderline().run()}>U</TLabel>
+                <div style={{ width: 1, height: 16, background: 'var(--line)', margin: '0 4px' }} />
+                <TLabel title='Bullet List' active={editor.isActive('bulletList')} onClick={() => editor.chain().focus().toggleBulletList().run()}>List</TLabel>
                 <div style={{ position: 'relative' }}>
-                    <TBtn title={uploadingImage ? 'Uploading...' : 'Insert Image'} active={uploadingImage || imagePopoverOpen}
+                    <TLabel title={uploadingImage ? 'Uploading…' : 'Insert Image'} active={uploadingImage || imagePopoverOpen}
                         onClick={() => { if (!uploadingImage) setImagePopoverOpen(v => !v) }}
                     >
-                        <AddPhotoAlternate style={{ fontSize: 17, opacity: uploadingImage ? 0.4 : 1 }} />
-                    </TBtn>
+                        Image
+                    </TLabel>
                     {imagePopoverOpen && !uploadingImage && (
                         <div
                             onMouseDown={e => e.stopPropagation()}
-                            style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'rgba(14,14,14,0.97)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 4, padding: '4px 0', display: 'flex', flexDirection: 'column', minWidth: 190, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
+                            style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '4px 0', display: 'flex', flexDirection: 'column', minWidth: 190, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
                         >
                             <button type='button'
                                 onClick={() => { setImagePopoverOpen(false); imageInputRef.current?.click() }}
-                                style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'rgba(237,237,237,0.7)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
-                                onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.06)')}
+                                style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
+                                onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
                                 onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
                             >Upload from Computer</button>
                             <button type='button'
                                 onClick={() => { setImagePopoverOpen(false); setShowImageLibrary(true) }}
-                                style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'rgba(237,237,237,0.7)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
-                                onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.06)')}
+                                style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
+                                onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
                                 onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
                             >Select from Library</button>
                         </div>
                     )}
                 </div>
+
+                <div style={{ flex: 1 }} />
+
+                {/* Overflow — undo/redo, font size, strike/highlight, align,
+                    numbered list, quote, divider, link, clear formatting.
+                    Same commands the old 20-button row exposed directly;
+                    only their visibility moved. */}
                 <div style={{ position: 'relative' }}>
-                    <TBtn title={editor.isActive('link') ? 'Edit Link' : 'Insert Link'} active={editor.isActive('link')}
-                        onClick={() => {
-                            const existing = editor.getAttributes('link').href || ''
-                            setLinkUrl(existing)
-                            setLinkText('')
-                            setLinkPopover(v => !v)
-                            const noSel = editor.state.selection.empty
-                            setTimeout(() => (noSel ? linkTextInputRef.current : linkUrlInputRef.current)?.focus(), 40)
-                        }}
-                    >
-                        <InsertLink style={{ fontSize: 17 }} />
-                    </TBtn>
-                    {linkPopover && (
-                        <div {...{ [`data-link-popover-${sectionId}`]: true }} onMouseDown={e => e.stopPropagation()}
-                            style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'rgba(14,14,14,0.97)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 4, padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 280, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
+                    <TLabel title='More formatting' active={toolbarOverflowOpen} onClick={() => setToolbarOverflowOpen(v => !v)}>⋯</TLabel>
+                    {toolbarOverflowOpen && (
+                        <div
+                            onMouseDown={e => e.stopPropagation()}
+                            style={{ position: 'absolute', top: '110%', right: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: 6, display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 2, width: 232, boxShadow: '0 8px 24px rgba(0,0,0,0.5)' }}
                         >
-                            {editor.state.selection.empty && (
-                                <input ref={linkTextInputRef} value={linkText} onChange={e => setLinkText(e.target.value)} placeholder='Display text'
-                                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); linkUrlInputRef.current?.focus() } if (e.key === 'Escape') setLinkPopover(false) }}
-                                    style={{ background: 'transparent', border: 'none', borderBottom: '1px solid rgba(255,255,255,0.15)', color: 'rgba(237,237,237,0.85)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
-                                />
-                            )}
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                                <input ref={linkUrlInputRef} value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder='https://…'
-                                    onKeyDown={e => {
-                                        if (e.key === 'Enter') { e.preventDefault(); applyLink() }
-                                        if (e.key === 'Escape') setLinkPopover(false)
+                            <TBtn title='Undo' onClick={() => editor.chain().focus().undo().run()}><Undo style={{ fontSize: 16 }} /></TBtn>
+                            <TBtn title='Redo' onClick={() => editor.chain().focus().redo().run()}><Redo style={{ fontSize: 16 }} /></TBtn>
+                            <TDivider />
+                            <TBtn title='Strikethrough' active={editor.isActive('strike')} onClick={() => editor.chain().focus().toggleStrike().run()}><StrikethroughS style={{ fontSize: 17 }} /></TBtn>
+                            <TBtn title='Highlight' active={editor.isActive('highlight')} onClick={() => editor.chain().focus().toggleHighlight().run()}><FormatColorFill style={{ fontSize: 17 }} /></TBtn>
+                            <TDivider />
+                            <TBtn title='Align Left' active={editor.isActive({ textAlign: 'left' })} onClick={() => editor.chain().focus().setTextAlign('left').run()}><FormatAlignLeft style={{ fontSize: 17 }} /></TBtn>
+                            <TBtn title='Align Centre' active={editor.isActive({ textAlign: 'center' })} onClick={() => editor.chain().focus().setTextAlign('center').run()}><FormatAlignCenter style={{ fontSize: 17 }} /></TBtn>
+                            <TBtn title='Align Right' active={editor.isActive({ textAlign: 'right' })} onClick={() => editor.chain().focus().setTextAlign('right').run()}><FormatAlignRight style={{ fontSize: 17 }} /></TBtn>
+                            <TDivider />
+                            <TBtn title='Numbered List' active={editor.isActive('orderedList')} onClick={() => editor.chain().focus().toggleOrderedList().run()}><FormatListNumbered style={{ fontSize: 17 }} /></TBtn>
+                            <TBtn title='Quote' active={editor.isActive('blockquote')} onClick={() => editor.chain().focus().toggleBlockquote().run()}><FormatQuote style={{ fontSize: 17 }} /></TBtn>
+                            <TBtn title='Section Divider' onClick={() => editor.chain().focus().setHorizontalRule().run()}><HorizontalRule style={{ fontSize: 17 }} /></TBtn>
+                            <TDivider />
+                            <div style={{ position: 'relative' }}>
+                                <TBtn title={editor.isActive('link') ? 'Edit Link' : 'Insert Link'} active={editor.isActive('link')}
+                                    onClick={() => {
+                                        const existing = editor.getAttributes('link').href || ''
+                                        setLinkUrl(existing)
+                                        setLinkText('')
+                                        setLinkPopover(v => !v)
+                                        const noSel = editor.state.selection.empty
+                                        setTimeout(() => (noSel ? linkTextInputRef.current : linkUrlInputRef.current)?.focus(), 40)
                                     }}
-                                    style={{ flex: 1, background: 'transparent', border: 'none', borderBottom: '1px solid rgba(255,255,255,0.15)', color: 'rgba(237,237,237,0.85)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
-                                />
-                                <button type='button' onClick={applyLink}
-                                    style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: `rgba(${r},${g},${b},0.85)`, background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', flexShrink: 0 }}
-                                >Apply</button>
+                                >
+                                    <InsertLink style={{ fontSize: 17 }} />
+                                </TBtn>
+                                {linkPopover && (
+                                    <div {...{ [`data-link-popover-${sectionId}`]: true }} onMouseDown={e => e.stopPropagation()}
+                                        style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 280, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
+                                    >
+                                        {editor.state.selection.empty && (
+                                            <input ref={linkTextInputRef} value={linkText} onChange={e => setLinkText(e.target.value)} placeholder='Display text'
+                                                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); linkUrlInputRef.current?.focus() } if (e.key === 'Escape') setLinkPopover(false) }}
+                                                style={{ background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
+                                            />
+                                        )}
+                                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                                            <input ref={linkUrlInputRef} value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder='https://…'
+                                                onKeyDown={e => {
+                                                    if (e.key === 'Enter') { e.preventDefault(); applyLink() }
+                                                    if (e.key === 'Escape') setLinkPopover(false)
+                                                }}
+                                                style={{ flex: 1, background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
+                                            />
+                                            <button type='button' onClick={applyLink}
+                                                style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--acc)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', flexShrink: 0 }}
+                                            >Apply</button>
+                                        </div>
+                                    </div>
+                                )}
                             </div>
+                            <TBtn title='Remove Link' onClick={() => { editor.chain().focus().unsetLink().run(); setLinkPopover(false) }}>
+                                <LinkOff style={{ fontSize: 17 }} />
+                            </TBtn>
+                            <TDivider />
+                            <TBtn title='Clear Formatting' onClick={() => editor.chain().focus().clearNodes().unsetAllMarks().run()}>
+                                <FormatClear style={{ fontSize: 17 }} />
+                            </TBtn>
+                            <select
+                                value={(editor.getAttributes('textStyle').fontSize as string | undefined) || ''}
+                                onChange={e => {
+                                    if (e.target.value) (editor.chain().focus() as any).setFontSize(e.target.value).run()
+                                    else (editor.chain().focus() as any).unsetFontSize().run()
+                                }}
+                                title='Font size'
+                                style={{ background: 'var(--s3)', border: '1px solid var(--line-2)', color: 'var(--ink-2)', fontSize: '0.65rem', padding: '0 4px', cursor: 'pointer', height: 26, outline: 'none', minWidth: 52 }}>
+                                <option value=''>Size</option>
+                                {[10, 11, 12, 13, 14, 16, 18, 20, 24, 28, 32, 36, 48].map(s => (
+                                    <option key={s} value={`${s}px`}>{s}</option>
+                                ))}
+                            </select>
                         </div>
                     )}
                 </div>
-                <TBtn title='Remove Link' onClick={() => { editor.chain().focus().unsetLink().run(); setLinkPopover(false) }}>
-                    <LinkOff style={{ fontSize: 17 }} />
-                </TBtn>
-                <TDivider />
-                <TBtn title='Clear Formatting' onClick={() => editor.chain().focus().clearNodes().unsetAllMarks().run()}>
-                    <FormatClear style={{ fontSize: 17 }} />
-                </TBtn>
             </div>
 
             <EditorContent editor={editor} />
@@ -1076,4 +1157,29 @@ function TBtn({ onClick, active, title, children }: { onClick: () => void; activ
 
 function TDivider() {
     return <div style={{ width: 1, height: 18, background: 'rgba(255,255,255,0.1)', margin: '0 3px' }} />
+}
+
+/** Primary-toolbar control (visual-fixes spec §2): a quiet mono text label
+ * rather than an MUI icon — used for the small set of controls that stay
+ * visible on the slim main row (block style, B/I/U, list, image, the
+ * overflow toggle). Everything else keeps the icon-based `TBtn` inside the
+ * overflow panel. */
+function TLabel({ onClick, active, title, children }: { onClick: () => void; active?: boolean; title: string; children: React.ReactNode }) {
+    return (
+        <button type='button' title={title} onClick={onClick}
+            style={{
+                padding: '5px 8px',
+                background: active ? 'var(--s2)' : 'transparent',
+                border: 'none',
+                borderRadius: 'var(--r)',
+                color: active ? 'var(--ink)' : 'var(--ink-2)',
+                fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
+                cursor: 'pointer', transition: 'all 0.15s',
+            }}
+            onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--ink)' }}
+            onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--ink-2)' }}
+        >
+            {children}
+        </button>
+    )
 }

--- a/apps/web/components/editor/CollabEditor.tsx
+++ b/apps/web/components/editor/CollabEditor.tsx
@@ -2,6 +2,7 @@
 
 import React, { useContext, useEffect, useRef, useState } from 'react'
 import { useEditor, EditorContent, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import type { Editor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Image from '@tiptap/extension-image'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -456,6 +457,22 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
     const [seedSectionId, setSeedSectionId] = useState<string | null>(null)
     const [peers, setPeers] = useState<Peer[]>([])
     const [isMobile, setIsMobile] = useState(false)
+    // The one shared formatting toolbar (visual-fixes spec §1) dispatches to
+    // whichever section's editor last reported focus — set/cleared by each
+    // SectionEditor's own onFocus/onBlur below. null means "nothing focused",
+    // which the toolbar renders as disabled rather than guessing a target.
+    // `activeSectionId` drives each section's own focus ring (spec §3);
+    // kept separate from `activeEditor` because SectionEditor only knows its
+    // own id, not its own Editor instance, until useEditor() returns it.
+    const [activeEditor, setActiveEditor] = useState<Editor | null>(null)
+    const [activeSectionId, setActiveSectionId] = useState<string | null>(null)
+    // Lets the blur handler below tell "focus moved into the toolbar itself"
+    // (a button, a select, a popover — keep the target) apart from "focus
+    // left the document entirely" (clear it), via the blur event's
+    // relatedTarget. Without this, mousedown on a toolbar button blurs the
+    // editor and clears activeEditor before the button's own onClick (which
+    // reads activeEditor via the `editor` prop closure) ever runs.
+    const toolbarRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
         const check = () => setIsMobile(window.innerWidth < 768)
@@ -589,67 +606,334 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
                     synced={synced}
                     allowedTypes={allowedTypes}
                 />
-                <div style={{
-                    flex: 1, minWidth: 0,
-                    padding: isMobile ? 0 : 'clamp(1.5rem, 2.5vw, 2.5rem)',
-                }}>
-                    <div style={{ maxWidth: 740, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16 }}>
-                        {activePageType !== 'intel' && (
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'flex-end' }}>
-                                <span style={{ fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-3)', marginRight: 2 }}>
-                                    {readOnly ? 'Viewing' : 'Editing'}
-                                </span>
-                                <PresenceAvatar key='self' peer={{ clientId: -1, ...user }} self />
-                                {peers.map(peer => (
-                                    <PresenceAvatar key={peer.clientId} peer={peer} />
-                                ))}
-                            </div>
-                        )}
+                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+                    {/* One persistent formatting toolbar, owned by the column rather
+                        than any section (visual-fixes spec §1) — pinned above all
+                        document content and, via `position: sticky`, staying put as
+                        the content beneath it scrolls inside .mainScroll. It always
+                        targets `activeEditor`, the last section to report focus. */}
+                    {!readOnly && activePageType !== 'intel' && (
+                        <EditorToolbar editor={activeEditor} uploadUrl={uploadUrl} containerRef={toolbarRef} />
+                    )}
+                    <div style={{ flex: 1, padding: isMobile ? 0 : '24px 48px 40px' }}>
+                        {/* Widened measure (visual-fixes spec §2): ~1100-1200px rather
+                            than the old ~740px cap, so the document reads as a real
+                            writing surface instead of a phone-width column. */}
+                        <div style={{ maxWidth: 1160, margin: '0 auto', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', gap: 16 }}>
+                            {activePageType !== 'intel' && (
+                                <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'flex-end' }}>
+                                    <span style={{ fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-3)', marginRight: 2 }}>
+                                        {readOnly ? 'Viewing' : 'Editing'}
+                                    </span>
+                                    <PresenceAvatar key='self' peer={{ clientId: -1, ...user }} self />
+                                    {peers.map(peer => (
+                                        <PresenceAvatar key={peer.clientId} peer={peer} />
+                                    ))}
+                                </div>
+                            )}
 
-                        {activePageType === 'intel' ? (
-                            <IntelPackageEditor
-                                key={activePage}
-                                operationId={operationId}
-                                readOnly={readOnly}
-                                themeColor={themeColor}
-                            />
-                        ) : (
-                            <>
-                                {sectionIds.map((id, idx) => (
-                                    <SectionEditor
-                                        key={`${activePage}-${id}`}
-                                        ydoc={ydoc}
-                                        sectionId={id}
-                                        pageId={activePage}
-                                        pageTitle={activePageTitle}
-                                        provider={provider}
-                                        user={user}
-                                        uploadUrl={uploadUrl}
-                                        onRemove={() => removeSection(id)}
-                                        onMoveUp={() => moveSection(id, 'up')}
-                                        onMoveDown={() => moveSection(id, 'down')}
-                                        canMoveUp={idx > 0}
-                                        canMoveDown={idx < sectionIds.length - 1}
-                                        themeColor={themeColor}
-                                        readOnly={readOnly}
-                                        seedContent={activePage === 'main' && id === seedSectionId ? initialContent : undefined}
-                                    />
-                                ))}
-                                {!readOnly && (
-                                    <button type='button' onClick={addSection}
-                                        style={{ alignSelf: 'flex-start', padding: '6px 2px', background: 'transparent', border: 'none', color: 'var(--ink-3)', fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', cursor: 'pointer', transition: 'color 0.15s' }}
-                                        onMouseEnter={e => { e.currentTarget.style.color = 'var(--ink)' }}
-                                        onMouseLeave={e => { e.currentTarget.style.color = 'var(--ink-3)' }}
-                                    >
-                                        + Add Section
-                                    </button>
-                                )}
-                            </>
-                        )}
+                            {activePageType === 'intel' ? (
+                                <IntelPackageEditor
+                                    key={activePage}
+                                    operationId={operationId}
+                                    readOnly={readOnly}
+                                    themeColor={themeColor}
+                                />
+                            ) : (
+                                <div style={{ display: 'flex', flexDirection: 'column', flex: 1, gap: 40 }}>
+                                    {sectionIds.map((id, idx) => (
+                                        <SectionEditor
+                                            key={`${activePage}-${id}`}
+                                            ydoc={ydoc}
+                                            sectionId={id}
+                                            pageId={activePage}
+                                            pageTitle={activePageTitle}
+                                            provider={provider}
+                                            user={user}
+                                            uploadUrl={uploadUrl}
+                                            onRemove={() => removeSection(id)}
+                                            onMoveUp={() => moveSection(id, 'up')}
+                                            onMoveDown={() => moveSection(id, 'down')}
+                                            canMoveUp={idx > 0}
+                                            canMoveDown={idx < sectionIds.length - 1}
+                                            themeColor={themeColor}
+                                            readOnly={readOnly}
+                                            seedContent={activePage === 'main' && id === seedSectionId ? initialContent : undefined}
+                                            isFirst={idx === 0}
+                                            isLast={idx === sectionIds.length - 1}
+                                            focused={activeSectionId === id}
+                                            onFocusEditor={editor => { setActiveEditor(editor); setActiveSectionId(id) }}
+                                            onBlurEditor={(editor, event) => {
+                                                // Focus landing anywhere inside the toolbar (a button,
+                                                // a select, an open popover) isn't "nothing focused" —
+                                                // keep dispatching to this section until focus actually
+                                                // leaves both the document and the toolbar.
+                                                const related = event.relatedTarget as Node | null
+                                                if (related && toolbarRef.current?.contains(related)) return
+                                                setActiveEditor(prev => (prev === editor ? null : prev))
+                                                setActiveSectionId(prev => (prev === id ? null : prev))
+                                            }}
+                                        />
+                                    ))}
+                                    {!readOnly && (
+                                        <button type='button' onClick={addSection}
+                                            style={{ alignSelf: 'flex-start', marginTop: 8, padding: '6px 2px', background: 'transparent', border: 'none', color: 'var(--ink-3)', fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', cursor: 'pointer', transition: 'color 0.15s' }}
+                                            onMouseEnter={e => { e.currentTarget.style.color = 'var(--ink)' }}
+                                            onMouseLeave={e => { e.currentTarget.style.color = 'var(--ink-3)' }}
+                                        >
+                                            + Add Section
+                                        </button>
+                                    )}
+                                </div>
+                            )}
+                        </div>
                     </div>
                 </div>
             </div>
         </ThemeContext.Provider>
+    )
+}
+
+// ─── Editor Toolbar ────────────────────────────────────────────────────────────
+
+interface EditorToolbarProps {
+    /** Whichever section's editor last reported focus, or null when nothing
+     * in the document is focused — the toolbar renders every control
+     * disabled rather than guess a target (visual-fixes spec §1). */
+    editor: Editor | null
+    uploadUrl: string
+    /** ActiveEditor's own ref to this toolbar's root DOM node, so its blur
+     * handler can tell "focus moved into the toolbar" (keep the target)
+     * apart from "focus left the document entirely" (clear it) — see the
+     * `relatedTarget` check in ActiveEditor's onBlurEditor. */
+    containerRef: React.RefObject<HTMLDivElement>
+}
+
+/**
+ * The one persistent formatting toolbar (visual-fixes spec §1) — pinned
+ * above all document content via `position: sticky`, owned by the editor
+ * column rather than any one section. Every control dispatches to whichever
+ * section last reported focus (the `editor` prop); when that's null every
+ * control renders disabled instead of silently doing nothing or throwing.
+ *
+ * This also now owns the image/link insertion flows that used to live in
+ * each section's own toolbar — they're text-formatting concerns, not
+ * per-section chrome, so they moved here with everything else. Paste/drop
+ * image upload stays in SectionEditor itself (it fires on whichever editor
+ * the image actually lands in, independent of this toolbar's own state).
+ */
+function EditorToolbar({ editor, uploadUrl, containerRef }: EditorToolbarProps) {
+    const [toolbarOverflowOpen, setToolbarOverflowOpen] = useState(false)
+    const [imagePopoverOpen, setImagePopoverOpen] = useState(false)
+    const [showImageLibrary, setShowImageLibrary] = useState(false)
+    const [uploadingImage, setUploadingImage] = useState(false)
+    const [linkPopover, setLinkPopover] = useState(false)
+    const [linkUrl, setLinkUrl] = useState('')
+    const [linkText, setLinkText] = useState('')
+    const imageInputRef = useRef<HTMLInputElement>(null)
+    const linkUrlInputRef = useRef<HTMLInputElement>(null)
+    const linkTextInputRef = useRef<HTMLInputElement>(null)
+
+    useEffect(() => {
+        if (!linkPopover) return
+        const close = (e: MouseEvent) => {
+            if (!(e.target as Element).closest('[data-shared-link-popover]')) setLinkPopover(false)
+        }
+        document.addEventListener('mousedown', close)
+        return () => document.removeEventListener('mousedown', close)
+    }, [linkPopover])
+
+    async function handleImageUpload(file: File) {
+        if (!editor || uploadingImage) return
+        setUploadingImage(true)
+        try {
+            const formData = new FormData()
+            formData.append('file', file)
+            const res = await fetch(uploadUrl, { method: 'POST', body: formData })
+            const json = await res.json()
+            if (json.url) editor.chain().focus().setImage({ src: json.url }).run()
+            else alert(json.error || 'Upload failed')
+        } finally {
+            setUploadingImage(false)
+        }
+    }
+
+    function applyLink() {
+        if (!editor) return
+        const hasSelection = !editor.state.selection.empty
+        if (!hasSelection && linkText.trim() && linkUrl.trim()) {
+            editor.chain().focus().insertContent(`<a href="${linkUrl.trim()}">${linkText.trim()}</a>`).run()
+        } else if (linkUrl.trim()) {
+            editor.chain().focus().setLink({ href: linkUrl.trim() }).run()
+        } else {
+            editor.chain().focus().unsetLink().run()
+        }
+        setLinkPopover(false)
+        setLinkText('')
+        setLinkUrl('')
+    }
+
+    const disabled = !editor
+    // 0 means "plain paragraph", matching whichever of H1/H2/H3 (if any) the
+    // focused section's cursor is currently in.
+    const currentHeadingLevel = editor ? (([1, 2, 3] as const).find(l => editor.isActive('heading', { level: l })) ?? 0) : 0
+
+    return (
+        <div ref={containerRef} style={{
+            display: 'flex', alignItems: 'center', gap: 2, height: 44, flexShrink: 0,
+            borderBottom: '1px solid var(--line)', background: 'var(--bg)', padding: '0 20px',
+            position: 'sticky', top: 0, zIndex: 20,
+            opacity: disabled ? 0.45 : 1, transition: 'opacity 0.15s',
+        }}>
+            <select
+                value={String(currentHeadingLevel)}
+                disabled={disabled}
+                onChange={e => {
+                    if (!editor) return
+                    const lvl = Number(e.target.value)
+                    if (lvl === 0) editor.chain().focus().setParagraph().run()
+                    else editor.chain().focus().setHeading({ level: lvl as 1 | 2 | 3 }).run()
+                }}
+                title='Block style'
+                style={{ background: 'none', border: 'none', color: 'var(--ink-2)', fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', padding: '4px 6px', cursor: disabled ? 'default' : 'pointer', outline: 'none' }}
+            >
+                <option value='0'>Text</option>
+                <option value='1'>Heading 1</option>
+                <option value='2'>Heading 2</option>
+                <option value='3'>Heading 3</option>
+            </select>
+            <TDivider />
+            <TLabel title='Bold' disabled={disabled} active={!!editor?.isActive('bold')} onClick={() => editor?.chain().focus().toggleBold().run()}>B</TLabel>
+            <TLabel title='Italic' disabled={disabled} active={!!editor?.isActive('italic')} onClick={() => editor?.chain().focus().toggleItalic().run()}>I</TLabel>
+            <TLabel title='Underline' disabled={disabled} active={!!editor?.isActive('underline')} onClick={() => editor?.chain().focus().toggleUnderline().run()}>U</TLabel>
+            <TDivider />
+            <TLabel title='Bullet List' disabled={disabled} active={!!editor?.isActive('bulletList')} onClick={() => editor?.chain().focus().toggleBulletList().run()}>List</TLabel>
+            <div style={{ position: 'relative' }}>
+                <TLabel title={uploadingImage ? 'Uploading…' : 'Insert Image'} disabled={disabled} active={uploadingImage || imagePopoverOpen}
+                    onClick={() => { if (!uploadingImage) setImagePopoverOpen(v => !v) }}
+                >
+                    Image
+                </TLabel>
+                {imagePopoverOpen && !uploadingImage && (
+                    <div
+                        onMouseDown={e => e.stopPropagation()}
+                        style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '4px 0', display: 'flex', flexDirection: 'column', minWidth: 190, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
+                    >
+                        <button type='button'
+                            onClick={() => { setImagePopoverOpen(false); imageInputRef.current?.click() }}
+                            style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
+                            onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
+                            onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+                        >Upload from Computer</button>
+                        <button type='button'
+                            onClick={() => { setImagePopoverOpen(false); setShowImageLibrary(true) }}
+                            style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
+                            onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
+                            onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+                        >Select from Library</button>
+                    </div>
+                )}
+            </div>
+
+            <div style={{ flex: 1 }} />
+
+            {/* Overflow — undo/redo, font size, strike/highlight, align,
+                numbered list, quote, divider, link, clear formatting. Same
+                commands the old per-section overflow menu exposed; only the
+                toolbar hosting them moved. */}
+            <div style={{ position: 'relative' }}>
+                <TLabel title='More formatting' disabled={disabled} active={toolbarOverflowOpen} onClick={() => setToolbarOverflowOpen(v => !v)}>⋯</TLabel>
+                {toolbarOverflowOpen && editor && (
+                    <div
+                        onMouseDown={e => e.stopPropagation()}
+                        style={{ position: 'absolute', top: '110%', right: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: 6, display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 2, width: 232, boxShadow: '0 8px 24px rgba(0,0,0,0.5)' }}
+                    >
+                        <TBtn title='Undo' onClick={() => editor.chain().focus().undo().run()}><Undo style={{ fontSize: 16 }} /></TBtn>
+                        <TBtn title='Redo' onClick={() => editor.chain().focus().redo().run()}><Redo style={{ fontSize: 16 }} /></TBtn>
+                        <TDivider />
+                        <TBtn title='Strikethrough' active={editor.isActive('strike')} onClick={() => editor.chain().focus().toggleStrike().run()}><StrikethroughS style={{ fontSize: 17 }} /></TBtn>
+                        <TBtn title='Highlight' active={editor.isActive('highlight')} onClick={() => editor.chain().focus().toggleHighlight().run()}><FormatColorFill style={{ fontSize: 17 }} /></TBtn>
+                        <TDivider />
+                        <TBtn title='Align Left' active={editor.isActive({ textAlign: 'left' })} onClick={() => editor.chain().focus().setTextAlign('left').run()}><FormatAlignLeft style={{ fontSize: 17 }} /></TBtn>
+                        <TBtn title='Align Centre' active={editor.isActive({ textAlign: 'center' })} onClick={() => editor.chain().focus().setTextAlign('center').run()}><FormatAlignCenter style={{ fontSize: 17 }} /></TBtn>
+                        <TBtn title='Align Right' active={editor.isActive({ textAlign: 'right' })} onClick={() => editor.chain().focus().setTextAlign('right').run()}><FormatAlignRight style={{ fontSize: 17 }} /></TBtn>
+                        <TDivider />
+                        <TBtn title='Numbered List' active={editor.isActive('orderedList')} onClick={() => editor.chain().focus().toggleOrderedList().run()}><FormatListNumbered style={{ fontSize: 17 }} /></TBtn>
+                        <TBtn title='Quote' active={editor.isActive('blockquote')} onClick={() => editor.chain().focus().toggleBlockquote().run()}><FormatQuote style={{ fontSize: 17 }} /></TBtn>
+                        <TBtn title='Section Divider' onClick={() => editor.chain().focus().setHorizontalRule().run()}><HorizontalRule style={{ fontSize: 17 }} /></TBtn>
+                        <TDivider />
+                        <div style={{ position: 'relative' }}>
+                            <TBtn title={editor.isActive('link') ? 'Edit Link' : 'Insert Link'} active={editor.isActive('link')}
+                                onClick={() => {
+                                    const existing = editor.getAttributes('link').href || ''
+                                    setLinkUrl(existing)
+                                    setLinkText('')
+                                    setLinkPopover(v => !v)
+                                    const noSel = editor.state.selection.empty
+                                    setTimeout(() => (noSel ? linkTextInputRef.current : linkUrlInputRef.current)?.focus(), 40)
+                                }}
+                            >
+                                <InsertLink style={{ fontSize: 17 }} />
+                            </TBtn>
+                            {linkPopover && (
+                                <div data-shared-link-popover onMouseDown={e => e.stopPropagation()}
+                                    style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 280, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
+                                >
+                                    {editor.state.selection.empty && (
+                                        <input ref={linkTextInputRef} value={linkText} onChange={e => setLinkText(e.target.value)} placeholder='Display text'
+                                            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); linkUrlInputRef.current?.focus() } if (e.key === 'Escape') setLinkPopover(false) }}
+                                            style={{ background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
+                                        />
+                                    )}
+                                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                                        <input ref={linkUrlInputRef} value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder='https://…'
+                                            onKeyDown={e => {
+                                                if (e.key === 'Enter') { e.preventDefault(); applyLink() }
+                                                if (e.key === 'Escape') setLinkPopover(false)
+                                            }}
+                                            style={{ flex: 1, background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
+                                        />
+                                        <button type='button' onClick={applyLink}
+                                            style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--acc)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', flexShrink: 0 }}
+                                        >Apply</button>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                        <TBtn title='Remove Link' onClick={() => { editor.chain().focus().unsetLink().run(); setLinkPopover(false) }}>
+                            <LinkOff style={{ fontSize: 17 }} />
+                        </TBtn>
+                        <TDivider />
+                        <TBtn title='Clear Formatting' onClick={() => editor.chain().focus().clearNodes().unsetAllMarks().run()}>
+                            <FormatClear style={{ fontSize: 17 }} />
+                        </TBtn>
+                        <select
+                            value={(editor.getAttributes('textStyle').fontSize as string | undefined) || ''}
+                            onChange={e => {
+                                if (e.target.value) (editor.chain().focus() as any).setFontSize(e.target.value).run()
+                                else (editor.chain().focus() as any).unsetFontSize().run()
+                            }}
+                            title='Font size'
+                            style={{ background: 'var(--s3)', border: '1px solid var(--line-2)', color: 'var(--ink-2)', fontSize: '0.65rem', padding: '0 4px', cursor: 'pointer', height: 26, outline: 'none', minWidth: 52 }}>
+                            <option value=''>Size</option>
+                            {[10, 11, 12, 13, 14, 16, 18, 20, 24, 28, 32, 36, 48].map(s => (
+                                <option key={s} value={`${s}px`}>{s}</option>
+                            ))}
+                        </select>
+                    </div>
+                )}
+            </div>
+
+            <input ref={imageInputRef} type='file' accept='image/*' style={{ display: 'none' }}
+                onChange={e => { const file = e.target.files?.[0]; if (file) handleImageUpload(file); e.target.value = '' }}
+            />
+            {showImageLibrary && (
+                <ImageLibraryModal
+                    onSelect={url => { editor?.chain().focus().setImage({ src: url }).run(); setShowImageLibrary(false) }}
+                    onClose={() => setShowImageLibrary(false)}
+                />
+            )}
+        </div>
     )
 }
 
@@ -674,9 +958,27 @@ interface SectionEditorProps {
     themeColor?: string
     readOnly?: boolean
     seedContent?: any
+    /** First/last in the section list — `isFirst` skips the inter-section
+     * hairline rule (visual-fixes spec §3), `isLast` lets the editable area
+     * grow to fill any leftover column height (spec §2) rather than
+     * collapsing to its content's own height. */
+    isFirst?: boolean
+    isLast?: boolean
+    /** True while ActiveEditor's `activeSectionId` names this section —
+     * drives the focus ring (visual-fixes spec §3). Lives in the parent
+     * (not local state here) so it reflects "this is the shared toolbar's
+     * current target" rather than raw ProseMirror DOM focus, which would
+     * flicker off the instant a toolbar button is clicked. */
+    focused?: boolean
+    /** Reports this section's own editor to ActiveEditor's `activeEditor`
+     * state whenever it gains/loses browser focus, so the one shared
+     * toolbar (rendered above all sections) always dispatches to whichever
+     * section the caret is actually in (visual-fixes spec §1). */
+    onFocusEditor?: (editor: Editor) => void
+    onBlurEditor?: (editor: Editor, event: FocusEvent) => void
 }
 
-function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, uploadUrl, onRemove, onMoveUp, onMoveDown, canMoveUp, canMoveDown, themeColor = '#db001d', readOnly = false, seedContent }: SectionEditorProps) {
+function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, uploadUrl, onRemove, onMoveUp, onMoveDown, canMoveUp, canMoveDown, themeColor = '#db001d', readOnly = false, seedContent, isFirst = false, isLast = false, focused = false, onFocusEditor, onBlurEditor }: SectionEditorProps) {
     const isNonMain = pageId && pageId !== 'main'
     const metaKey = isNonMain ? `smeta-${pageId}-${sectionId}` : `smeta-${sectionId}`
     const contentKey = isNonMain ? `scontent-${pageId}-${sectionId}` : `scontent-${sectionId}`
@@ -692,9 +994,18 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
     // helper: same colour, token-backed per the visual-fixes design tokens
     // rule. blockquote/hr/mark/list-marker rules restyled for spec §2 (quote
     // → card-style callout with a corner tick, bullets → accent squares);
-    // h1/h2/a keep the same tint treatment they always had.
+    // h1/h2/a keep the same tint treatment they always had. The editable
+    // area's own ground/border/radius live on the shared `.op-editor` rule
+    // in globals.css; this scoped block only layers the per-instance bits
+    // that rule can't know — min-height, the focus ring, and (for the last
+    // section) growing to fill the column (spec §2/§3).
     const themeCSS = `
-        .op-editor-${sectionId} { min-height: ${sectionMinHeight}px; }
+        .op-editor-${sectionId} {
+            min-height: ${sectionMinHeight}px;
+            box-shadow: ${focused ? '0 0 0 2px rgba(var(--acc-rgb), 0.4)' : 'none'};
+            border-color: ${focused ? 'rgba(var(--acc-rgb), 0.5)' : 'var(--line)'};
+            ${isLast ? 'flex: 1; display: flex; flex-direction: column;' : ''}
+        }
         .op-editor-${sectionId} h1 { border-left-color: rgba(var(--acc-rgb), 0.75); background: rgba(var(--acc-rgb), 0.045); }
         .op-editor-${sectionId} h2 { color: rgba(var(--acc-rgb), 0.88); }
         .op-editor-${sectionId} h2::before { color: rgba(var(--acc-rgb), 0.65); }
@@ -717,20 +1028,13 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
     `
     const [confirmingRemove, setConfirmingRemove] = useState(false)
     const [hovered, setHovered] = useState(false)
-    const [toolbarOverflowOpen, setToolbarOverflowOpen] = useState(false)
-    const [imagePopoverOpen, setImagePopoverOpen] = useState(false)
-    const [showImageLibrary, setShowImageLibrary] = useState(false)
     const seededRef = useRef(false)
-    const imageInputRef = useRef<HTMLInputElement>(null)
     const borderColorInputRef = useRef<HTMLInputElement>(null)
-    const [uploadingImage, setUploadingImage] = useState(false)
+    // Paste/drop image upload stays local to each section — it fires on
+    // whichever editor the image actually landed in, independent of the
+    // shared toolbar's own (separately stateful) Image control.
     const uploadingImageRef = useRef(false)
     const pasteUploadRef = useRef<(file: File) => void>(() => {})
-    const [linkPopover, setLinkPopover] = useState(false)
-    const [linkUrl, setLinkUrl] = useState('')
-    const [linkText, setLinkText] = useState('')
-    const linkUrlInputRef = useRef<HTMLInputElement>(null)
-    const linkTextInputRef = useRef<HTMLInputElement>(null)
     const heightDragRef = useRef({ startY: 0, startH: 0 })
 
     useEffect(() => {
@@ -760,6 +1064,8 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
     const editor = useEditor({
         immediatelyRender: false,
         editable: !readOnly,
+        onFocus: ({ editor: e }) => onFocusEditor?.(e),
+        onBlur: ({ editor: e, event }) => onBlurEditor?.(e, event),
         extensions: [
             StarterKit.configure({ undoRedo: false }),
             TextAlign.configure({ types: ['heading', 'paragraph'] }),
@@ -819,30 +1125,6 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
         return () => { provider.off('synced', trySeek) }
     }, [editor, provider, seedContent])
 
-    useEffect(() => {
-        if (!linkPopover) return
-        const close = (e: MouseEvent) => {
-            if (!(e.target as Element).closest(`[data-link-popover-${sectionId}]`)) setLinkPopover(false)
-        }
-        document.addEventListener('mousedown', close)
-        return () => document.removeEventListener('mousedown', close)
-    }, [linkPopover, sectionId])
-
-    function applyLink() {
-        if (!editor) return
-        const hasSelection = !editor.state.selection.empty
-        if (!hasSelection && linkText.trim() && linkUrl.trim()) {
-            editor.chain().focus().insertContent(`<a href="${linkUrl.trim()}">${linkText.trim()}</a>`).run()
-        } else if (linkUrl.trim()) {
-            editor.chain().focus().setLink({ href: linkUrl.trim() }).run()
-        } else {
-            editor.chain().focus().unsetLink().run()
-        }
-        setLinkPopover(false)
-        setLinkText('')
-        setLinkUrl('')
-    }
-
     function onHeightDragStart(e: React.MouseEvent) {
         e.preventDefault()
         heightDragRef.current = { startY: e.clientY, startH: sectionMinHeight }
@@ -863,7 +1145,6 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
     async function handleImageUpload(file: File) {
         if (!editor || uploadingImageRef.current) return
         uploadingImageRef.current = true
-        setUploadingImage(true)
         try {
             const formData = new FormData()
             formData.append('file', file)
@@ -873,22 +1154,28 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
             else alert(json.error || 'Upload failed')
         } finally {
             uploadingImageRef.current = false
-            setUploadingImage(false)
         }
     }
     pasteUploadRef.current = handleImageUpload
 
     if (!editor) return null
 
-    // Drives the toolbar's block-style select — 0 means "plain paragraph",
-    // matching whichever of H1/H2/H3 (if any) the cursor is currently in.
-    const currentHeadingLevel = ([1, 2, 3] as const).find(l => editor.isActive('heading', { level: l })) ?? 0
     const chromeVisible = hovered || confirmingRemove
 
     return (
-        <div style={{ position: 'relative' }}
+        <div style={{
+            position: 'relative',
+            display: isLast ? 'flex' : undefined,
+            flexDirection: isLast ? 'column' : undefined,
+            flex: isLast ? 1 : undefined,
+            // Hairline + clear space between consecutive sections (visual-
+            // fixes spec §3) — skipped on the first section, which already
+            // sits right below the shared toolbar with its own breathing room.
+            borderTop: isFirst ? 'none' : '1px solid var(--line)',
+            paddingTop: isFirst ? 0 : 32,
+        }}
             onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => { setHovered(false); setToolbarOverflowOpen(false) }}
+            onMouseLeave={() => setHovered(false)}
         >
             <style>{themeCSS}</style>
 
@@ -961,147 +1248,15 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
                 )}
             </div>
 
-            {/* Toolbar — one slim row: block style, B/I/U, list, image, and an
-                overflow menu for everything else (visual-fixes spec §2). */}
-            <div style={{ display: readOnly ? 'none' : 'flex', alignItems: 'center', gap: 2, height: 44, borderBottom: '1px solid var(--line)', marginBottom: 18 }}>
-                <select
-                    value={String(currentHeadingLevel)}
-                    onChange={e => {
-                        const lvl = Number(e.target.value)
-                        if (lvl === 0) editor.chain().focus().setParagraph().run()
-                        else editor.chain().focus().setHeading({ level: lvl as 1 | 2 | 3 }).run()
-                    }}
-                    title='Block style'
-                    style={{ background: 'none', border: 'none', color: 'var(--ink-2)', fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', padding: '4px 6px', cursor: 'pointer', outline: 'none' }}
-                >
-                    <option value='0'>Text</option>
-                    <option value='1'>Heading 1</option>
-                    <option value='2'>Heading 2</option>
-                    <option value='3'>Heading 3</option>
-                </select>
-                <TLabel title='Bold' active={editor.isActive('bold')} onClick={() => editor.chain().focus().toggleBold().run()}>B</TLabel>
-                <TLabel title='Italic' active={editor.isActive('italic')} onClick={() => editor.chain().focus().toggleItalic().run()}>I</TLabel>
-                <TLabel title='Underline' active={editor.isActive('underline')} onClick={() => editor.chain().focus().toggleUnderline().run()}>U</TLabel>
-                <div style={{ width: 1, height: 16, background: 'var(--line)', margin: '0 4px' }} />
-                <TLabel title='Bullet List' active={editor.isActive('bulletList')} onClick={() => editor.chain().focus().toggleBulletList().run()}>List</TLabel>
-                <div style={{ position: 'relative' }}>
-                    <TLabel title={uploadingImage ? 'Uploading…' : 'Insert Image'} active={uploadingImage || imagePopoverOpen}
-                        onClick={() => { if (!uploadingImage) setImagePopoverOpen(v => !v) }}
-                    >
-                        Image
-                    </TLabel>
-                    {imagePopoverOpen && !uploadingImage && (
-                        <div
-                            onMouseDown={e => e.stopPropagation()}
-                            style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '4px 0', display: 'flex', flexDirection: 'column', minWidth: 190, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
-                        >
-                            <button type='button'
-                                onClick={() => { setImagePopoverOpen(false); imageInputRef.current?.click() }}
-                                style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
-                                onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
-                                onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-                            >Upload from Computer</button>
-                            <button type='button'
-                                onClick={() => { setImagePopoverOpen(false); setShowImageLibrary(true) }}
-                                style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
-                                onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
-                                onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-                            >Select from Library</button>
-                        </div>
-                    )}
-                </div>
-
-                <div style={{ flex: 1 }} />
-
-                {/* Overflow — undo/redo, font size, strike/highlight, align,
-                    numbered list, quote, divider, link, clear formatting.
-                    Same commands the old 20-button row exposed directly;
-                    only their visibility moved. */}
-                <div style={{ position: 'relative' }}>
-                    <TLabel title='More formatting' active={toolbarOverflowOpen} onClick={() => setToolbarOverflowOpen(v => !v)}>⋯</TLabel>
-                    {toolbarOverflowOpen && (
-                        <div
-                            onMouseDown={e => e.stopPropagation()}
-                            style={{ position: 'absolute', top: '110%', right: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: 6, display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 2, width: 232, boxShadow: '0 8px 24px rgba(0,0,0,0.5)' }}
-                        >
-                            <TBtn title='Undo' onClick={() => editor.chain().focus().undo().run()}><Undo style={{ fontSize: 16 }} /></TBtn>
-                            <TBtn title='Redo' onClick={() => editor.chain().focus().redo().run()}><Redo style={{ fontSize: 16 }} /></TBtn>
-                            <TDivider />
-                            <TBtn title='Strikethrough' active={editor.isActive('strike')} onClick={() => editor.chain().focus().toggleStrike().run()}><StrikethroughS style={{ fontSize: 17 }} /></TBtn>
-                            <TBtn title='Highlight' active={editor.isActive('highlight')} onClick={() => editor.chain().focus().toggleHighlight().run()}><FormatColorFill style={{ fontSize: 17 }} /></TBtn>
-                            <TDivider />
-                            <TBtn title='Align Left' active={editor.isActive({ textAlign: 'left' })} onClick={() => editor.chain().focus().setTextAlign('left').run()}><FormatAlignLeft style={{ fontSize: 17 }} /></TBtn>
-                            <TBtn title='Align Centre' active={editor.isActive({ textAlign: 'center' })} onClick={() => editor.chain().focus().setTextAlign('center').run()}><FormatAlignCenter style={{ fontSize: 17 }} /></TBtn>
-                            <TBtn title='Align Right' active={editor.isActive({ textAlign: 'right' })} onClick={() => editor.chain().focus().setTextAlign('right').run()}><FormatAlignRight style={{ fontSize: 17 }} /></TBtn>
-                            <TDivider />
-                            <TBtn title='Numbered List' active={editor.isActive('orderedList')} onClick={() => editor.chain().focus().toggleOrderedList().run()}><FormatListNumbered style={{ fontSize: 17 }} /></TBtn>
-                            <TBtn title='Quote' active={editor.isActive('blockquote')} onClick={() => editor.chain().focus().toggleBlockquote().run()}><FormatQuote style={{ fontSize: 17 }} /></TBtn>
-                            <TBtn title='Section Divider' onClick={() => editor.chain().focus().setHorizontalRule().run()}><HorizontalRule style={{ fontSize: 17 }} /></TBtn>
-                            <TDivider />
-                            <div style={{ position: 'relative' }}>
-                                <TBtn title={editor.isActive('link') ? 'Edit Link' : 'Insert Link'} active={editor.isActive('link')}
-                                    onClick={() => {
-                                        const existing = editor.getAttributes('link').href || ''
-                                        setLinkUrl(existing)
-                                        setLinkText('')
-                                        setLinkPopover(v => !v)
-                                        const noSel = editor.state.selection.empty
-                                        setTimeout(() => (noSel ? linkTextInputRef.current : linkUrlInputRef.current)?.focus(), 40)
-                                    }}
-                                >
-                                    <InsertLink style={{ fontSize: 17 }} />
-                                </TBtn>
-                                {linkPopover && (
-                                    <div {...{ [`data-link-popover-${sectionId}`]: true }} onMouseDown={e => e.stopPropagation()}
-                                        style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 280, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
-                                    >
-                                        {editor.state.selection.empty && (
-                                            <input ref={linkTextInputRef} value={linkText} onChange={e => setLinkText(e.target.value)} placeholder='Display text'
-                                                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); linkUrlInputRef.current?.focus() } if (e.key === 'Escape') setLinkPopover(false) }}
-                                                style={{ background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
-                                            />
-                                        )}
-                                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                                            <input ref={linkUrlInputRef} value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder='https://…'
-                                                onKeyDown={e => {
-                                                    if (e.key === 'Enter') { e.preventDefault(); applyLink() }
-                                                    if (e.key === 'Escape') setLinkPopover(false)
-                                                }}
-                                                style={{ flex: 1, background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
-                                            />
-                                            <button type='button' onClick={applyLink}
-                                                style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--acc)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', flexShrink: 0 }}
-                                            >Apply</button>
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                            <TBtn title='Remove Link' onClick={() => { editor.chain().focus().unsetLink().run(); setLinkPopover(false) }}>
-                                <LinkOff style={{ fontSize: 17 }} />
-                            </TBtn>
-                            <TDivider />
-                            <TBtn title='Clear Formatting' onClick={() => editor.chain().focus().clearNodes().unsetAllMarks().run()}>
-                                <FormatClear style={{ fontSize: 17 }} />
-                            </TBtn>
-                            <select
-                                value={(editor.getAttributes('textStyle').fontSize as string | undefined) || ''}
-                                onChange={e => {
-                                    if (e.target.value) (editor.chain().focus() as any).setFontSize(e.target.value).run()
-                                    else (editor.chain().focus() as any).unsetFontSize().run()
-                                }}
-                                title='Font size'
-                                style={{ background: 'var(--s3)', border: '1px solid var(--line-2)', color: 'var(--ink-2)', fontSize: '0.65rem', padding: '0 4px', cursor: 'pointer', height: 26, outline: 'none', minWidth: 52 }}>
-                                <option value=''>Size</option>
-                                {[10, 11, 12, 13, 14, 16, 18, 20, 24, 28, 32, 36, 48].map(s => (
-                                    <option key={s} value={`${s}px`}>{s}</option>
-                                ))}
-                            </select>
-                        </div>
-                    )}
-                </div>
-            </div>
-
-            <EditorContent editor={editor} />
+            {/* The formatting toolbar used to live here, per section — it's
+                now the one shared instance ActiveEditor renders above all
+                sections (visual-fixes spec §1). This is just the editable
+                surface itself: `.op-editor`/`.op-editor-${sectionId}`
+                (globals.css + themeCSS above) give it a distinct ground,
+                border and — when focused — accent ring (spec §3), and, for
+                the last section, `flex: 1` to fill any leftover column
+                height (spec §2). */}
+            <EditorContent editor={editor} style={isLast ? { flex: 1, display: 'flex', flexDirection: 'column' } : undefined} />
 
             {!readOnly && (
                 <div onMouseDown={onHeightDragStart}
@@ -1109,16 +1264,6 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
                     title='Drag to set minimum height'>
                     <div style={{ width: 28, height: 2, background: 'rgba(255,255,255,0.1)', borderRadius: 1 }} />
                 </div>
-            )}
-
-            <input ref={imageInputRef} type='file' accept='image/*' style={{ display: 'none' }}
-                onChange={e => { const file = e.target.files?.[0]; if (file) handleImageUpload(file); e.target.value = '' }}
-            />
-            {showImageLibrary && (
-                <ImageLibraryModal
-                    onSelect={url => { editor.chain().focus().setImage({ src: url }).run(); setShowImageLibrary(false) }}
-                    onClose={() => setShowImageLibrary(false)}
-                />
             )}
         </div>
     )
@@ -1164,9 +1309,9 @@ function TDivider() {
  * visible on the slim main row (block style, B/I/U, list, image, the
  * overflow toggle). Everything else keeps the icon-based `TBtn` inside the
  * overflow panel. */
-function TLabel({ onClick, active, title, children }: { onClick: () => void; active?: boolean; title: string; children: React.ReactNode }) {
+function TLabel({ onClick, active, title, disabled, children }: { onClick: () => void; active?: boolean; title: string; disabled?: boolean; children: React.ReactNode }) {
     return (
-        <button type='button' title={title} onClick={onClick}
+        <button type='button' title={title} onClick={onClick} disabled={disabled}
             style={{
                 padding: '5px 8px',
                 background: active ? 'var(--s2)' : 'transparent',
@@ -1174,7 +1319,7 @@ function TLabel({ onClick, active, title, children }: { onClick: () => void; act
                 borderRadius: 'var(--r)',
                 color: active ? 'var(--ink)' : 'var(--ink-2)',
                 fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
-                cursor: 'pointer', transition: 'all 0.15s',
+                cursor: disabled ? 'default' : 'pointer', transition: 'all 0.15s',
             }}
             onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--ink)' }}
             onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--ink-2)' }}

--- a/apps/web/components/editor/CollabEditor.tsx
+++ b/apps/web/components/editor/CollabEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useEditor, EditorContent, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
 import type { Editor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
@@ -602,6 +602,15 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
                     orientation={isMobile ? 'top' : 'sidebar'}
                     synced={synced}
                     allowedTypes={allowedTypes}
+                    readOnly={readOnly}
+                    // The rail's own footer now carries the "EDITING" presence
+                    // indicator (visual-fixes FIX 3) that used to float at the
+                    // top-right of the editor column — same `user`/`peers`
+                    // this component already derives from the Hocuspocus
+                    // awareness state for the collaborative cursors, just
+                    // handed down instead of a second channel.
+                    presenceUser={{ id: 'self', ...user }}
+                    presencePeers={peers.map(p => ({ id: p.clientId, name: p.name, color: p.color, avatar: p.avatar }))}
                 />
                 <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
                     {/* One persistent formatting toolbar, owned by the column rather
@@ -617,17 +626,11 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
                             than the old ~740px cap, so the document reads as a real
                             writing surface instead of a phone-width column. */}
                         <div style={{ maxWidth: 1160, margin: '0 auto', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', gap: 16 }}>
-                            {activePageType !== 'intel' && (
-                                <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'flex-end' }}>
-                                    <span style={{ fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--ink-3)', marginRight: 2 }}>
-                                        {readOnly ? 'Viewing' : 'Editing'}
-                                    </span>
-                                    <PresenceAvatar key='self' peer={{ clientId: -1, ...user }} self />
-                                    {peers.map(peer => (
-                                        <PresenceAvatar key={peer.clientId} peer={peer} />
-                                    ))}
-                                </div>
-                            )}
+                            {/* The "EDITING" presence indicator that used to float here
+                                (top-right of the editor column) now lives in the rail's
+                                own footer instead (visual-fixes FIX 3) — see the
+                                `presenceUser`/`presencePeers` props passed to
+                                PageSidebar above. */}
 
                             {activePageType === 'intel' ? (
                                 <IntelPackageEditor
@@ -706,6 +709,95 @@ interface EditorToolbarProps {
     containerRef: React.RefObject<HTMLDivElement>
 }
 
+// Fixed sizes baked into the group-fit math below — not "hardcoded viewport
+// maths" in the sense FIX 2 warns against (those approximated an *unrelated*
+// layout region via vh arithmetic that drifted out of sync); these are a
+// component measuring its own children's own fixed CSS, values that only
+// change if TDivider's or TIconBtn's own inline styles do, right next to
+// this file's other toolbar controls.
+const TOOLBAR_DIVIDER_WIDTH = 9        // TDivider: 1px bar + 4px margin each side
+const TOOLBAR_OVERFLOW_BTN_WIDTH = 26  // matches TIconBtn's fixed 26×26 box
+
+/**
+ * Measurement-driven toolbar overflow (visual-fixes FIX 1): decides how many
+ * leading groups of `groupKeys` (already in the toolbar's fixed display
+ * order) fit inside the container's own observed width before the rest have
+ * to move into the "⋯" popover. Reacts only to the container's own
+ * ResizeObserver'd width — not to *why* it changed — so deck collapse,
+ * window resize, and sidebar collapse all correct it the same way, with no
+ * per-cause breakpoint list to keep in sync.
+ *
+ * A group is measured (via `setGroupRef`) only while it's actually rendered
+ * on the bar; one currently sitting in the overflow popover keeps its last
+ * known width in `widthsRef` rather than being treated as 0-width, so it
+ * doesn't flicker in and out on every render once it's been pushed off.
+ * Every group here is fixed-width (icon buttons) except the block-style/
+ * size dropdowns, whose label text shifts slightly with the cursor's
+ * position — that group sits early enough in the fixed order that it's the
+ * last one ever pushed into overflow, so a briefly stale cached width for
+ * it in practice never happens.
+ */
+function useToolbarOverflow(groupKeys: readonly string[], containerRef: React.RefObject<HTMLDivElement>) {
+    const [containerWidth, setContainerWidth] = useState<number | null>(null)
+    const groupRefs = useRef<Record<string, HTMLDivElement | null>>({})
+    const widthsRef = useRef<Record<string, number>>({})
+    const [visibleCount, setVisibleCount] = useState(groupKeys.length)
+
+    useEffect(() => {
+        const el = containerRef.current
+        if (!el) return
+        const observer = new ResizeObserver(entries => {
+            const width = entries[0]?.contentRect.width
+            if (width != null) setContainerWidth(width)
+        })
+        observer.observe(el)
+        return () => observer.disconnect()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // No dependency array: this needs to re-measure/re-decide after *any*
+    // render that might have changed a visible group's rendered width (e.g.
+    // the block-style dropdown's label text) as well as after containerWidth
+    // itself changes — cheaper to just always check than to enumerate every
+    // input that can move a group's width. Can't loop: `setVisibleCount`
+    // below only actually updates state (and so only triggers the re-render
+    // that re-runs this effect) when the computed value differs from the
+    // last one, so it converges instead of chaining forever.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useLayoutEffect(() => {
+        for (const key of groupKeys) {
+            const node = groupRefs.current[key]
+            if (node) widthsRef.current[key] = node.offsetWidth
+        }
+        if (containerWidth == null) return
+
+        const widths = groupKeys.map(k => widthsRef.current[k] ?? 0)
+        const totalWidth = widths.reduce((a, b) => a + b, 0) + TOOLBAR_DIVIDER_WIDTH * Math.max(groupKeys.length - 1, 0)
+
+        let next = groupKeys.length
+        if (totalWidth > containerWidth) {
+            const reserved = TOOLBAR_OVERFLOW_BTN_WIDTH + TOOLBAR_DIVIDER_WIDTH
+            let used = 0
+            let count = 0
+            for (let i = 0; i < groupKeys.length; i++) {
+                const dividerBefore = i > 0 ? TOOLBAR_DIVIDER_WIDTH : 0
+                if (used + dividerBefore + widths[i] + reserved <= containerWidth) {
+                    used += dividerBefore + widths[i]
+                    count++
+                } else {
+                    break
+                }
+            }
+            next = count
+        }
+        setVisibleCount(prev => (prev === next ? prev : next))
+    })
+
+    const setGroupRef = (key: string) => (el: HTMLDivElement | null) => { groupRefs.current[key] = el }
+
+    return { visibleCount, setGroupRef }
+}
+
 /**
  * The one persistent formatting toolbar (visual-fixes spec §1) — pinned
  * above all document content via `position: sticky`, owned by the editor
@@ -718,6 +810,13 @@ interface EditorToolbarProps {
  * per-section chrome, so they moved here with everything else. Paste/drop
  * image upload stays in SectionEditor itself (it fires on whichever editor
  * the image actually lands in, independent of this toolbar's own state).
+ *
+ * Every group renders on the bar by default (visual-fixes FIX 1) — the "⋯"
+ * overflow popover only ever takes the *trailing* groups that genuinely
+ * don't fit, decided by `useToolbarOverflow` below from the container's own
+ * measured width, never a fixed split. Group order and dividers are
+ * unchanged: history | block type + size | inline marks | highlight |
+ * alignment | lists | blocks | insert | clear.
  */
 function EditorToolbar({ editor, uploadUrl, containerRef }: EditorToolbarProps) {
     const [imagePopoverOpen, setImagePopoverOpen] = useState(false)
@@ -775,138 +874,174 @@ function EditorToolbar({ editor, uploadUrl, containerRef }: EditorToolbarProps) 
     const currentHeadingLevel = editor ? (([1, 2, 3] as const).find(l => editor.isActive('heading', { level: l })) ?? 0) : 0
     const currentFontSize = (editor?.getAttributes('textStyle').fontSize as string | undefined) || ''
 
+    // Same nine groups, same order, as the previous always-inline toolbar —
+    // just named and grouped now so `useToolbarOverflow` can measure and
+    // relocate them as units (visual-fixes FIX 1) instead of individual
+    // buttons ending up orphaned on either side of a divider.
+    const groups: { key: string; node: React.ReactNode }[] = [
+        { key: 'history', node: (
+            <>
+                <TIconBtn title='Undo' disabled={disabled} onClick={() => editor?.chain().focus().undo().run()}><IconUndo /></TIconBtn>
+                <TIconBtn title='Redo' disabled={disabled} onClick={() => editor?.chain().focus().redo().run()}><IconRedo /></TIconBtn>
+            </>
+        ) },
+        { key: 'block', node: (
+            <>
+                <ToolbarDropdown title='Block style' disabled={disabled} minWidth={92}
+                    value={String(currentHeadingLevel)} options={HEADING_OPTIONS}
+                    onSelect={v => {
+                        if (!editor) return
+                        const lvl = Number(v)
+                        if (lvl === 0) editor.chain().focus().setParagraph().run()
+                        else editor.chain().focus().setHeading({ level: lvl as 1 | 2 | 3 }).run()
+                    }}
+                />
+                <ToolbarDropdown title='Text size' disabled={disabled} minWidth={52}
+                    value={currentFontSize} options={FONT_SIZE_OPTIONS}
+                    onSelect={v => {
+                        if (!editor) return
+                        if (v) (editor.chain().focus() as any).setFontSize(v).run()
+                        else (editor.chain().focus() as any).unsetFontSize().run()
+                    }}
+                />
+            </>
+        ) },
+        { key: 'marks', node: (
+            <>
+                <TLabel title='Bold' disabled={disabled} active={!!editor?.isActive('bold')} onClick={() => editor?.chain().focus().toggleBold().run()}>B</TLabel>
+                <TLabel title='Italic' disabled={disabled} active={!!editor?.isActive('italic')} onClick={() => editor?.chain().focus().toggleItalic().run()}>I</TLabel>
+                <TLabel title='Underline' disabled={disabled} active={!!editor?.isActive('underline')} onClick={() => editor?.chain().focus().toggleUnderline().run()}>U</TLabel>
+                <TIconBtn title='Strikethrough' disabled={disabled} active={!!editor?.isActive('strike')} onClick={() => editor?.chain().focus().toggleStrike().run()}><IconStrikethrough /></TIconBtn>
+            </>
+        ) },
+        { key: 'highlight', node: (
+            <TIconBtn title='Highlight' disabled={disabled} active={!!editor?.isActive('highlight')} onClick={() => editor?.chain().focus().toggleHighlight().run()}><IconHighlight /></TIconBtn>
+        ) },
+        { key: 'align', node: (
+            <>
+                <TIconBtn title='Align Left' disabled={disabled} active={!!editor?.isActive({ textAlign: 'left' })} onClick={() => editor?.chain().focus().setTextAlign('left').run()}><IconAlignLeft /></TIconBtn>
+                <TIconBtn title='Align Centre' disabled={disabled} active={!!editor?.isActive({ textAlign: 'center' })} onClick={() => editor?.chain().focus().setTextAlign('center').run()}><IconAlignCenter /></TIconBtn>
+                <TIconBtn title='Align Right' disabled={disabled} active={!!editor?.isActive({ textAlign: 'right' })} onClick={() => editor?.chain().focus().setTextAlign('right').run()}><IconAlignRight /></TIconBtn>
+            </>
+        ) },
+        { key: 'lists', node: (
+            <>
+                <TIconBtn title='Bullet List' disabled={disabled} active={!!editor?.isActive('bulletList')} onClick={() => editor?.chain().focus().toggleBulletList().run()}><IconListBullet /></TIconBtn>
+                <TIconBtn title='Numbered List' disabled={disabled} active={!!editor?.isActive('orderedList')} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><IconListNumber /></TIconBtn>
+            </>
+        ) },
+        { key: 'blocks', node: (
+            <>
+                <TIconBtn title='Quote' disabled={disabled} active={!!editor?.isActive('blockquote')} onClick={() => editor?.chain().focus().toggleBlockquote().run()}><IconQuote /></TIconBtn>
+                <TIconBtn title='Section Divider' disabled={disabled} onClick={() => editor?.chain().focus().setHorizontalRule().run()}><IconRule /></TIconBtn>
+            </>
+        ) },
+        { key: 'insert', node: (
+            <>
+                <div style={{ position: 'relative', flexShrink: 0 }}>
+                    <TIconBtn title={uploadingImage ? 'Uploading…' : 'Insert Image'} disabled={disabled} active={uploadingImage || imagePopoverOpen}
+                        onClick={() => { if (!uploadingImage) setImagePopoverOpen(v => !v) }}
+                    >
+                        <IconImage />
+                    </TIconBtn>
+                    {imagePopoverOpen && !uploadingImage && (
+                        <div
+                            onMouseDown={e => e.stopPropagation()}
+                            style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '4px 0', display: 'flex', flexDirection: 'column', minWidth: 190, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
+                        >
+                            <button type='button'
+                                onMouseDown={e => e.preventDefault()}
+                                onClick={() => { setImagePopoverOpen(false); imageInputRef.current?.click() }}
+                                style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
+                                onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
+                                onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+                            >Upload from Computer</button>
+                            <button type='button'
+                                onMouseDown={e => e.preventDefault()}
+                                onClick={() => { setImagePopoverOpen(false); setShowImageLibrary(true) }}
+                                style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
+                                onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
+                                onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+                            >Select from Library</button>
+                        </div>
+                    )}
+                </div>
+                <div style={{ position: 'relative', flexShrink: 0 }}>
+                    <TIconBtn title={editor?.isActive('link') ? 'Edit Link' : 'Insert Link'} disabled={disabled} active={!!editor?.isActive('link')}
+                        onClick={() => {
+                            if (!editor) return
+                            const existing = editor.getAttributes('link').href || ''
+                            setLinkUrl(existing)
+                            setLinkText('')
+                            setLinkPopover(v => !v)
+                            const noSel = editor.state.selection.empty
+                            setTimeout(() => (noSel ? linkTextInputRef.current : linkUrlInputRef.current)?.focus(), 40)
+                        }}
+                    >
+                        <IconLink />
+                    </TIconBtn>
+                    {linkPopover && editor && (
+                        <div data-shared-link-popover onMouseDown={e => e.stopPropagation()}
+                            style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 280, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
+                        >
+                            {editor.state.selection.empty && (
+                                <input ref={linkTextInputRef} value={linkText} onChange={e => setLinkText(e.target.value)} placeholder='Display text'
+                                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); linkUrlInputRef.current?.focus() } if (e.key === 'Escape') setLinkPopover(false) }}
+                                    style={{ background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
+                                />
+                            )}
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                                <input ref={linkUrlInputRef} value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder='https://…'
+                                    onKeyDown={e => {
+                                        if (e.key === 'Enter') { e.preventDefault(); applyLink() }
+                                        if (e.key === 'Escape') setLinkPopover(false)
+                                    }}
+                                    style={{ flex: 1, background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
+                                />
+                                <button type='button' onMouseDown={e => e.preventDefault()} onClick={applyLink}
+                                    style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--acc)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', flexShrink: 0 }}
+                                >Apply</button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+                <TIconBtn title='Remove Link' disabled={disabled} onClick={() => { editor?.chain().focus().unsetLink().run(); setLinkPopover(false) }}><IconUnlink /></TIconBtn>
+            </>
+        ) },
+        { key: 'clear', node: (
+            <TIconBtn title='Clear Formatting' disabled={disabled} onClick={() => editor?.chain().focus().clearNodes().unsetAllMarks().run()}><IconClear /></TIconBtn>
+        ) },
+    ]
+
+    const { visibleCount, setGroupRef } = useToolbarOverflow(groups.map(g => g.key), containerRef)
+    const visibleGroups = groups.slice(0, visibleCount)
+    const overflowGroups = groups.slice(visibleCount)
+
     return (
         <div ref={containerRef} style={{
             display: 'flex', alignItems: 'center', gap: 2, height: 44, flexShrink: 0,
             borderBottom: '1px solid var(--line)', background: 'var(--bg)', padding: '0 16px',
-            position: 'sticky', top: 0, zIndex: 20, overflowX: 'auto',
+            position: 'sticky', top: 0, zIndex: 20,
             opacity: disabled ? 0.45 : 1, transition: 'opacity 0.15s',
         }}>
-            {/* History */}
-            <TIconBtn title='Undo' disabled={disabled} onClick={() => editor?.chain().focus().undo().run()}><IconUndo /></TIconBtn>
-            <TIconBtn title='Redo' disabled={disabled} onClick={() => editor?.chain().focus().redo().run()}><IconRedo /></TIconBtn>
-            <TDivider />
-
-            {/* Block type + text size */}
-            <ToolbarDropdown title='Block style' disabled={disabled} minWidth={92}
-                value={String(currentHeadingLevel)} options={HEADING_OPTIONS}
-                onSelect={v => {
-                    if (!editor) return
-                    const lvl = Number(v)
-                    if (lvl === 0) editor.chain().focus().setParagraph().run()
-                    else editor.chain().focus().setHeading({ level: lvl as 1 | 2 | 3 }).run()
-                }}
-            />
-            <ToolbarDropdown title='Text size' disabled={disabled} minWidth={52}
-                value={currentFontSize} options={FONT_SIZE_OPTIONS}
-                onSelect={v => {
-                    if (!editor) return
-                    if (v) (editor.chain().focus() as any).setFontSize(v).run()
-                    else (editor.chain().focus() as any).unsetFontSize().run()
-                }}
-            />
-            <TDivider />
-
-            {/* Inline marks */}
-            <TLabel title='Bold' disabled={disabled} active={!!editor?.isActive('bold')} onClick={() => editor?.chain().focus().toggleBold().run()}>B</TLabel>
-            <TLabel title='Italic' disabled={disabled} active={!!editor?.isActive('italic')} onClick={() => editor?.chain().focus().toggleItalic().run()}>I</TLabel>
-            <TLabel title='Underline' disabled={disabled} active={!!editor?.isActive('underline')} onClick={() => editor?.chain().focus().toggleUnderline().run()}>U</TLabel>
-            <TIconBtn title='Strikethrough' disabled={disabled} active={!!editor?.isActive('strike')} onClick={() => editor?.chain().focus().toggleStrike().run()}><IconStrikethrough /></TIconBtn>
-            <TDivider />
-
-            {/* Colour / highlight */}
-            <TIconBtn title='Highlight' disabled={disabled} active={!!editor?.isActive('highlight')} onClick={() => editor?.chain().focus().toggleHighlight().run()}><IconHighlight /></TIconBtn>
-            <TDivider />
-
-            {/* Alignment */}
-            <TIconBtn title='Align Left' disabled={disabled} active={!!editor?.isActive({ textAlign: 'left' })} onClick={() => editor?.chain().focus().setTextAlign('left').run()}><IconAlignLeft /></TIconBtn>
-            <TIconBtn title='Align Centre' disabled={disabled} active={!!editor?.isActive({ textAlign: 'center' })} onClick={() => editor?.chain().focus().setTextAlign('center').run()}><IconAlignCenter /></TIconBtn>
-            <TIconBtn title='Align Right' disabled={disabled} active={!!editor?.isActive({ textAlign: 'right' })} onClick={() => editor?.chain().focus().setTextAlign('right').run()}><IconAlignRight /></TIconBtn>
-            <TDivider />
-
-            {/* Lists */}
-            <TIconBtn title='Bullet List' disabled={disabled} active={!!editor?.isActive('bulletList')} onClick={() => editor?.chain().focus().toggleBulletList().run()}><IconListBullet /></TIconBtn>
-            <TIconBtn title='Numbered List' disabled={disabled} active={!!editor?.isActive('orderedList')} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><IconListNumber /></TIconBtn>
-            <TDivider />
-
-            {/* Blocks */}
-            <TIconBtn title='Quote' disabled={disabled} active={!!editor?.isActive('blockquote')} onClick={() => editor?.chain().focus().toggleBlockquote().run()}><IconQuote /></TIconBtn>
-            <TIconBtn title='Section Divider' disabled={disabled} onClick={() => editor?.chain().focus().setHorizontalRule().run()}><IconRule /></TIconBtn>
-            <TDivider />
-
-            {/* Insert */}
-            <div style={{ position: 'relative', flexShrink: 0 }}>
-                <TIconBtn title={uploadingImage ? 'Uploading…' : 'Insert Image'} disabled={disabled} active={uploadingImage || imagePopoverOpen}
-                    onClick={() => { if (!uploadingImage) setImagePopoverOpen(v => !v) }}
-                >
-                    <IconImage />
-                </TIconBtn>
-                {imagePopoverOpen && !uploadingImage && (
-                    <div
-                        onMouseDown={e => e.stopPropagation()}
-                        style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '4px 0', display: 'flex', flexDirection: 'column', minWidth: 190, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
-                    >
-                        <button type='button'
-                            onMouseDown={e => e.preventDefault()}
-                            onClick={() => { setImagePopoverOpen(false); imageInputRef.current?.click() }}
-                            style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
-                            onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
-                            onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-                        >Upload from Computer</button>
-                        <button type='button'
-                            onMouseDown={e => e.preventDefault()}
-                            onClick={() => { setImagePopoverOpen(false); setShowImageLibrary(true) }}
-                            style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
-                            onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
-                            onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-                        >Select from Library</button>
+            {visibleGroups.map((g, i) => (
+                <React.Fragment key={g.key}>
+                    {i > 0 && <TDivider />}
+                    <div ref={setGroupRef(g.key)} style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
+                        {g.node}
                     </div>
-                )}
-            </div>
-            <div style={{ position: 'relative', flexShrink: 0 }}>
-                <TIconBtn title={editor?.isActive('link') ? 'Edit Link' : 'Insert Link'} disabled={disabled} active={!!editor?.isActive('link')}
-                    onClick={() => {
-                        if (!editor) return
-                        const existing = editor.getAttributes('link').href || ''
-                        setLinkUrl(existing)
-                        setLinkText('')
-                        setLinkPopover(v => !v)
-                        const noSel = editor.state.selection.empty
-                        setTimeout(() => (noSel ? linkTextInputRef.current : linkUrlInputRef.current)?.focus(), 40)
-                    }}
-                >
-                    <IconLink />
-                </TIconBtn>
-                {linkPopover && editor && (
-                    <div data-shared-link-popover onMouseDown={e => e.stopPropagation()}
-                        style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 280, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
-                    >
-                        {editor.state.selection.empty && (
-                            <input ref={linkTextInputRef} value={linkText} onChange={e => setLinkText(e.target.value)} placeholder='Display text'
-                                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); linkUrlInputRef.current?.focus() } if (e.key === 'Escape') setLinkPopover(false) }}
-                                style={{ background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
-                            />
-                        )}
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                            <input ref={linkUrlInputRef} value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder='https://…'
-                                onKeyDown={e => {
-                                    if (e.key === 'Enter') { e.preventDefault(); applyLink() }
-                                    if (e.key === 'Escape') setLinkPopover(false)
-                                }}
-                                style={{ flex: 1, background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
-                            />
-                            <button type='button' onMouseDown={e => e.preventDefault()} onClick={applyLink}
-                                style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--acc)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', flexShrink: 0 }}
-                            >Apply</button>
-                        </div>
-                    </div>
-                )}
-            </div>
-            <TIconBtn title='Remove Link' disabled={disabled} onClick={() => { editor?.chain().focus().unsetLink().run(); setLinkPopover(false) }}><IconUnlink /></TIconBtn>
-            <TDivider />
+                </React.Fragment>
+            ))}
 
-            {/* Clear */}
-            <TIconBtn title='Clear Formatting' disabled={disabled} onClick={() => editor?.chain().focus().clearNodes().unsetAllMarks().run()}><IconClear /></TIconBtn>
+            {/* "⋯" only ever appears once genuinely needed (visual-fixes FIX
+                1) — useToolbarOverflow returns the full group count, and this
+                stays unrendered, whenever everything already fits. */}
+            {overflowGroups.length > 0 && (
+                <>
+                    <TDivider />
+                    <ToolbarOverflowMenu groups={overflowGroups} />
+                </>
+            )}
 
             <input ref={imageInputRef} type='file' accept='image/*' style={{ display: 'none' }}
                 onChange={e => { const file = e.target.files?.[0]; if (file) handleImageUpload(file); e.target.value = '' }}
@@ -916,6 +1051,48 @@ function EditorToolbar({ editor, uploadUrl, containerRef }: EditorToolbarProps) 
                     onSelect={url => { editor?.chain().focus().setImage({ src: url }).run(); setShowImageLibrary(false) }}
                     onClose={() => setShowImageLibrary(false)}
                 />
+            )}
+        </div>
+    )
+}
+
+/**
+ * The "⋯" overflow trigger + popover (visual-fixes FIX 1) — holds whichever
+ * trailing groups `useToolbarOverflow` decided don't fit on the bar, in the
+ * same fixed order they'd otherwise appear in. Every control inside still
+ * goes through TIconBtn/TLabel/ToolbarDropdown, so the mousedown
+ * preventDefault that keeps focus in the document (and this trigger button
+ * itself, via TIconBtn) is never reintroduced as a regression here.
+ */
+function ToolbarOverflowMenu({ groups }: { groups: { key: string; node: React.ReactNode }[] }) {
+    const [open, setOpen] = useState(false)
+    const ref = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!open) return
+        const close = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) setOpen(false) }
+        document.addEventListener('mousedown', close)
+        return () => document.removeEventListener('mousedown', close)
+    }, [open])
+
+    return (
+        <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
+            <TIconBtn title='More formatting options' active={open} onClick={() => setOpen(v => !v)}>
+                <IconMoreHoriz />
+            </TIconBtn>
+            {open && (
+                <div onMouseDown={e => e.stopPropagation()}
+                    style={{ position: 'absolute', top: '110%', right: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: 6, display: 'flex', flexDirection: 'column', gap: 6, minWidth: 160, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
+                >
+                    {groups.map((g, i) => (
+                        <React.Fragment key={g.key}>
+                            {i > 0 && <div style={{ height: 1, background: 'var(--line)' }} />}
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                                {g.node}
+                            </div>
+                        </React.Fragment>
+                    ))}
+                </div>
             )}
         </div>
     )
@@ -1349,22 +1526,6 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
     )
 }
 
-function PresenceAvatar({ peer, self }: { peer: Peer; self?: boolean }) {
-    const [hovered, setHovered] = useState(false)
-    return (
-        <div style={{ position: 'relative', flexShrink: 0 }} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
-            <div style={{ width: 26, height: 26, borderRadius: '50%', background: peer.color, border: `2px solid ${self ? 'rgba(255,255,255,0.5)' : peer.color}`, overflow: 'hidden', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, fontWeight: 700, color: '#fff', textTransform: 'uppercase', cursor: 'default', flexShrink: 0, opacity: self ? 0.85 : 1 }}>
-                {peer.avatar ? <img src={peer.avatar} alt={peer.name} style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} /> : peer.name.charAt(0)}
-            </div>
-            {hovered && (
-                <div style={{ position: 'absolute', bottom: '120%', left: '50%', transform: 'translateX(-50%)', background: peer.color, color: '#fff', fontSize: 11, fontWeight: 600, padding: '3px 8px', borderRadius: 3, whiteSpace: 'nowrap', pointerEvents: 'none', zIndex: 100 }}>
-                    {self ? `${peer.name} (you)` : peer.name}
-                </div>
-            )}
-        </div>
-    )
-}
-
 /** Compact icon control for the shared toolbar (visual-fixes-report FIX 2) —
  * every icon-bearing button in `EditorToolbar` routes through this so the
  * `onMouseDown` focus-retention fix (FIX 1) and the active/hover token
@@ -1450,3 +1611,4 @@ const IconLink = () => <Svg><path d='M10 14a4.5 4.5 0 0 1 0-6.36l2-2a4.5 4.5 0 1
 const IconUnlink = () => <Svg><path d='M9.5 14.5a4.5 4.5 0 0 1-1.15-4.4' /><path d='M14.5 9.5a4.5 4.5 0 0 1 1.15 4.4' /><path d='m12.35 6.85 1.65-1.65a4.5 4.5 0 1 1 6.36 6.36l-1.65 1.65' /><path d='m11.65 17.15-1.65 1.65a4.5 4.5 0 1 1-6.36-6.36l1.65-1.65' /><line x1='4' y1='4' x2='20' y2='20' /></Svg>
 const IconClear = () => <Svg><path d='M18 5H8.5L4 9.5 12.5 18H18' /><path d='m13.5 9.5-4.5 4.5' /><line x1='9' y1='21' x2='19' y2='21' /></Svg>
 const IconChevronDown = () => <Svg size={11}><path d='M6 9l6 6 6-6' /></Svg>
+const IconMoreHoriz = () => <Svg><circle cx='5' cy='12' r='1.6' fill='currentColor' stroke='none' /><circle cx='12' cy='12' r='1.6' fill='currentColor' stroke='none' /><circle cx='19' cy='12' r='1.6' fill='currentColor' stroke='none' /></Svg>

--- a/apps/web/components/editor/CollabEditor.tsx
+++ b/apps/web/components/editor/CollabEditor.tsx
@@ -22,6 +22,7 @@ import { TextStyle } from '@tiptap/extension-text-style'
 import PageSidebar from './PageSidebar'
 import IntelPackageEditor from './intel-package/IntelPackageEditor'
 import ImageLibraryModal from './ImageLibraryModal'
+import { useThinScrollFade } from './useThinScrollFade'
 import {
     FormatAlignLeft, FormatAlignCenter, FormatAlignRight,
     Delete, Lock, LockOpen,
@@ -481,6 +482,11 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
     // reads activeEditor via the `editor` prop closure) ever runs.
     const toolbarRef = useRef<HTMLDivElement>(null)
 
+    // The editor column is its own scroll container on desktop (see the
+    // `overflowY` note on the column div below), so it gets the same thin
+    // fading overlay scrollbar treatment `.mainScroll` has.
+    const columnScrollRef = useThinScrollFade<HTMLDivElement>()
+
     useEffect(() => {
         const check = () => setIsMobile(window.innerWidth < 768)
         check()
@@ -637,11 +643,39 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
                     presenceUser={{ id: 'self', ...user }}
                     presencePeers={peers.map(p => ({ id: p.clientId, name: p.name, color: p.color, avatar: p.avatar }))}
                 />
-                <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+                {/*
+                 * The editor column, not `.mainScroll`, is what actually
+                 * scrolls on desktop. The rail beside it is `position:
+                 * sticky`, and a sticky box can only travel inside its own
+                 * containing block — which here is this row, exactly one
+                 * viewport tall. A three-screen document scrolling in an
+                 * ancestor therefore gave the rail nowhere to stick to and
+                 * it simply scrolled away with the content. Confining the
+                 * overflow to this column instead means the row never
+                 * scrolls at all, so the rail (and the sticky toolbar just
+                 * inside here, which had the same containing-block problem)
+                 * stay put by construction rather than by viewport maths.
+                 * `minHeight: 0` is the usual flex-child override without
+                 * which this box refuses to shrink below its content and
+                 * never overflows in the first place.
+                 *
+                 * Mobile keeps scrolling in `.mainScroll`: there the rail is
+                 * `orientation='top'` and this is a column, so there's no
+                 * sticky side rail to preserve.
+                 */}
+                <div
+                    ref={columnScrollRef}
+                    className={isMobile ? undefined : 'thin-scroll'}
+                    style={{
+                        flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column',
+                        minHeight: isMobile ? undefined : 0,
+                        overflowY: isMobile ? undefined : 'auto',
+                    }}
+                >
                     {/* One persistent formatting toolbar, owned by the column rather
                         than any section (visual-fixes spec §1) — pinned above all
                         document content and, via `position: sticky`, staying put as
-                        the content beneath it scrolls inside .mainScroll. It always
+                        the content beneath it scrolls in this column. It always
                         targets `activeEditor`, the last section to report focus. */}
                     {!readOnly && activePageType !== 'intel' && (
                         <EditorToolbar editor={activeEditor} uploadUrl={uploadUrl} containerRef={toolbarRef} />

--- a/apps/web/components/editor/CollabEditor.tsx
+++ b/apps/web/components/editor/CollabEditor.tsx
@@ -22,11 +22,8 @@ import PageSidebar from './PageSidebar'
 import IntelPackageEditor from './intel-package/IntelPackageEditor'
 import ImageLibraryModal from './ImageLibraryModal'
 import {
-    Undo, Redo, StrikethroughS,
-    FormatListNumbered,
     FormatAlignLeft, FormatAlignCenter, FormatAlignRight,
-    FormatQuote, HorizontalRule, FormatClear, FormatColorFill,
-    InsertLink, LinkOff, Delete, Lock, LockOpen,
+    Delete, Lock, LockOpen,
 } from '@mui/icons-material'
 
 
@@ -723,7 +720,6 @@ interface EditorToolbarProps {
  * the image actually lands in, independent of this toolbar's own state).
  */
 function EditorToolbar({ editor, uploadUrl, containerRef }: EditorToolbarProps) {
-    const [toolbarOverflowOpen, setToolbarOverflowOpen] = useState(false)
     const [imagePopoverOpen, setImagePopoverOpen] = useState(false)
     const [showImageLibrary, setShowImageLibrary] = useState(false)
     const [uploadingImage, setUploadingImage] = useState(false)
@@ -777,55 +773,88 @@ function EditorToolbar({ editor, uploadUrl, containerRef }: EditorToolbarProps) 
     // 0 means "plain paragraph", matching whichever of H1/H2/H3 (if any) the
     // focused section's cursor is currently in.
     const currentHeadingLevel = editor ? (([1, 2, 3] as const).find(l => editor.isActive('heading', { level: l })) ?? 0) : 0
+    const currentFontSize = (editor?.getAttributes('textStyle').fontSize as string | undefined) || ''
 
     return (
         <div ref={containerRef} style={{
             display: 'flex', alignItems: 'center', gap: 2, height: 44, flexShrink: 0,
-            borderBottom: '1px solid var(--line)', background: 'var(--bg)', padding: '0 20px',
-            position: 'sticky', top: 0, zIndex: 20,
+            borderBottom: '1px solid var(--line)', background: 'var(--bg)', padding: '0 16px',
+            position: 'sticky', top: 0, zIndex: 20, overflowX: 'auto',
             opacity: disabled ? 0.45 : 1, transition: 'opacity 0.15s',
         }}>
-            <select
-                value={String(currentHeadingLevel)}
-                disabled={disabled}
-                onChange={e => {
+            {/* History */}
+            <TIconBtn title='Undo' disabled={disabled} onClick={() => editor?.chain().focus().undo().run()}><IconUndo /></TIconBtn>
+            <TIconBtn title='Redo' disabled={disabled} onClick={() => editor?.chain().focus().redo().run()}><IconRedo /></TIconBtn>
+            <TDivider />
+
+            {/* Block type + text size */}
+            <ToolbarDropdown title='Block style' disabled={disabled} minWidth={92}
+                value={String(currentHeadingLevel)} options={HEADING_OPTIONS}
+                onSelect={v => {
                     if (!editor) return
-                    const lvl = Number(e.target.value)
+                    const lvl = Number(v)
                     if (lvl === 0) editor.chain().focus().setParagraph().run()
                     else editor.chain().focus().setHeading({ level: lvl as 1 | 2 | 3 }).run()
                 }}
-                title='Block style'
-                style={{ background: 'none', border: 'none', color: 'var(--ink-2)', fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase', padding: '4px 6px', cursor: disabled ? 'default' : 'pointer', outline: 'none' }}
-            >
-                <option value='0'>Text</option>
-                <option value='1'>Heading 1</option>
-                <option value='2'>Heading 2</option>
-                <option value='3'>Heading 3</option>
-            </select>
+            />
+            <ToolbarDropdown title='Text size' disabled={disabled} minWidth={52}
+                value={currentFontSize} options={FONT_SIZE_OPTIONS}
+                onSelect={v => {
+                    if (!editor) return
+                    if (v) (editor.chain().focus() as any).setFontSize(v).run()
+                    else (editor.chain().focus() as any).unsetFontSize().run()
+                }}
+            />
             <TDivider />
+
+            {/* Inline marks */}
             <TLabel title='Bold' disabled={disabled} active={!!editor?.isActive('bold')} onClick={() => editor?.chain().focus().toggleBold().run()}>B</TLabel>
             <TLabel title='Italic' disabled={disabled} active={!!editor?.isActive('italic')} onClick={() => editor?.chain().focus().toggleItalic().run()}>I</TLabel>
             <TLabel title='Underline' disabled={disabled} active={!!editor?.isActive('underline')} onClick={() => editor?.chain().focus().toggleUnderline().run()}>U</TLabel>
+            <TIconBtn title='Strikethrough' disabled={disabled} active={!!editor?.isActive('strike')} onClick={() => editor?.chain().focus().toggleStrike().run()}><IconStrikethrough /></TIconBtn>
             <TDivider />
-            <TLabel title='Bullet List' disabled={disabled} active={!!editor?.isActive('bulletList')} onClick={() => editor?.chain().focus().toggleBulletList().run()}>List</TLabel>
-            <div style={{ position: 'relative' }}>
-                <TLabel title={uploadingImage ? 'Uploading…' : 'Insert Image'} disabled={disabled} active={uploadingImage || imagePopoverOpen}
+
+            {/* Colour / highlight */}
+            <TIconBtn title='Highlight' disabled={disabled} active={!!editor?.isActive('highlight')} onClick={() => editor?.chain().focus().toggleHighlight().run()}><IconHighlight /></TIconBtn>
+            <TDivider />
+
+            {/* Alignment */}
+            <TIconBtn title='Align Left' disabled={disabled} active={!!editor?.isActive({ textAlign: 'left' })} onClick={() => editor?.chain().focus().setTextAlign('left').run()}><IconAlignLeft /></TIconBtn>
+            <TIconBtn title='Align Centre' disabled={disabled} active={!!editor?.isActive({ textAlign: 'center' })} onClick={() => editor?.chain().focus().setTextAlign('center').run()}><IconAlignCenter /></TIconBtn>
+            <TIconBtn title='Align Right' disabled={disabled} active={!!editor?.isActive({ textAlign: 'right' })} onClick={() => editor?.chain().focus().setTextAlign('right').run()}><IconAlignRight /></TIconBtn>
+            <TDivider />
+
+            {/* Lists */}
+            <TIconBtn title='Bullet List' disabled={disabled} active={!!editor?.isActive('bulletList')} onClick={() => editor?.chain().focus().toggleBulletList().run()}><IconListBullet /></TIconBtn>
+            <TIconBtn title='Numbered List' disabled={disabled} active={!!editor?.isActive('orderedList')} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><IconListNumber /></TIconBtn>
+            <TDivider />
+
+            {/* Blocks */}
+            <TIconBtn title='Quote' disabled={disabled} active={!!editor?.isActive('blockquote')} onClick={() => editor?.chain().focus().toggleBlockquote().run()}><IconQuote /></TIconBtn>
+            <TIconBtn title='Section Divider' disabled={disabled} onClick={() => editor?.chain().focus().setHorizontalRule().run()}><IconRule /></TIconBtn>
+            <TDivider />
+
+            {/* Insert */}
+            <div style={{ position: 'relative', flexShrink: 0 }}>
+                <TIconBtn title={uploadingImage ? 'Uploading…' : 'Insert Image'} disabled={disabled} active={uploadingImage || imagePopoverOpen}
                     onClick={() => { if (!uploadingImage) setImagePopoverOpen(v => !v) }}
                 >
-                    Image
-                </TLabel>
+                    <IconImage />
+                </TIconBtn>
                 {imagePopoverOpen && !uploadingImage && (
                     <div
                         onMouseDown={e => e.stopPropagation()}
                         style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '4px 0', display: 'flex', flexDirection: 'column', minWidth: 190, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
                     >
                         <button type='button'
+                            onMouseDown={e => e.preventDefault()}
                             onClick={() => { setImagePopoverOpen(false); imageInputRef.current?.click() }}
                             style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
                             onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
                             onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
                         >Upload from Computer</button>
                         <button type='button'
+                            onMouseDown={e => e.preventDefault()}
                             onClick={() => { setImagePopoverOpen(false); setShowImageLibrary(true) }}
                             style={{ padding: '8px 14px', background: 'transparent', border: 'none', color: 'var(--ink-2)', fontSize: '0.65rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer', textAlign: 'left' }}
                             onMouseEnter={e => (e.currentTarget.style.background = 'var(--s3)')}
@@ -834,95 +863,50 @@ function EditorToolbar({ editor, uploadUrl, containerRef }: EditorToolbarProps) 
                     </div>
                 )}
             </div>
-
-            <div style={{ flex: 1 }} />
-
-            {/* Overflow — undo/redo, font size, strike/highlight, align,
-                numbered list, quote, divider, link, clear formatting. Same
-                commands the old per-section overflow menu exposed; only the
-                toolbar hosting them moved. */}
-            <div style={{ position: 'relative' }}>
-                <TLabel title='More formatting' disabled={disabled} active={toolbarOverflowOpen} onClick={() => setToolbarOverflowOpen(v => !v)}>⋯</TLabel>
-                {toolbarOverflowOpen && editor && (
-                    <div
-                        onMouseDown={e => e.stopPropagation()}
-                        style={{ position: 'absolute', top: '110%', right: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: 6, display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 2, width: 232, boxShadow: '0 8px 24px rgba(0,0,0,0.5)' }}
+            <div style={{ position: 'relative', flexShrink: 0 }}>
+                <TIconBtn title={editor?.isActive('link') ? 'Edit Link' : 'Insert Link'} disabled={disabled} active={!!editor?.isActive('link')}
+                    onClick={() => {
+                        if (!editor) return
+                        const existing = editor.getAttributes('link').href || ''
+                        setLinkUrl(existing)
+                        setLinkText('')
+                        setLinkPopover(v => !v)
+                        const noSel = editor.state.selection.empty
+                        setTimeout(() => (noSel ? linkTextInputRef.current : linkUrlInputRef.current)?.focus(), 40)
+                    }}
+                >
+                    <IconLink />
+                </TIconBtn>
+                {linkPopover && editor && (
+                    <div data-shared-link-popover onMouseDown={e => e.stopPropagation()}
+                        style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 280, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
                     >
-                        <TBtn title='Undo' onClick={() => editor.chain().focus().undo().run()}><Undo style={{ fontSize: 16 }} /></TBtn>
-                        <TBtn title='Redo' onClick={() => editor.chain().focus().redo().run()}><Redo style={{ fontSize: 16 }} /></TBtn>
-                        <TDivider />
-                        <TBtn title='Strikethrough' active={editor.isActive('strike')} onClick={() => editor.chain().focus().toggleStrike().run()}><StrikethroughS style={{ fontSize: 17 }} /></TBtn>
-                        <TBtn title='Highlight' active={editor.isActive('highlight')} onClick={() => editor.chain().focus().toggleHighlight().run()}><FormatColorFill style={{ fontSize: 17 }} /></TBtn>
-                        <TDivider />
-                        <TBtn title='Align Left' active={editor.isActive({ textAlign: 'left' })} onClick={() => editor.chain().focus().setTextAlign('left').run()}><FormatAlignLeft style={{ fontSize: 17 }} /></TBtn>
-                        <TBtn title='Align Centre' active={editor.isActive({ textAlign: 'center' })} onClick={() => editor.chain().focus().setTextAlign('center').run()}><FormatAlignCenter style={{ fontSize: 17 }} /></TBtn>
-                        <TBtn title='Align Right' active={editor.isActive({ textAlign: 'right' })} onClick={() => editor.chain().focus().setTextAlign('right').run()}><FormatAlignRight style={{ fontSize: 17 }} /></TBtn>
-                        <TDivider />
-                        <TBtn title='Numbered List' active={editor.isActive('orderedList')} onClick={() => editor.chain().focus().toggleOrderedList().run()}><FormatListNumbered style={{ fontSize: 17 }} /></TBtn>
-                        <TBtn title='Quote' active={editor.isActive('blockquote')} onClick={() => editor.chain().focus().toggleBlockquote().run()}><FormatQuote style={{ fontSize: 17 }} /></TBtn>
-                        <TBtn title='Section Divider' onClick={() => editor.chain().focus().setHorizontalRule().run()}><HorizontalRule style={{ fontSize: 17 }} /></TBtn>
-                        <TDivider />
-                        <div style={{ position: 'relative' }}>
-                            <TBtn title={editor.isActive('link') ? 'Edit Link' : 'Insert Link'} active={editor.isActive('link')}
-                                onClick={() => {
-                                    const existing = editor.getAttributes('link').href || ''
-                                    setLinkUrl(existing)
-                                    setLinkText('')
-                                    setLinkPopover(v => !v)
-                                    const noSel = editor.state.selection.empty
-                                    setTimeout(() => (noSel ? linkTextInputRef.current : linkUrlInputRef.current)?.focus(), 40)
+                        {editor.state.selection.empty && (
+                            <input ref={linkTextInputRef} value={linkText} onChange={e => setLinkText(e.target.value)} placeholder='Display text'
+                                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); linkUrlInputRef.current?.focus() } if (e.key === 'Escape') setLinkPopover(false) }}
+                                style={{ background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
+                            />
+                        )}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                            <input ref={linkUrlInputRef} value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder='https://…'
+                                onKeyDown={e => {
+                                    if (e.key === 'Enter') { e.preventDefault(); applyLink() }
+                                    if (e.key === 'Escape') setLinkPopover(false)
                                 }}
-                            >
-                                <InsertLink style={{ fontSize: 17 }} />
-                            </TBtn>
-                            {linkPopover && (
-                                <div data-shared-link-popover onMouseDown={e => e.stopPropagation()}
-                                    style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 280, boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
-                                >
-                                    {editor.state.selection.empty && (
-                                        <input ref={linkTextInputRef} value={linkText} onChange={e => setLinkText(e.target.value)} placeholder='Display text'
-                                            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); linkUrlInputRef.current?.focus() } if (e.key === 'Escape') setLinkPopover(false) }}
-                                            style={{ background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
-                                        />
-                                    )}
-                                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                                        <input ref={linkUrlInputRef} value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder='https://…'
-                                            onKeyDown={e => {
-                                                if (e.key === 'Enter') { e.preventDefault(); applyLink() }
-                                                if (e.key === 'Escape') setLinkPopover(false)
-                                            }}
-                                            style={{ flex: 1, background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
-                                        />
-                                        <button type='button' onClick={applyLink}
-                                            style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--acc)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', flexShrink: 0 }}
-                                        >Apply</button>
-                                    </div>
-                                </div>
-                            )}
+                                style={{ flex: 1, background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', color: 'var(--ink)', fontSize: '0.78rem', letterSpacing: '0.02em', outline: 'none', padding: '3px 2px' }}
+                            />
+                            <button type='button' onMouseDown={e => e.preventDefault()} onClick={applyLink}
+                                style={{ fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--acc)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', flexShrink: 0 }}
+                            >Apply</button>
                         </div>
-                        <TBtn title='Remove Link' onClick={() => { editor.chain().focus().unsetLink().run(); setLinkPopover(false) }}>
-                            <LinkOff style={{ fontSize: 17 }} />
-                        </TBtn>
-                        <TDivider />
-                        <TBtn title='Clear Formatting' onClick={() => editor.chain().focus().clearNodes().unsetAllMarks().run()}>
-                            <FormatClear style={{ fontSize: 17 }} />
-                        </TBtn>
-                        <select
-                            value={(editor.getAttributes('textStyle').fontSize as string | undefined) || ''}
-                            onChange={e => {
-                                if (e.target.value) (editor.chain().focus() as any).setFontSize(e.target.value).run()
-                                else (editor.chain().focus() as any).unsetFontSize().run()
-                            }}
-                            title='Font size'
-                            style={{ background: 'var(--s3)', border: '1px solid var(--line-2)', color: 'var(--ink-2)', fontSize: '0.65rem', padding: '0 4px', cursor: 'pointer', height: 26, outline: 'none', minWidth: 52 }}>
-                            <option value=''>Size</option>
-                            {[10, 11, 12, 13, 14, 16, 18, 20, 24, 28, 32, 36, 48].map(s => (
-                                <option key={s} value={`${s}px`}>{s}</option>
-                            ))}
-                        </select>
                     </div>
                 )}
             </div>
+            <TIconBtn title='Remove Link' disabled={disabled} onClick={() => { editor?.chain().focus().unsetLink().run(); setLinkPopover(false) }}><IconUnlink /></TIconBtn>
+            <TDivider />
+
+            {/* Clear */}
+            <TIconBtn title='Clear Formatting' disabled={disabled} onClick={() => editor?.chain().focus().clearNodes().unsetAllMarks().run()}><IconClear /></TIconBtn>
 
             <input ref={imageInputRef} type='file' accept='image/*' style={{ display: 'none' }}
                 onChange={e => { const file = e.target.files?.[0]; if (file) handleImageUpload(file); e.target.value = '' }}
@@ -932,6 +916,87 @@ function EditorToolbar({ editor, uploadUrl, containerRef }: EditorToolbarProps) 
                     onSelect={url => { editor?.chain().focus().setImage({ src: url }).run(); setShowImageLibrary(false) }}
                     onClose={() => setShowImageLibrary(false)}
                 />
+            )}
+        </div>
+    )
+}
+
+const HEADING_OPTIONS = [
+    { value: '0', label: 'Text' },
+    { value: '1', label: 'Heading 1' },
+    { value: '2', label: 'Heading 2' },
+    { value: '3', label: 'Heading 3' },
+]
+
+const FONT_SIZE_OPTIONS = [
+    { value: '', label: 'Size' },
+    ...[10, 11, 12, 13, 14, 16, 18, 20, 24, 28, 32, 36, 48].map(s => ({ value: `${s}px`, label: String(s) })),
+]
+
+/**
+ * Custom button + menu standing in for a native `<select>` in the shared
+ * toolbar (visual-fixes-report FIX 1). A native `<select>`'s own dropdown
+ * needs its mousedown, so it can't take the `preventDefault` treatment every
+ * other control here gets — converting it to this component instead keeps
+ * the block-type and text-size controls on the same interaction model (and
+ * the same token-based styling) as everything else, rather than carving out
+ * a focus-and-reapply special case just for these two.
+ */
+function ToolbarDropdown({ value, options, onSelect, disabled, title, minWidth = 80 }: {
+    value: string
+    options: { value: string; label: string }[]
+    onSelect: (value: string) => void
+    disabled?: boolean
+    title: string
+    minWidth?: number
+}) {
+    const [open, setOpen] = useState(false)
+    const ref = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!open) return
+        const close = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) setOpen(false) }
+        document.addEventListener('mousedown', close)
+        return () => document.removeEventListener('mousedown', close)
+    }, [open])
+
+    const current = options.find(o => o.value === value) || options[0]
+
+    return (
+        <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
+            <button type='button' title={title} disabled={disabled}
+                onMouseDown={e => e.preventDefault()}
+                onClick={() => setOpen(v => !v)}
+                style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 4,
+                    padding: '5px 6px', minWidth, background: open ? 'var(--s2)' : 'transparent', border: 'none', borderRadius: 'var(--r)',
+                    color: 'var(--ink-2)', fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
+                    cursor: disabled ? 'default' : 'pointer', transition: 'color 0.15s',
+                }}
+                onMouseEnter={e => { e.currentTarget.style.color = 'var(--ink)' }}
+                onMouseLeave={e => { e.currentTarget.style.color = 'var(--ink-2)' }}
+            >
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{current.label}</span>
+                <IconChevronDown />
+            </button>
+            {open && (
+                <div onMouseDown={e => e.stopPropagation()}
+                    style={{ position: 'absolute', top: '110%', left: 0, zIndex: 50, background: 'var(--s2)', border: '1px solid var(--line-2)', borderRadius: 'var(--r)', padding: 4, display: 'flex', flexDirection: 'column', minWidth: Math.max(minWidth, 120), maxHeight: 280, overflowY: 'auto', boxShadow: '0 4px 20px rgba(0,0,0,0.6)' }}
+                >
+                    {options.map(o => (
+                        <button key={o.value} type='button'
+                            onMouseDown={e => e.preventDefault()}
+                            onClick={() => { onSelect(o.value); setOpen(false) }}
+                            style={{
+                                textAlign: 'left', padding: '6px 10px', background: o.value === value ? 'var(--s3)' : 'transparent',
+                                border: 'none', borderRadius: 'var(--r)', color: o.value === value ? 'var(--acc)' : 'var(--ink-2)',
+                                fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', cursor: 'pointer',
+                            }}
+                            onMouseEnter={e => { e.currentTarget.style.color = 'var(--ink)' }}
+                            onMouseLeave={e => { e.currentTarget.style.color = o.value === value ? 'var(--acc)' : 'var(--ink-2)' }}
+                        >{o.label}</button>
+                    ))}
+                </div>
             )}
         </div>
     )
@@ -1300,15 +1365,26 @@ function PresenceAvatar({ peer, self }: { peer: Peer; self?: boolean }) {
     )
 }
 
-function TBtn({ onClick, active, title, children }: { onClick: () => void; active?: boolean; title: string; children: React.ReactNode }) {
-    const themeColor = useContext(ThemeContext)
-    const { r, g, b } = hexToRgb(themeColor)
-    const c = (a: number) => `rgba(${r},${g},${b},${a})`
+/** Compact icon control for the shared toolbar (visual-fixes-report FIX 2) —
+ * every icon-bearing button in `EditorToolbar` routes through this so the
+ * `onMouseDown` focus-retention fix (FIX 1) and the active/hover token
+ * colours only need to live in one place. */
+function TIconBtn({ onClick, active, title, disabled, children }: { onClick: () => void; active?: boolean; title: string; disabled?: boolean; children: React.ReactNode }) {
     return (
-        <button type='button' title={title} onClick={onClick}
-            style={{ padding: '4px 7px', background: active ? c(0.15) : 'transparent', border: active ? `1px solid ${c(0.3)}` : '1px solid transparent', color: active ? c(0.9) : 'rgba(237,237,237,0.5)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 2, transition: 'all 0.15s', minWidth: 28, height: 28 }}
-            onMouseEnter={e => { if (!active) { e.currentTarget.style.color = 'rgba(237,237,237,0.9)'; e.currentTarget.style.background = 'rgba(255,255,255,0.06)' } }}
-            onMouseLeave={e => { if (!active) { e.currentTarget.style.color = 'rgba(237,237,237,0.5)'; e.currentTarget.style.background = 'transparent' } }}
+        <button type='button' title={title} disabled={disabled}
+            onMouseDown={e => e.preventDefault()}
+            onClick={onClick}
+            style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                width: 26, height: 26, padding: 0,
+                background: active ? 'rgba(var(--acc-rgb), 0.16)' : 'transparent',
+                border: active ? '1px solid rgba(var(--acc-rgb), 0.35)' : '1px solid transparent',
+                borderRadius: 'var(--r)',
+                color: active ? 'var(--acc)' : 'var(--ink-2)',
+                cursor: disabled ? 'default' : 'pointer', transition: 'all 0.15s',
+            }}
+            onMouseEnter={e => { if (!active) e.currentTarget.style.color = 'var(--ink)' }}
+            onMouseLeave={e => { if (!active) e.currentTarget.style.color = 'var(--ink-2)' }}
         >
             {children}
         </button>
@@ -1316,23 +1392,23 @@ function TBtn({ onClick, active, title, children }: { onClick: () => void; activ
 }
 
 function TDivider() {
-    return <div style={{ width: 1, height: 18, background: 'rgba(255,255,255,0.1)', margin: '0 3px' }} />
+    return <div style={{ width: 1, height: 16, background: 'var(--line)', margin: '0 4px', flexShrink: 0 }} />
 }
 
-/** Primary-toolbar control (visual-fixes spec §2): a quiet mono text label
- * rather than an MUI icon — used for the small set of controls that stay
- * visible on the slim main row (block style, B/I/U, list, image, the
- * overflow toggle). Everything else keeps the icon-based `TBtn` inside the
- * overflow panel. */
+/** Primary-toolbar text control (visual-fixes-report FIX 2) — a quiet mono
+ * label rather than an icon, reserved for the few controls a label reads
+ * more clearly than an icon would (B / I / U). */
 function TLabel({ onClick, active, title, disabled, children }: { onClick: () => void; active?: boolean; title: string; disabled?: boolean; children: React.ReactNode }) {
     return (
-        <button type='button' title={title} onClick={onClick} disabled={disabled}
+        <button type='button' title={title} disabled={disabled}
+            onMouseDown={e => e.preventDefault()}
+            onClick={onClick}
             style={{
-                padding: '5px 8px',
-                background: active ? 'var(--s2)' : 'transparent',
+                padding: '5px 8px', flexShrink: 0,
+                background: active ? 'rgba(var(--acc-rgb), 0.14)' : 'transparent',
                 border: 'none',
                 borderRadius: 'var(--r)',
-                color: active ? 'var(--ink)' : 'var(--ink-2)',
+                color: active ? 'var(--acc)' : 'var(--ink-2)',
                 fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.14em', textTransform: 'uppercase',
                 cursor: disabled ? 'default' : 'pointer', transition: 'all 0.15s',
             }}
@@ -1343,3 +1419,34 @@ function TLabel({ onClick, active, title, disabled, children }: { onClick: () =>
         </button>
     )
 }
+
+// ─── Toolbar icons ─────────────────────────────────────────────────────────────
+// Small stroke-based inline SVGs (visual-fixes-report FIX 2) rather than the
+// MUI/Material glyph set used elsewhere in this file — kept to a single
+// consistent stroke weight and size so the shared toolbar reads as one quiet
+// row rather than a mix of icon styles. Scoped to `EditorToolbar`; the
+// per-image floating toolbar in `ResizableImageView` is a separate control
+// surface and keeps its existing MUI icons.
+function Svg({ children, size = 15 }: { children: React.ReactNode; size?: number }) {
+    return (
+        <svg width={size} height={size} viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth={1.75} strokeLinecap='round' strokeLinejoin='round'>
+            {children}
+        </svg>
+    )
+}
+const IconUndo = () => <Svg><path d='M3 7v6h6' /><path d='M21 17a9 9 0 0 0-9-9c-2.4 0-4.68.94-6.36 2.64L3 13' /></Svg>
+const IconRedo = () => <Svg><path d='M21 7v6h-6' /><path d='M3 17a9 9 0 0 1 9-9c2.4 0 4.68.94 6.36 2.64L21 13' /></Svg>
+const IconStrikethrough = () => <Svg><path d='M16 4H9.5A3.5 3.5 0 0 0 8 10.67' /><path d='M14 12a4 4 0 0 1 0 8H6' /><line x1='4' y1='12' x2='20' y2='12' /></Svg>
+const IconHighlight = () => <Svg><path d='M4 20h4l10.5-10.5-4-4L4 16Z' /><path d='m13 6.5 4 4' /><path d='M8 20H4v-4' /></Svg>
+const IconAlignLeft = () => <Svg><line x1='4' y1='6' x2='20' y2='6' /><line x1='4' y1='12' x2='13' y2='12' /><line x1='4' y1='18' x2='17' y2='18' /></Svg>
+const IconAlignCenter = () => <Svg><line x1='4' y1='6' x2='20' y2='6' /><line x1='7.5' y1='12' x2='16.5' y2='12' /><line x1='6' y1='18' x2='18' y2='18' /></Svg>
+const IconAlignRight = () => <Svg><line x1='4' y1='6' x2='20' y2='6' /><line x1='11' y1='12' x2='20' y2='12' /><line x1='7' y1='18' x2='20' y2='18' /></Svg>
+const IconListBullet = () => <Svg><circle cx='4.5' cy='6' r='1' fill='currentColor' stroke='none' /><circle cx='4.5' cy='12' r='1' fill='currentColor' stroke='none' /><circle cx='4.5' cy='18' r='1' fill='currentColor' stroke='none' /><line x1='9' y1='6' x2='20' y2='6' /><line x1='9' y1='12' x2='20' y2='12' /><line x1='9' y1='18' x2='20' y2='18' /></Svg>
+const IconListNumber = () => <Svg><path d='M4.5 5.5h1v3' /><path d='M4.5 14.3c0-.8.7-1.3 1.4-1.3.8 0 1.4.4 1.4 1.1 0 .5-.4.8-.9 1.3l-1.9 1.8h2.8' /><line x1='11' y1='6' x2='20' y2='6' /><line x1='11' y1='12' x2='20' y2='12' /><line x1='11' y1='18' x2='20' y2='18' /></Svg>
+const IconQuote = () => <Svg><path d='M7 8a3 3 0 0 0-3 3v2a2 2 0 0 0 2 2h1v3l-3 2' /><path d='M17 8a3 3 0 0 0-3 3v2a2 2 0 0 0 2 2h1v3l-3 2' /></Svg>
+const IconRule = () => <Svg><line x1='4' y1='12' x2='20' y2='12' /></Svg>
+const IconImage = () => <Svg><rect x='3.5' y='4.5' width='17' height='15' rx='1.5' /><circle cx='9' cy='10' r='1.6' /><path d='m5 17 5-5 3.5 3.5L18 11l1.5 1.5' /></Svg>
+const IconLink = () => <Svg><path d='M10 14a4.5 4.5 0 0 1 0-6.36l2-2a4.5 4.5 0 1 1 6.36 6.36l-1.1 1.1' /><path d='M14 10a4.5 4.5 0 0 1 0 6.36l-2 2a4.5 4.5 0 1 1-6.36-6.36l1.1-1.1' /></Svg>
+const IconUnlink = () => <Svg><path d='M9.5 14.5a4.5 4.5 0 0 1-1.15-4.4' /><path d='M14.5 9.5a4.5 4.5 0 0 1 1.15 4.4' /><path d='m12.35 6.85 1.65-1.65a4.5 4.5 0 1 1 6.36 6.36l-1.65 1.65' /><path d='m11.65 17.15-1.65 1.65a4.5 4.5 0 1 1-6.36-6.36l1.65-1.65' /><line x1='4' y1='4' x2='20' y2='20' /></Svg>
+const IconClear = () => <Svg><path d='M18 5H8.5L4 9.5 12.5 18H18' /><path d='m13.5 9.5-4.5 4.5' /><line x1='9' y1='21' x2='19' y2='21' /></Svg>
+const IconChevronDown = () => <Svg size={11}><path d='M6 9l6 6 6-6' /></Svg>

--- a/apps/web/components/editor/CollabEditor.tsx
+++ b/apps/web/components/editor/CollabEditor.tsx
@@ -640,7 +640,7 @@ function ActiveEditor({ ydoc, provider, user, operationId, uploadUrl, defaultSec
                                     themeColor={themeColor}
                                 />
                             ) : (
-                                <div style={{ display: 'flex', flexDirection: 'column', flex: 1, gap: 40 }}>
+                                <div style={{ display: 'flex', flexDirection: 'column', flex: 1, gap: 56 }}>
                                     {sectionIds.map((id, idx) => (
                                         <SectionEditor
                                             key={`${activePage}-${id}`}
@@ -1171,19 +1171,34 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
             // Hairline + clear space between consecutive sections (visual-
             // fixes spec §3) — skipped on the first section, which already
             // sits right below the shared toolbar with its own breathing room.
+            // The header band below adds its own full-width hairline under
+            // the title+controls row; this borderTop is the separate rule
+            // that actually falls *between* two sections, so both stay —
+            // they're doing different jobs (visual-fixes header-band spec).
             borderTop: isFirst ? 'none' : '1px solid var(--line)',
-            paddingTop: isFirst ? 0 : 32,
+            paddingTop: isFirst ? 0 : 40,
         }}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
         >
             <style>{themeCSS}</style>
 
-            {/* Eyebrow (document name) + section title + accent rule — the
-                section's chrome (colour/visibility/reorder/delete) is a
-                hover-revealed row alongside it rather than a permanent bar
-                (visual-fixes spec §2). */}
-            <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: 10 }}>
+            {/* Header band: title block (left) and section chrome (right)
+                bound into one full-width row so the two pieces that used to
+                float at opposite ends now read as a single unit, closed off
+                by a full-width hairline that runs under both — the main
+                structural cue separating this section's header from its
+                body and from the next section (visual-fixes header-band
+                spec). The short accent rule under the title is a separate,
+                shorter rule doing a different job (the title's own
+                underline) and stays as-is. The faint accent-tinted ground
+                is deliberately quiet — just enough to read as "header" vs.
+                body text, not a bordered card. */}
+            <div style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12,
+                marginBottom: 18, padding: '6px 2px 14px', borderBottom: '1px solid var(--line)',
+                background: 'rgba(var(--acc-rgb), 0.02)',
+            }}>
                 <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ fontFamily: 'var(--mono)', fontSize: 9.5, fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--ink-3)', marginBottom: 6 }}>
                         {pageTitle}
@@ -1203,7 +1218,7 @@ function SectionEditor({ ydoc, sectionId, pageId, pageTitle, provider, user, upl
 
                 {!readOnly && (
                     <div style={{
-                        display: 'flex', alignItems: 'center', gap: 3, flexShrink: 0, paddingTop: 2,
+                        display: 'flex', alignItems: 'center', gap: 3, flexShrink: 0,
                         opacity: chromeVisible ? 1 : 0, pointerEvents: chromeVisible ? 'auto' : 'none', transition: 'opacity 0.12s',
                     }}>
                         {/* Section accent colour picker */}

--- a/apps/web/components/editor/ImageLibraryModal.tsx
+++ b/apps/web/components/editor/ImageLibraryModal.tsx
@@ -61,7 +61,7 @@ export default function ImageLibraryModal({ onSelect, onClose }: Props) {
                     </button>
                 </div>
 
-                <div style={{ flex: 1, overflowY: 'auto', padding: 14 }}>
+                <div className='thin-scroll' style={{ flex: 1, overflowY: 'auto', padding: 14 }}>
                     {loading ? (
                         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: 200, color: 'rgba(237,237,237,0.3)', fontSize: '0.72rem', letterSpacing: '0.1em', textTransform: 'uppercase' }}>
                             Loading…

--- a/apps/web/components/editor/PageSidebar.tsx
+++ b/apps/web/components/editor/PageSidebar.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import * as Y from 'yjs'
-import { Delete, Description, DragIndicator, Article, HorizontalRule, ContentCopy } from '@mui/icons-material'
+import { Delete, DragIndicator, HorizontalRule, ContentCopy } from '@mui/icons-material'
 
 interface PageEntry {
     id: string
@@ -61,6 +61,20 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
     const dragSrcRef = useRef<number>(-1)
     const renameInputRef = useRef<HTMLInputElement>(null)
     const defaultInitRef = useRef(false)
+    const [hoveredRowId, setHoveredRowId] = useState<string | null>(null)
+
+    // Current user, for the sidebar footer (name + avatar) only — same
+    // endpoint CollabEditor/useMapYjs already call for the collab token, no
+    // new prop needed and nothing here touches Y.Doc state.
+    const [currentUser, setCurrentUser] = useState<{ name: string; avatar: string | null } | null>(null)
+    useEffect(() => {
+        let cancelled = false
+        fetch('/api/me/token')
+            .then(r => r.json())
+            .then(({ name, avatar }) => { if (!cancelled) setCurrentUser({ name: name || 'Unknown', avatar: avatar || null }) })
+            .catch(() => {})
+        return () => { cancelled = true }
+    }, [])
 
     // Restore system cursor over modals (globals.css sets cursor:none !important for custom cursor)
     useEffect(() => {
@@ -480,31 +494,32 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
     // ── Sidebar (desktop) orientation ─────────────────────────────────────────
     return (
         <div style={{
-            width: 200,
+            width: 208,
             flexShrink: 0,
             display: 'flex',
             flexDirection: 'column',
-            gap: 2,
-            paddingRight: 12,
-            borderRight: `1px solid rgba(255,255,255,0.07)`,
-            marginRight: 8,
+            borderRight: '1px solid var(--line)',
+            background: 'linear-gradient(180deg, var(--s1), var(--bg))',
             position: 'sticky',
-            top: 24,
+            top: 0,
             alignSelf: 'flex-start',
-            maxHeight: 'calc(100vh - 120px)',
-            overflowY: 'auto',
+            height: 'calc(100vh - 116px)',
         }}>
             <div style={{
-                fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase',
-                color: 'rgba(237,237,237,0.25)', marginBottom: 6, paddingLeft: 2,
+                fontSize: 11, fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase',
+                color: 'var(--ink)', padding: '14px 18px',
+                borderBottom: '1px solid var(--line)', flexShrink: 0,
             }}>
                 Documents
             </div>
 
+            <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '6px 0' }}>
             {pages.map((page, idx) => {
                 const isActive = page.id === activePage
                 const isRenaming = renamingId === page.id
                 const isConfirmingDelete = confirmingDeleteId === page.id
+                const isRowHovered = hoveredRowId === page.id
+                const showRowActions = isRowHovered || isConfirmingDelete || confirmingDuplicateId === page.id
 
                 // ── Separator ─────────────────────────────────────────────────
                 if (page.pageType === 'separator') {
@@ -517,10 +532,12 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                             onDragLeave={() => setDragInsertIdx(null)}
                             onDrop={() => { let t = idx; if (dragSrcRef.current < t) t--; movePage(dragSrcRef.current, t); setDragInsertIdx(null) }}
                             onDragEnd={() => setDragInsertIdx(null)}
-                            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 2px', cursor: 'default', marginTop: 4 }}
+                            onMouseEnter={() => setHoveredRowId(page.id)}
+                            onMouseLeave={() => setHoveredRowId(null)}
+                            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '8px 14px', cursor: 'default' }}
                         >
-                            <DragIndicator style={{ fontSize: 12, color: 'rgba(237,237,237,0.12)', cursor: 'grab', flexShrink: 0 }} />
-                            <div style={{ flex: 1, height: 1, background: 'rgba(255,255,255,0.09)' }} />
+                            <DragIndicator style={{ fontSize: 12, color: 'var(--ink-3)', opacity: isRowHovered ? 0.6 : 0, cursor: 'grab', flexShrink: 0, transition: 'opacity 0.12s' }} />
+                            <div style={{ flex: 1, height: 1, background: 'var(--line)' }} />
                             {isRenaming ? (
                                 <input
                                     ref={renameInputRef}
@@ -529,11 +546,11 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                                     onBlur={commitRename}
                                     onKeyDown={e => { if (e.key === 'Enter') commitRename(); if (e.key === 'Escape') setRenamingId(null); e.stopPropagation() }}
                                     onClick={e => e.stopPropagation()}
-                                    style={{ width: 80, background: 'transparent', border: 'none', borderBottom: '1px solid rgba(255,255,255,0.2)', outline: 'none', color: 'rgba(237,237,237,0.5)', fontSize: '0.55rem', fontWeight: 600, padding: '1px 2px', letterSpacing: '0.12em', textTransform: 'uppercase' }}
+                                    style={{ width: 80, background: 'transparent', border: 'none', borderBottom: '1px solid var(--line-2)', outline: 'none', color: 'var(--ink-2)', fontSize: '0.6rem', fontWeight: 600, padding: '1px 2px', letterSpacing: '0.12em', textTransform: 'uppercase' }}
                                 />
                             ) : page.title && page.title !== '──────────' ? (
                                 <span
-                                    style={{ fontSize: '0.52rem', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'rgba(237,237,237,0.2)', whiteSpace: 'nowrap', flexShrink: 0 }}
+                                    style={{ fontSize: '0.58rem', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--ink-3)', whiteSpace: 'nowrap', flexShrink: 0 }}
                                     onDoubleClick={e => { e.stopPropagation(); startRename(page.id, page.title === '──────────' ? '' : page.title) }}
                                     title='Double-click to add label'
                                 >
@@ -541,7 +558,7 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                                 </span>
                             ) : (
                                 <span
-                                    style={{ fontSize: '0.52rem', color: 'rgba(237,237,237,0.08)', cursor: 'default', flexShrink: 0 }}
+                                    style={{ fontSize: '0.58rem', color: 'var(--ink-3)', opacity: 0.4, cursor: 'default', flexShrink: 0 }}
                                     onDoubleClick={e => { e.stopPropagation(); startRename(page.id, '') }}
                                     title='Double-click to add label'
                                 >
@@ -551,14 +568,14 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                             {!isRenaming && (
                                 isConfirmingDelete ? (
                                     <div style={{ display: 'flex', gap: 2 }} onClick={e => e.stopPropagation()}>
-                                        <button type='button' onClick={() => deletePage(page.id)} style={{ padding: '1px 5px', fontSize: '0.55rem', fontWeight: 700, background: 'rgba(200,40,40,0.7)', border: '1px solid rgba(200,40,40,0.9)', color: '#fff', cursor: 'pointer', borderRadius: 3 }}>Del</button>
-                                        <button type='button' onClick={() => setConfirmingDeleteId(null)} style={{ padding: '1px 5px', fontSize: '0.55rem', fontWeight: 700, background: 'transparent', border: '1px solid rgba(255,255,255,0.15)', color: 'rgba(237,237,237,0.5)', cursor: 'pointer', borderRadius: 3 }}>✕</button>
+                                        <button type='button' onClick={() => deletePage(page.id)} style={{ padding: '1px 5px', fontSize: '0.55rem', fontWeight: 700, background: 'var(--crit)', border: '1px solid var(--crit)', color: '#fff', cursor: 'pointer', borderRadius: 'var(--r)' }}>Del</button>
+                                        <button type='button' onClick={() => setConfirmingDeleteId(null)} style={{ padding: '1px 5px', fontSize: '0.55rem', fontWeight: 700, background: 'transparent', border: '1px solid var(--line-2)', color: 'var(--ink-3)', cursor: 'pointer', borderRadius: 'var(--r)' }}>✕</button>
                                     </div>
                                 ) : (
                                     <button type='button' onClick={e => { e.stopPropagation(); setConfirmingDeleteId(page.id) }}
-                                        style={{ background: 'transparent', border: 'none', padding: 1, cursor: 'pointer', color: 'rgba(237,237,237,0.15)', display: 'flex', alignItems: 'center', borderRadius: 2, flexShrink: 0 }}
-                                        onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = 'rgba(220,60,60,0.7)' }}
-                                        onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = 'rgba(237,237,237,0.15)' }}
+                                        style={{ background: 'transparent', border: 'none', padding: 1, cursor: 'pointer', color: 'var(--ink-3)', opacity: showRowActions ? 0.7 : 0, display: 'flex', alignItems: 'center', borderRadius: 2, flexShrink: 0, transition: 'opacity 0.12s, color 0.12s' }}
+                                        onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--crit)' }}
+                                        onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-3)' }}
                                     >
                                         <Delete style={{ fontSize: 11 }} />
                                     </button>
@@ -568,36 +585,26 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                     )
                 }
 
-                // Per-page-type accent colors (only applied when active)
-                const accent = page.pageType === 'zeus'
-                    ? { bg: 'rgba(0,195,255,0.08)', border: 'rgba(0,195,255,0.25)', left: '2px solid rgba(0,195,255,0.7)', icon: isActive ? 'rgba(0,195,255,0.85)' : 'rgba(0,195,255,0.4)', text: isActive ? 'rgba(0,195,255,0.9)' : 'rgba(0,195,255,0.5)' }
-                    : page.pageType === 'ocap'
-                    ? { bg: 'rgba(16,185,129,0.08)', border: 'rgba(16,185,129,0.25)', left: '2px solid rgba(16,185,129,0.7)', icon: isActive ? 'rgba(16,185,129,0.85)' : 'rgba(16,185,129,0.4)', text: isActive ? 'rgba(16,185,129,0.9)' : 'rgba(16,185,129,0.5)' }
-                    : page.pageType === 'staff_orders'
-                    ? ((): { bg: string; border: string; left: string; icon: string; text: string } => {
-                        const hex = page.pageColor || '#22c55e'
-                        const { r: sr, g: sg, b: sb } = hexToRgb(hex)
-                        const rc = (a: number) => `rgba(${sr},${sg},${sb},${a})`
-                        return { bg: rc(0.04), border: rc(0.25), left: `2px solid ${rc(0.7)}`, icon: isActive ? rc(0.85) : rc(0.4), text: isActive ? rc(0.92) : rc(0.55) }
-                    })()
-                    : page.pageType === 'aar'
-                    ? { bg: 'rgba(99,102,241,0.03)', border: 'rgba(99,102,241,0.25)', left: '2px solid rgba(99,102,241,0.7)', icon: isActive ? 'rgba(99,102,241,0.85)' : 'rgba(99,102,241,0.4)', text: isActive ? 'rgba(139,140,255,0.95)' : 'rgba(99,102,241,0.55)' }
-                    : { bg: c(0.12), border: c(0.3), left: `2px solid ${c(0.85)}`, icon: isActive ? c(0.85) : c(0.4), text: isActive ? 'rgba(237,237,237,0.9)' : c(0.6) }
-
-                const pageIcon = page.pageType === 'staff_orders'
-                    ? <Article style={{ fontSize: 13, color: accent.icon, flexShrink: 0 }} />
-                    : <Description style={{ fontSize: 13, color: accent.icon, flexShrink: 0 }} />
+                // Per-page-type dot colour — a functional legend (document kind),
+                // not a themeable surface, so these stay literal hex rather than
+                // design tokens; 'orders'/'main' (the common case) uses the
+                // operation's own accent instead of a fixed colour.
+                const dotColor = page.pageType === 'zeus' ? '#00c3ff'
+                    : page.pageType === 'ocap' ? '#10b981'
+                    : page.pageType === 'staff_orders' ? (page.pageColor || '#22c55e')
+                    : page.pageType === 'aar' ? '#6366f1'
+                    : 'var(--acc)'
 
                 const isNestTarget = dragNestTargetId === page.id
 
                 return (
                     <div
                         key={page.id}
-                        style={{ paddingLeft: page.parentId ? 16 : 0 }}
+                        style={page.parentId ? { paddingLeft: 14, marginLeft: 10, borderLeft: '1px solid var(--line)' } : undefined}
                     >
                     {/* Drag insert line before this item */}
                     {dragInsertIdx === idx && dragSrcRef.current !== idx && (
-                        <div style={{ height: 2, background: c(0.8), borderRadius: 1, margin: '2px 0', pointerEvents: 'none' }} />
+                        <div style={{ height: 2, background: 'var(--acc)', margin: '2px 10px', pointerEvents: 'none' }} />
                     )}
                     <div
                         draggable
@@ -631,29 +638,20 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                             setDragNestTargetId(null)
                         }}
                         onDragEnd={() => { setDragInsertIdx(null); setDragNestTargetId(null) }}
-                        style={{
-                            display: 'flex', alignItems: 'center', gap: 4,
-                            padding: '6px 8px',
-                            borderRadius: 4,
-                            background: isNestTarget ? c(0.08) : isActive ? accent.bg : 'transparent',
-                            borderTop: isActive ? `1px solid ${accent.border}` : isNestTarget ? `1px solid ${c(0.2)}` : '1px solid transparent',
-                            borderRight: isActive ? `1px solid ${accent.border}` : isNestTarget ? `1px solid ${c(0.2)}` : '1px solid transparent',
-                            borderBottom: isActive ? `1px solid ${accent.border}` : isNestTarget ? `1px solid ${c(0.2)}` : '1px solid transparent',
-                            borderLeft: isActive ? accent.left : isNestTarget ? `1px solid ${c(0.2)}` : '1px solid transparent',
-                            cursor: 'pointer',
-                            transition: 'all 0.1s',
-                            position: 'relative',
-                        }}
                         onClick={() => { if (!isRenaming) onSelectPage(page.id) }}
-                        onMouseEnter={e => {
-                            if (!isActive) (e.currentTarget as HTMLDivElement).style.background = 'rgba(255,255,255,0.04)'
-                        }}
-                        onMouseLeave={e => {
-                            if (!isActive) (e.currentTarget as HTMLDivElement).style.background = isNestTarget ? 'rgba(255,255,255,0.07)' : 'transparent'
+                        onMouseEnter={() => setHoveredRowId(page.id)}
+                        onMouseLeave={() => setHoveredRowId(null)}
+                        style={{
+                            display: 'flex', alignItems: 'center', gap: 7,
+                            padding: '8px 10px',
+                            background: isNestTarget ? 'var(--s3)' : isActive ? 'var(--s2)' : 'transparent',
+                            borderLeft: isActive ? '2px solid var(--acc)' : '2px solid transparent',
+                            cursor: 'pointer',
+                            transition: 'background 0.1s',
                         }}
                     >
-                        <DragIndicator style={{ fontSize: 14, flexShrink: 0, color: 'rgba(237,237,237,0.15)', cursor: 'grab' }} />
-                        {pageIcon}
+                        <DragIndicator style={{ fontSize: 13, flexShrink: 0, color: 'var(--ink-3)', opacity: isRowHovered ? 0.5 : 0, cursor: 'grab', transition: 'opacity 0.12s' }} />
+                        <span style={{ width: 5, height: 5, flexShrink: 0, background: dotColor }} />
 
                         {isRenaming ? (
                             <input
@@ -671,9 +669,9 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                                     flex: 1, minWidth: 0,
                                     background: 'transparent',
                                     border: 'none',
-                                    borderBottom: `1px solid ${c(0.5)}`,
+                                    borderBottom: '1px solid var(--line-2)',
                                     outline: 'none',
-                                    color: 'rgba(237,237,237,0.9)',
+                                    color: 'var(--ink)',
                                     fontSize: '0.72rem',
                                     fontWeight: 600,
                                     padding: '1px 2px',
@@ -683,10 +681,9 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                             <span
                                 style={{
                                     flex: 1, minWidth: 0,
-                                    fontSize: '0.72rem', fontWeight: isActive ? 700 : 500,
-                                    color: accent.text,
+                                    fontSize: 12.5, fontWeight: isActive ? 700 : 500,
+                                    color: isActive ? 'var(--ink)' : 'var(--ink-2)',
                                     overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                                    letterSpacing: '0.02em',
                                 }}
                                 onDoubleClick={e => { e.stopPropagation(); startRename(page.id, page.title) }}
                                 title={`${page.title}${page.pageType === 'intel' ? ' (Intel Package)' : page.pageType === 'zeus' ? ' (Zeus Notes — J6 only)' : page.pageType === 'ocap' ? ' (OCAP)' : page.pageType === 'staff_orders' ? ' (Staff Orders)' : page.pageType === 'aar' ? ' (After Action Review)' : ''} (double-click to rename)`}
@@ -699,50 +696,47 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                             isConfirmingDelete ? (
                                 <div style={{ display: 'flex', gap: 3 }} onClick={e => e.stopPropagation()}>
                                     <button type='button' onClick={() => deletePage(page.id)}
-                                        style={{ padding: '1px 5px', fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.06em', background: 'rgba(200,40,40,0.7)', border: '1px solid rgba(200,40,40,0.9)', color: '#fff', cursor: 'pointer', borderRadius: 3 }}>
+                                        style={{ padding: '1px 5px', fontSize: '0.6rem', fontWeight: 700, letterSpacing: '0.06em', background: 'var(--crit)', border: '1px solid var(--crit)', color: '#fff', cursor: 'pointer', borderRadius: 'var(--r)' }}>
                                         Del
                                     </button>
                                     <button type='button' onClick={() => setConfirmingDeleteId(null)}
-                                        style={{ padding: '1px 5px', fontSize: '0.6rem', fontWeight: 700, background: 'transparent', border: '1px solid rgba(255,255,255,0.15)', color: 'rgba(237,237,237,0.5)', cursor: 'pointer', borderRadius: 3 }}>
+                                        style={{ padding: '1px 5px', fontSize: '0.6rem', fontWeight: 700, background: 'transparent', border: '1px solid var(--line-2)', color: 'var(--ink-3)', cursor: 'pointer', borderRadius: 'var(--r)' }}>
                                         ✕
                                     </button>
                                 </div>
                             ) : confirmingDuplicateId === page.id ? (
                                 <div style={{ display: 'flex', gap: 2 }} onClick={e => e.stopPropagation()}>
                                     <button type='button' onClick={() => { duplicatePage(page.id); setConfirmingDuplicateId(null) }}
-                                        style={{ padding: '1px 5px', fontSize: '0.55rem', fontWeight: 700, background: 'rgba(60,130,200,0.6)', border: '1px solid rgba(100,180,237,0.7)', color: '#fff', cursor: 'pointer', borderRadius: 3 }}>Dup</button>
+                                        style={{ padding: '1px 5px', fontSize: '0.55rem', fontWeight: 700, background: 'var(--s3)', border: '1px solid var(--line-2)', color: 'var(--ink)', cursor: 'pointer', borderRadius: 'var(--r)' }}>Dup</button>
                                     <button type='button' onClick={() => setConfirmingDuplicateId(null)}
-                                        style={{ padding: '1px 5px', fontSize: '0.55rem', fontWeight: 700, background: 'transparent', border: '1px solid rgba(255,255,255,0.15)', color: 'rgba(237,237,237,0.5)', cursor: 'pointer', borderRadius: 3 }}>✕</button>
+                                        style={{ padding: '1px 5px', fontSize: '0.55rem', fontWeight: 700, background: 'transparent', border: '1px solid var(--line-2)', color: 'var(--ink-3)', cursor: 'pointer', borderRadius: 'var(--r)' }}>✕</button>
                                 </div>
                             ) : (
-                                <div style={{ display: 'flex', gap: 1, opacity: isActive ? 1 : 0, transition: 'opacity 0.12s' }}
-                                    onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.opacity = '1' }}
-                                    onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.opacity = isActive ? '1' : '0' }}
-                                >
+                                <div style={{ display: 'flex', gap: 1, opacity: showRowActions ? 1 : 0, transition: 'opacity 0.12s', flexShrink: 0 }}>
                                     {page.pageType === 'staff_orders' ? (
                                         <button type='button' title='Import sections from another document'
                                             onClick={e => { e.stopPropagation(); setImportTargetId(page.id); setImportSourceId(''); setImportSelected(new Set()) }}
-                                            style={{ background: 'transparent', border: 'none', padding: 2, cursor: 'pointer', color: 'rgba(237,237,237,0.2)', display: 'flex', alignItems: 'center', borderRadius: 3, transition: 'color 0.12s' }}
-                                            onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = 'rgba(245,158,11,0.8)' }}
-                                            onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = 'rgba(237,237,237,0.2)' }}
+                                            style={{ background: 'transparent', border: 'none', padding: 2, cursor: 'pointer', color: 'var(--ink-3)', display: 'flex', alignItems: 'center', borderRadius: 2, transition: 'color 0.12s' }}
+                                            onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--warn)' }}
+                                            onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-3)' }}
                                         >
                                             <ContentCopy style={{ fontSize: 11 }} />
                                         </button>
                                     ) : (
                                     <button type='button' title='Duplicate page'
                                         onClick={e => { e.stopPropagation(); duplicatePage(page.id) }}
-                                        style={{ background: 'transparent', border: 'none', padding: 2, cursor: 'pointer', color: 'rgba(237,237,237,0.2)', display: 'flex', alignItems: 'center', borderRadius: 3, transition: 'color 0.12s' }}
-                                        onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = 'rgba(100,180,237,0.8)' }}
-                                        onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = 'rgba(237,237,237,0.2)' }}
+                                        style={{ background: 'transparent', border: 'none', padding: 2, cursor: 'pointer', color: 'var(--ink-3)', display: 'flex', alignItems: 'center', borderRadius: 2, transition: 'color 0.12s' }}
+                                        onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink)' }}
+                                        onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-3)' }}
                                     >
                                         <ContentCopy style={{ fontSize: 11 }} />
                                     </button>
                                     )}
                                     <button type='button' title='Delete page'
                                         onClick={e => { e.stopPropagation(); setConfirmingDeleteId(page.id) }}
-                                        style={{ background: 'transparent', border: 'none', padding: 2, cursor: 'pointer', color: 'rgba(237,237,237,0.2)', display: 'flex', alignItems: 'center', borderRadius: 3, transition: 'color 0.12s' }}
-                                        onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = 'rgba(220,60,60,0.8)' }}
-                                        onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = 'rgba(237,237,237,0.2)' }}
+                                        style={{ background: 'transparent', border: 'none', padding: 2, cursor: 'pointer', color: 'var(--ink-3)', display: 'flex', alignItems: 'center', borderRadius: 2, transition: 'color 0.12s' }}
+                                        onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--crit)' }}
+                                        onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-3)' }}
                                     >
                                         <Delete style={{ fontSize: 13 }} />
                                     </button>
@@ -756,23 +750,45 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
 
             {/* Drag insert line after last item */}
             {dragInsertIdx === pages.length && dragSrcRef.current !== pages.length - 1 && (
-                <div style={{ height: 2, background: c(0.8), borderRadius: 1, margin: '2px 0', pointerEvents: 'none' }} />
+                <div style={{ height: 2, background: 'var(--acc)', margin: '2px 10px', pointerEvents: 'none' }} />
             )}
 
             <button type='button' onClick={() => { setShowTypeModal(true); setTypeModalStep('type') }}
                 style={{
-                    marginTop: 8, padding: '6px 8px',
+                    display: 'block', margin: '6px 10px 4px', padding: '6px 8px',
                     background: 'transparent',
-                    border: `1px dashed ${c(0.25)}`,
-                    color: c(0.45),
+                    border: 'none',
+                    color: 'var(--ink-3)',
                     fontSize: '0.62rem', fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase',
-                    cursor: 'pointer', transition: 'all 0.15s', borderRadius: 4, width: '100%',
+                    cursor: 'pointer', transition: 'color 0.15s', textAlign: 'left',
                 }}
-                onMouseEnter={e => { e.currentTarget.style.borderColor = c(0.6); e.currentTarget.style.color = c(0.85) }}
-                onMouseLeave={e => { e.currentTarget.style.borderColor = c(0.25); e.currentTarget.style.color = c(0.45) }}
+                onMouseEnter={e => { e.currentTarget.style.color = 'var(--ink)' }}
+                onMouseLeave={e => { e.currentTarget.style.color = 'var(--ink-3)' }}
             >
                 + Add Document
             </button>
+            </div>
+
+            {/* Footer — current user */}
+            <div style={{
+                display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0,
+                padding: '10px 14px',
+                borderTop: '1px solid var(--line)',
+            }}>
+                <div style={{
+                    width: 18, height: 18, borderRadius: '50%', flexShrink: 0, overflow: 'hidden',
+                    background: 'var(--acc)',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: 9, fontWeight: 700, color: '#fff', textTransform: 'uppercase',
+                }}>
+                    {currentUser?.avatar ? (
+                        <img src={currentUser.avatar} alt='' style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
+                    ) : (currentUser?.name?.charAt(0) ?? '?')}
+                </div>
+                <span style={{ fontSize: 11, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {currentUser?.name ?? 'Loading…'}
+                </span>
+            </div>
 
             {/* Section import modal */}
             {importTargetId && (

--- a/apps/web/components/editor/PageSidebar.tsx
+++ b/apps/web/components/editor/PageSidebar.tsx
@@ -508,14 +508,18 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
             background: 'linear-gradient(180deg, var(--s1), var(--bg))',
             position: 'sticky',
             top: 0,
-            // Flex-driven, not viewport maths (visual-fixes FIX 2): this row's
-            // parent (CollabEditor's ActiveEditor root) has `minHeight: '100%'`
-            // resolved against EditorShell's now-definite wrapper, so it's at
-            // least as tall as the visible body region and taller when the
-            // document itself is. Default `align-items: stretch` (no override
-            // here) plus this `height: '100%'` makes the rail match that
-            // exactly, so it reaches the status bar on a short document and
-            // keeps sticking through the whole scroll on a long one — a fixed
+            // Flex-driven, not viewport maths (visual-fixes FIX 3): this row's
+            // parent (CollabEditor's ActiveEditor root) sets `height: '100%'`
+            // — a real `height`, not `minHeight` — resolved against
+            // EditorShell's own definite wrapper. That's what lets this
+            // `height: '100%'` here resolve to an actual pixel value instead
+            // of falling back to this element's own (short) content height;
+            // an ancestor whose only sizing is `min-height` never counts as
+            // "definite" for a percentage-height descendant to resolve
+            // against, which is what made the rail stop a quarter of the way
+            // down the viewport before. `position: sticky` + this height is
+            // what makes it reach the status bar on a short document and
+            // keep sticking through the whole scroll on a long one — a fixed
             // `calc(100vh - N)` could do neither once N drifted out of sync
             // with the real chrome height.
             height: '100%',

--- a/apps/web/components/editor/PageSidebar.tsx
+++ b/apps/web/components/editor/PageSidebar.tsx
@@ -519,11 +519,14 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
             // an ancestor whose only sizing is `min-height` never counts as
             // "definite" for a percentage-height descendant to resolve
             // against, which is what made the rail stop a quarter of the way
-            // down the viewport before. `position: sticky` + this height is
-            // what makes it reach the status bar on a short document and
-            // keep sticking through the whole scroll on a long one — a fixed
-            // `calc(100vh - N)` could do neither once N drifted out of sync
-            // with the real chrome height.
+            // What keeps the rail on screen through a long document is not
+            // this `sticky` but the fact that CollabEditor confines the
+            // scroll to the editor column beside it, so this row never
+            // scrolls at all - see that file's comment on the column div.
+            // Sticky is kept only as a harmless backstop should an ancestor
+            // ever scroll again; on its own it could not do the job, because
+            // a sticky box may only travel within its containing block and
+            // that block is exactly one viewport tall.
             height: '100%',
         }}>
             <div style={{

--- a/apps/web/components/editor/PageSidebar.tsx
+++ b/apps/web/components/editor/PageSidebar.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import * as Y from 'yjs'
 import { Delete, DragIndicator, HorizontalRule, ContentCopy } from '@mui/icons-material'
+import { useThinScrollFade } from './useThinScrollFade'
 
 interface PageEntry {
     id: string
@@ -81,6 +82,7 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
     const renameInputRef = useRef<HTMLInputElement>(null)
     const defaultInitRef = useRef(false)
     const [hoveredRowId, setHoveredRowId] = useState<string | null>(null)
+    const listFadeRef = useThinScrollFade<HTMLDivElement>()
 
     // Restore system cursor over modals (globals.css sets cursor:none !important for custom cursor)
     useEffect(() => {
@@ -532,7 +534,7 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
                 Documents
             </div>
 
-            <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '6px 0' }}>
+            <div ref={listFadeRef} className='thin-scroll' style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '6px 0' }}>
             {pages.map((page, idx) => {
                 const isActive = page.id === activePage
                 const isRenaming = renamingId === page.id
@@ -863,7 +865,7 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
 
                         {/* Section checklist */}
                         {importSourceId && (
-                            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 200, overflowY: 'auto', padding: '4px 0' }}>
+                            <div className='thin-scroll' style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 200, overflowY: 'auto', padding: '4px 0' }}>
                                 {importSectionList.length === 0 ? (
                                     <div style={{ fontSize: '0.72rem', color: 'rgba(237,237,237,0.3)', fontStyle: 'italic' }}>No sections found in this document.</div>
                                 ) : (

--- a/apps/web/components/editor/PageSidebar.tsx
+++ b/apps/web/components/editor/PageSidebar.tsx
@@ -16,6 +16,17 @@ interface PageEntry {
 
 const STAFF_SECTION_PRESETS = ['HQ Orders', '1 PLT Orders', '2 PLT Orders', '3 PLT Orders'] as const
 
+/** Shape both `presenceUser` and each entry of `presencePeers` share — just
+ * enough identity to render an avatar (visual-fixes FIX 3). `id` is a
+ * Y.js/Hocuspocus awareness clientID for peers, or the literal 'self' for
+ * the local user; either way it's only ever used as a React key here. */
+interface PresencePerson {
+    id: string | number
+    name: string
+    color: string
+    avatar: string | null
+}
+
 interface Props {
     ydoc: Y.Doc
     activePage: string
@@ -24,6 +35,14 @@ interface Props {
     orientation?: 'sidebar' | 'top'
     synced?: boolean
     allowedTypes?: string[]
+    readOnly?: boolean
+    /** The local user and everyone else currently in the document — both
+     * read off the same Hocuspocus awareness state the collaborative cursors
+     * already use (ActiveEditor's own `user`/`peers`), not a second channel.
+     * Drives the rail footer's "EDITING" indicator (visual-fixes FIX 3),
+     * which replaces the old current-user-only footer. */
+    presenceUser?: PresencePerson
+    presencePeers?: PresencePerson[]
 }
 
 function hexToRgb(hex: string) {
@@ -35,7 +54,7 @@ function hexToRgb(hex: string) {
     }
 }
 
-export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor, orientation = 'sidebar', synced = false, allowedTypes }: Props) {
+export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor, orientation = 'sidebar', synced = false, allowedTypes, readOnly = false, presenceUser, presencePeers = [] }: Props) {
     const { r, g, b } = hexToRgb(themeColor)
     const c = (a: number) => `rgba(${r},${g},${b},${a})`
 
@@ -62,19 +81,6 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
     const renameInputRef = useRef<HTMLInputElement>(null)
     const defaultInitRef = useRef(false)
     const [hoveredRowId, setHoveredRowId] = useState<string | null>(null)
-
-    // Current user, for the sidebar footer (name + avatar) only — same
-    // endpoint CollabEditor/useMapYjs already call for the collab token, no
-    // new prop needed and nothing here touches Y.Doc state.
-    const [currentUser, setCurrentUser] = useState<{ name: string; avatar: string | null } | null>(null)
-    useEffect(() => {
-        let cancelled = false
-        fetch('/api/me/token')
-            .then(r => r.json())
-            .then(({ name, avatar }) => { if (!cancelled) setCurrentUser({ name: name || 'Unknown', avatar: avatar || null }) })
-            .catch(() => {})
-        return () => { cancelled = true }
-    }, [])
 
     // Restore system cursor over modals (globals.css sets cursor:none !important for custom cursor)
     useEffect(() => {
@@ -502,8 +508,17 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
             background: 'linear-gradient(180deg, var(--s1), var(--bg))',
             position: 'sticky',
             top: 0,
-            alignSelf: 'flex-start',
-            height: 'calc(100vh - 116px)',
+            // Flex-driven, not viewport maths (visual-fixes FIX 2): this row's
+            // parent (CollabEditor's ActiveEditor root) has `minHeight: '100%'`
+            // resolved against EditorShell's now-definite wrapper, so it's at
+            // least as tall as the visible body region and taller when the
+            // document itself is. Default `align-items: stretch` (no override
+            // here) plus this `height: '100%'` makes the rail match that
+            // exactly, so it reaches the status bar on a short document and
+            // keeps sticking through the whole scroll on a long one — a fixed
+            // `calc(100vh - N)` could do neither once N drifted out of sync
+            // with the real chrome height.
+            height: '100%',
         }}>
             <div style={{
                 fontSize: 11, fontWeight: 700, letterSpacing: '0.22em', textTransform: 'uppercase',
@@ -769,24 +784,52 @@ export default function PageSidebar({ ydoc, activePage, onSelectPage, themeColor
             </button>
             </div>
 
-            {/* Footer — current user */}
+            {/* Footer — collaborator presence (visual-fixes FIX 3). Replaces the
+                old current-user-only footer; the "EDITING" indicator that used
+                to float at the top-right of the editor column now lives here
+                instead, reusing the same `presenceUser`/`presencePeers` identity
+                ActiveEditor already derives from the Hocuspocus awareness state
+                for the collaborative cursors — no second presence channel. */}
             <div style={{
                 display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0,
                 padding: '10px 14px',
                 borderTop: '1px solid var(--line)',
             }}>
-                <div style={{
-                    width: 18, height: 18, borderRadius: '50%', flexShrink: 0, overflow: 'hidden',
-                    background: 'var(--acc)',
-                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    fontSize: 9, fontWeight: 700, color: '#fff', textTransform: 'uppercase',
+                {presenceUser && (() => {
+                    const shown = [presenceUser, ...presencePeers].slice(0, 6)
+                    const overflowCount = presenceUser ? 1 + presencePeers.length - shown.length : 0
+                    return (
+                        <div style={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+                            {shown.map((p, i) => (
+                                <div key={p.id} title={p.name} style={{
+                                    width: 18, height: 18, borderRadius: '50%', flexShrink: 0, overflow: 'hidden',
+                                    background: p.color, border: '1.5px solid var(--bg)',
+                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                    fontSize: 8.5, fontWeight: 700, color: '#fff', textTransform: 'uppercase',
+                                    marginLeft: i === 0 ? 0 : -6, position: 'relative', zIndex: shown.length - i,
+                                }}>
+                                    {p.avatar ? <img src={p.avatar} alt='' style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} /> : p.name.charAt(0)}
+                                </div>
+                            ))}
+                            {overflowCount > 0 && (
+                                <div style={{
+                                    width: 18, height: 18, borderRadius: '50%', flexShrink: 0,
+                                    background: 'var(--s3)', border: '1.5px solid var(--bg)',
+                                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                    fontSize: 8, fontWeight: 700, color: 'var(--ink-2)',
+                                    marginLeft: -6, position: 'relative', zIndex: 0,
+                                }}>
+                                    +{overflowCount}
+                                </div>
+                            )}
+                        </div>
+                    )
+                })()}
+                <span style={{
+                    fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase',
+                    color: 'var(--ink-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
                 }}>
-                    {currentUser?.avatar ? (
-                        <img src={currentUser.avatar} alt='' style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }} />
-                    ) : (currentUser?.name?.charAt(0) ?? '?')}
-                </div>
-                <span style={{ fontSize: 11, color: 'var(--ink-2)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    {currentUser?.name ?? 'Loading…'}
+                    {!presenceUser ? 'Connecting…' : presencePeers.length === 0 ? 'Only you' : readOnly ? 'Viewing' : 'Editing'}
                 </span>
             </div>
 

--- a/apps/web/components/editor/SimpleEditor.tsx
+++ b/apps/web/components/editor/SimpleEditor.tsx
@@ -381,7 +381,7 @@ export default function SimpleEditor({ initialContent = '', onChange, readOnly =
                 </div>
             )}
 
-            <div style={{ minHeight, padding: readOnly ? 0 : '16px 20px', background: readOnly ? 'transparent' : 'rgba(255,255,255,0.015)', overflowX: 'auto' }}>
+            <div className='thin-scroll' style={{ minHeight, padding: readOnly ? 0 : '16px 20px', background: readOnly ? 'transparent' : 'rgba(255,255,255,0.015)', overflowX: 'auto' }}>
                 <EditorContent editor={editor} />
             </div>
         </div>

--- a/apps/web/components/editor/intel-package/IntelPackageEditor.tsx
+++ b/apps/web/components/editor/intel-package/IntelPackageEditor.tsx
@@ -1277,7 +1277,7 @@ export default function IntelPackageEditor({ operationId, readOnly = false, them
                     </div>
 
                     {/* Form content */}
-                    <div style={{ flex: 1, padding: '24px 28px', overflowY: 'auto' }}>
+                    <div className='thin-scroll' style={{ flex: 1, padding: '24px 28px', overflowY: 'auto' }}>
                         {renderSlide(activeSlide)}
                     </div>
 

--- a/apps/web/components/editor/intel-package/IntelPackageViewer.tsx
+++ b/apps/web/components/editor/intel-package/IntelPackageViewer.tsx
@@ -1112,7 +1112,7 @@ export default function IntelPackageViewer({ operationId, themeColor = '#c62828'
                                             COMMS CARD
                                         </div>
                                         {commsMode === 'custom' && commsGroups.length > 0 ? (
-                                            <div style={{ flex: 1, padding: '8px 10px', overflowY: 'auto' }}>
+                                            <div className='thin-scroll' style={{ flex: 1, padding: '8px 10px', overflowY: 'auto' }}>
                                                 {/* Header row */}
                                                 <div style={{ display: 'grid', gridTemplateColumns: '1.8fr 1fr 1fr 1fr 1fr', gap: 4, marginBottom: 5, paddingBottom: 4, borderBottom: '1px solid rgba(198,40,40,0.2)' }}>
                                                     {['CALLSIGN','SR PRIM','SR ALT','LR PRIM','LR ALT'].map(h => (

--- a/apps/web/components/editor/useThinScrollFade.ts
+++ b/apps/web/components/editor/useThinScrollFade.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+/**
+ * Scroll-triggered half of the thin overlay scrollbar spec (styles/globals.css
+ * `.thin-scroll`). The CSS alone already fades the thumb in on `:hover` —
+ * this hook adds the other trigger, fading it in while the container is
+ * actually being scrolled (e.g. via mouse wheel or keyboard, cursor
+ * elsewhere) and back out shortly after motion stops, by toggling the
+ * `is-scrolling` class `.thin-scroll` reads in globals.css. No custom
+ * scrollbar is rendered here — this only flips a class.
+ *
+ * Uses the native `scrollend` event where supported (Chrome, Firefox) so
+ * the fade-out timing matches actual scroll physics instead of a guess;
+ * falls back to a debounced timeout (Safari, which has no `scrollend`).
+ *
+ * Usage: `<div ref={useThinScrollFade()} className="thin-scroll ...">`.
+ */
+export function useThinScrollFade<T extends HTMLElement>(fadeDelay = 500) {
+    const ref = useRef<T | null>(null)
+
+    useEffect(() => {
+        const el = ref.current
+        if (!el) return
+
+        const supportsScrollEnd = 'onscrollend' in window
+        let timer: ReturnType<typeof setTimeout> | undefined
+
+        const onScroll = () => {
+            el.classList.add('is-scrolling')
+            if (!supportsScrollEnd) {
+                clearTimeout(timer)
+                timer = setTimeout(() => el.classList.remove('is-scrolling'), fadeDelay)
+            }
+        }
+        const onScrollEnd = () => {
+            clearTimeout(timer)
+            el.classList.remove('is-scrolling')
+        }
+
+        el.addEventListener('scroll', onScroll, { passive: true })
+        if (supportsScrollEnd) el.addEventListener('scrollend', onScrollEnd)
+
+        return () => {
+            el.removeEventListener('scroll', onScroll)
+            if (supportsScrollEnd) el.removeEventListener('scrollend', onScrollEnd)
+            clearTimeout(timer)
+        }
+    }, [fadeDelay])
+
+    return ref
+}

--- a/apps/web/components/operations/OperationStatusBar.tsx
+++ b/apps/web/components/operations/OperationStatusBar.tsx
@@ -1,17 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-
-interface LiveStatus {
-    operationStatus: string | null
-    operationDate: string | null
-    stage?: string
-    rsvpOpen: boolean
-    rsvpOpenAt?: string
-    rsvpCloseOffsetMins?: number
-    confirmationOpen: boolean
-    confirmationOpenedAt?: string
-}
+import { LiveStatus, fmtCountdown, rsvpCloseAt } from '@/lib/operations/schedule'
 
 interface Props {
     operationId: string
@@ -21,18 +11,6 @@ interface Props {
     r: number
     g: number
     b: number
-}
-
-function fmtCountdown(target: Date, now: Date): string | null {
-    const diff = target.getTime() - now.getTime()
-    if (diff <= 0) return null
-    const s = Math.floor(diff / 1000)
-    const m = Math.floor(s / 60)
-    const h = Math.floor(m / 60)
-    const d = Math.floor(h / 24)
-    if (d > 0) return `${d}d ${h % 24}h`
-    if (h > 0) return `${h}h ${m % 60}m`
-    return `${m}m ${s % 60}s`
 }
 
 export default function OperationStatusBar({ operationId, operationDate: initialDate, operationStatus: initialStatus, r, g, b }: Props) {
@@ -67,7 +45,7 @@ export default function OperationStatusBar({ operationId, operationDate: initial
     const opDate = operationDate ? new Date(operationDate) : null
     const rsvpOpenAt = data.rsvpOpenAt ? new Date(data.rsvpOpenAt) : null
     const rsvpCloseOffsetMins = data.rsvpCloseOffsetMins ?? 60
-    const rsvpCloseDate = opDate ? new Date(opDate.getTime() - rsvpCloseOffsetMins * 60000) : null
+    const rsvpCloseDate = rsvpCloseAt(opDate, rsvpCloseOffsetMins)
     const confirmCloseDate = data.confirmationOpenedAt ? new Date(new Date(data.confirmationOpenedAt).getTime() + 24 * 3600000) : null
 
     const isCompleted   = operationStatus === 'Completed'

--- a/apps/web/lib/colour.test.ts
+++ b/apps/web/lib/colour.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect } from 'vitest'
+import { hexToRgb, rgbTriplet } from './colour'
+
+describe('hexToRgb', () => {
+    test('parses a six-digit hex with or without the hash', () => {
+        expect(hexToRgb('#db001d')).toEqual({ r: 219, g: 0, b: 29 })
+        expect(hexToRgb('db001d')).toEqual({ r: 219, g: 0, b: 29 })
+    })
+
+    test('falls back to ASOT red on anything malformed', () => {
+        expect(hexToRgb('')).toEqual({ r: 219, g: 0, b: 29 })
+        expect(hexToRgb('#fff')).toEqual({ r: 219, g: 0, b: 29 })
+    })
+})
+
+describe('rgbTriplet', () => {
+    test('formats for CSS custom properties', () => {
+        expect(rgbTriplet('#4dd0e1')).toBe('77,208,225')
+    })
+})

--- a/apps/web/lib/colour.ts
+++ b/apps/web/lib/colour.ts
@@ -1,0 +1,23 @@
+/**
+ * One home for hex -> rgb. It was previously redefined in at least three
+ * files (the editor page, PageSidebar, PageNavClient), each with the same
+ * body, which is how two of them ended up disagreeing about what to do with
+ * a malformed value.
+ */
+export interface Rgb { r: number; g: number; b: number }
+
+export function hexToRgb(hex: string): Rgb {
+    const h = String(hex ?? '').replace('#', '')
+    if (h.length !== 6) return { r: 219, g: 0, b: 29 }
+    return {
+        r: parseInt(h.substring(0, 2), 16),
+        g: parseInt(h.substring(2, 4), 16),
+        b: parseInt(h.substring(4, 6), 16),
+    }
+}
+
+/** `"219,0,29"` — the form CSS custom properties want for rgba() tinting. */
+export function rgbTriplet(hex: string): string {
+    const { r, g, b } = hexToRgb(hex)
+    return `${r},${g},${b}`
+}

--- a/apps/web/lib/operations/doc-stats.test.ts
+++ b/apps/web/lib/operations/doc-stats.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Feeds the status bar's "1,240 words · 6 sections". Takes a plain
+ * ProseMirror JSON document so it never needs a live editor to test.
+ */
+import { describe, test, expect } from 'vitest'
+import { docStats } from './doc-stats'
+
+const doc = {
+    type: 'doc',
+    content: [
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Situation' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Enemy forces hold the compound.' }] },
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Mission' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Seize and hold.' }] },
+    ],
+}
+
+describe('docStats', () => {
+    test('counts words across every text node, headings included', () => {
+        // Situation(1) + 5 + Mission(1) + 3
+        expect(docStats(doc).words).toBe(10)
+    })
+
+    test('counts headings as sections', () => {
+        expect(docStats(doc).sections).toBe(2)
+    })
+
+    test('collapses runs of whitespace rather than counting empties', () => {
+        const d = { type: 'doc', content: [
+            { type: 'paragraph', content: [{ type: 'text', text: '  spaced   out  ' }] },
+        ] }
+        expect(docStats(d).words).toBe(2)
+    })
+
+    test('returns zeroes for null, so the status bar renders before the doc loads', () => {
+        expect(docStats(null)).toEqual({ words: 0, sections: 0 })
+        expect(docStats(undefined)).toEqual({ words: 0, sections: 0 })
+    })
+
+    test('walks nested content such as lists and blockquotes', () => {
+        const d = { type: 'doc', content: [
+            { type: 'bulletList', content: [
+                { type: 'listItem', content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'one two three' }] },
+                ] },
+            ] },
+        ] }
+        expect(docStats(d).words).toBe(3)
+    })
+})

--- a/apps/web/lib/operations/doc-stats.ts
+++ b/apps/web/lib/operations/doc-stats.ts
@@ -1,0 +1,35 @@
+export interface DocStats {
+    words: number
+    sections: number
+}
+
+interface PmNode {
+    type?: string
+    text?: string
+    content?: PmNode[]
+}
+
+/**
+ * Word and section counts over a ProseMirror JSON document.
+ *
+ * Deliberately takes plain JSON rather than a TipTap Editor: the status bar
+ * gets its document from the Y.Doc, and keeping this free of editor types is
+ * what lets it be unit tested under the node-environment vitest runner.
+ */
+export function docStats(doc: unknown): DocStats {
+    let words = 0
+    let sections = 0
+
+    const walk = (node: PmNode | null | undefined): void => {
+        if (!node || typeof node !== 'object') return
+        if (node.type === 'heading') sections++
+        if (typeof node.text === 'string') {
+            const trimmed = node.text.trim()
+            if (trimmed) words += trimmed.split(/\s+/).length
+        }
+        node.content?.forEach(walk)
+    }
+
+    walk(doc as PmNode)
+    return { words, sections }
+}

--- a/apps/web/lib/operations/schedule.test.ts
+++ b/apps/web/lib/operations/schedule.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The editor's deck and the public status bar both render from these, so a
+ * disagreement between them is a bug users see as "the page says two things".
+ * All of it is pure and clock-injected, so it is tested directly.
+ */
+import { describe, test, expect } from 'vitest'
+import { fmtCountdown, rsvpCloseAt, buildTimeline, type LiveStatus } from './schedule'
+
+const base: LiveStatus = {
+    operationStatus: 'Upcoming',
+    operationDate: '2026-11-18T08:00:00.000Z',
+    rsvpOpen: false,
+    rsvpOpenAt: null,
+    rsvpCloseOffsetMins: 90,
+    confirmationOpen: false,
+    confirmationOpenedAt: null,
+    stage: 'preparing',
+}
+
+describe('fmtCountdown', () => {
+    const now = new Date('2026-08-18T00:00:00.000Z')
+
+    test('days and hours when more than a day out', () => {
+        expect(fmtCountdown(new Date('2026-08-20T05:00:00.000Z'), now)).toBe('2d 5h')
+    })
+
+    test('hours and minutes inside a day', () => {
+        expect(fmtCountdown(new Date('2026-08-18T03:30:00.000Z'), now)).toBe('3h 30m')
+    })
+
+    test('minutes and seconds inside an hour', () => {
+        expect(fmtCountdown(new Date('2026-08-18T00:02:05.000Z'), now)).toBe('2m 5s')
+    })
+
+    test('null once the target has passed, so callers can branch on it', () => {
+        expect(fmtCountdown(new Date('2026-08-17T23:59:59.000Z'), now)).toBeNull()
+        expect(fmtCountdown(now, now)).toBeNull()
+    })
+})
+
+describe('rsvpCloseAt', () => {
+    test('subtracts the offset from the operation date', () => {
+        expect(rsvpCloseAt(new Date('2026-11-18T08:00:00.000Z'), 90))
+            .toEqual(new Date('2026-11-18T06:30:00.000Z'))
+    })
+
+    test('null when the operation has no date yet', () => {
+        expect(rsvpCloseAt(null, 90)).toBeNull()
+    })
+})
+
+describe('buildTimeline', () => {
+    test('returns the five moments in chronological order', () => {
+        expect(buildTimeline(base).map(m => m.id)).toEqual([
+            'rsvp_opens', 'rsvp_closes', 'op_starts', 'confirmations_open', 'completed',
+        ])
+    })
+
+    test('reports a manual RSVP as Manual rather than inventing a time', () => {
+        const m = buildTimeline(base)[0]
+        expect(m.at).toBeNull()
+        expect(m.detail).toBe('Manual')
+    })
+
+    test('uses the scheduled open time when one is set', () => {
+        const m = buildTimeline({ ...base, rsvpOpenAt: '2026-11-17T08:00:00.000Z' })[0]
+        expect(m.at).toEqual(new Date('2026-11-17T08:00:00.000Z'))
+    })
+
+    test('marks the operation start as current once running', () => {
+        const t = buildTimeline({ ...base, stage: 'op_running' })
+        expect(t.find(m => m.id === 'op_starts')!.state).toBe('current')
+        expect(t.find(m => m.id === 'rsvp_closes')!.state).toBe('done')
+    })
+
+    test('closes confirmations 24 hours after they open, not 48', () => {
+        const t = buildTimeline({
+            ...base,
+            stage: 'confirmations_open',
+            confirmationOpen: true,
+            confirmationOpenedAt: '2026-11-18T12:00:00.000Z',
+        })
+        expect(t.find(m => m.id === 'completed')!.at)
+            .toEqual(new Date('2026-11-19T12:00:00.000Z'))
+    })
+
+    test('survives an operation with no date at all', () => {
+        const t = buildTimeline({ ...base, operationDate: null })
+        expect(t).toHaveLength(5)
+        expect(t.find(m => m.id === 'op_starts')!.at).toBeNull()
+    })
+})

--- a/apps/web/lib/operations/schedule.ts
+++ b/apps/web/lib/operations/schedule.ts
@@ -1,0 +1,128 @@
+/**
+ * Everything the editor deck and the public status bar need to say *when*
+ * something happens. Pure functions; `now` is passed in wherever it's needed
+ * (fmtCountdown) so the timeline is testable without faking timers.
+ *
+ * Lifted from components/operations/OperationStatusBar.tsx, which computed all
+ * of this inline and is now a consumer.
+ */
+
+import { STAGE_ORDER, stageIndex, type AttendanceStage } from './stage'
+
+export type { AttendanceStage }
+
+/** The `GET /api/operations/[id]/live-status` response. */
+export interface LiveStatus {
+    operationStatus: string | null
+    operationDate: string | null
+    rsvpOpen: boolean
+    rsvpOpenAt: string | null
+    rsvpCloseOffsetMins: number
+    confirmationOpen: boolean
+    confirmationOpenedAt: string | null
+    stage: AttendanceStage | null
+}
+
+export type MomentId =
+    | 'rsvp_opens' | 'rsvp_closes' | 'op_starts'
+    | 'confirmations_open' | 'completed'
+
+export interface TimelineMoment {
+    id: MomentId
+    label: string
+    /** null when the moment has no computable time — a manual RSVP, or no op date yet. */
+    at: Date | null
+    /** One human sentence for the row: a formatted date, 'Manual', or a rule. */
+    detail: string
+    state: 'done' | 'current' | 'pending'
+}
+
+/** Confirmations stay open for a day. 24h, not 48 — see OperationStatusBar. */
+const CONFIRMATION_WINDOW_MS = 24 * 3600_000
+
+export function fmtCountdown(target: Date, now: Date): string | null {
+    const diff = target.getTime() - now.getTime()
+    if (diff <= 0) return null
+    const s = Math.floor(diff / 1000)
+    const m = Math.floor(s / 60)
+    const h = Math.floor(m / 60)
+    const d = Math.floor(h / 24)
+    if (d > 0) return `${d}d ${h % 24}h`
+    if (h > 0) return `${h}h ${m % 60}m`
+    return `${m}m ${s % 60}s`
+}
+
+export function rsvpCloseAt(operationDate: Date | null, offsetMins: number): Date | null {
+    if (!operationDate) return null
+    return new Date(operationDate.getTime() - offsetMins * 60_000)
+}
+
+const STAGE_BY_MOMENT: Record<MomentId, AttendanceStage> = {
+    rsvp_opens: 'rsvp_open',
+    rsvp_closes: 'rsvp_closed',
+    op_starts: 'op_running',
+    confirmations_open: 'confirmations_open',
+    completed: 'completed',
+}
+
+function stateFor(moment: MomentId, stage: AttendanceStage | null): TimelineMoment['state'] {
+    const current = stageIndex(stage)
+    const mine = STAGE_ORDER.indexOf(STAGE_BY_MOMENT[moment])
+    if (mine < current) return 'done'
+    if (mine === current) return 'current'
+    return 'pending'
+}
+
+function fmtAt(at: Date | null): string {
+    if (!at) return '—'
+    return at.toLocaleString('en-AU', {
+        weekday: 'short', day: 'numeric', month: 'short',
+        hour: '2-digit', minute: '2-digit', hour12: false,
+    })
+}
+
+export function buildTimeline(status: LiveStatus): TimelineMoment[] {
+    const opDate = status.operationDate ? new Date(status.operationDate) : null
+    const openAt = status.rsvpOpenAt ? new Date(status.rsvpOpenAt) : null
+    const closeAt = rsvpCloseAt(opDate, status.rsvpCloseOffsetMins)
+    const confirmedAt = status.confirmationOpenedAt ? new Date(status.confirmationOpenedAt) : null
+    const completedAt = confirmedAt ? new Date(confirmedAt.getTime() + CONFIRMATION_WINDOW_MS) : null
+
+    return [
+        {
+            id: 'rsvp_opens',
+            label: 'RSVP opens',
+            at: openAt,
+            detail: openAt ? fmtAt(openAt) : 'Manual',
+            state: stateFor('rsvp_opens', status.stage),
+        },
+        {
+            id: 'rsvp_closes',
+            label: 'RSVP closes',
+            at: closeAt,
+            detail: closeAt ? fmtAt(closeAt) : '—',
+            state: stateFor('rsvp_closes', status.stage),
+        },
+        {
+            id: 'op_starts',
+            label: 'Operation starts',
+            at: opDate,
+            detail: opDate ? fmtAt(opDate) : 'No date set',
+            state: stateFor('op_starts', status.stage),
+        },
+        {
+            id: 'confirmations_open',
+            label: 'Confirmations open',
+            at: null,
+            detail: 'When the mission ends',
+            state: stateFor('confirmations_open', status.stage),
+        },
+        {
+            id: 'completed',
+            label: 'Completed',
+            at: completedAt,
+            detail: completedAt ? fmtAt(completedAt) : '24 hours after confirmations open',
+            state: stateFor('completed', status.stage),
+        },
+    ]
+}

--- a/apps/web/lib/operations/stage.test.ts
+++ b/apps/web/lib/operations/stage.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The deck's Advance button is a manual override on top of the cron that
+ * normally drives these transitions, so "what comes next" has to be one
+ * answer both agree on.
+ */
+import { describe, test, expect } from 'vitest'
+import { STAGE_ORDER, stageIndex, nextStage, stageLabel, stageProgress } from './stage'
+
+describe('STAGE_ORDER', () => {
+    test('is the lifecycle in order', () => {
+        expect(STAGE_ORDER).toEqual([
+            'preparing', 'rsvp_open', 'rsvp_closed',
+            'op_running', 'confirmations_open', 'completed',
+        ])
+    })
+})
+
+describe('stageIndex', () => {
+    test('locates a stage', () => {
+        expect(stageIndex('preparing')).toBe(0)
+        expect(stageIndex('completed')).toBe(5)
+    })
+
+    test('treats null and anything unrecognised as preparing', () => {
+        expect(stageIndex(null)).toBe(0)
+        expect(stageIndex('nonsense' as never)).toBe(0)
+    })
+})
+
+describe('nextStage', () => {
+    test('advances one step', () => {
+        expect(nextStage('preparing')).toBe('rsvp_open')
+        expect(nextStage('op_running')).toBe('confirmations_open')
+    })
+
+    test('null at the end, so the button can disable itself', () => {
+        expect(nextStage('completed')).toBeNull()
+    })
+})
+
+describe('stageLabel', () => {
+    test('renders human labels', () => {
+        expect(stageLabel('rsvp_open')).toBe('RSVP Open')
+        expect(stageLabel('op_running')).toBe('Op Running')
+        expect(stageLabel(null)).toBe('Preparing')
+    })
+})
+
+describe('stageProgress', () => {
+    test('is a 1-based count for the six-segment bar', () => {
+        expect(stageProgress('preparing')).toBe(1)
+        expect(stageProgress('completed')).toBe(6)
+    })
+})

--- a/apps/web/lib/operations/stage.ts
+++ b/apps/web/lib/operations/stage.ts
@@ -1,0 +1,37 @@
+export type AttendanceStage =
+    | 'preparing' | 'rsvp_open' | 'rsvp_closed'
+    | 'op_running' | 'confirmations_open' | 'completed'
+
+export const STAGE_ORDER = [
+    'preparing', 'rsvp_open', 'rsvp_closed',
+    'op_running', 'confirmations_open', 'completed',
+] as const satisfies readonly AttendanceStage[]
+
+const LABELS: Record<AttendanceStage, string> = {
+    preparing: 'Preparing',
+    rsvp_open: 'RSVP Open',
+    rsvp_closed: 'RSVP Closed',
+    op_running: 'Op Running',
+    confirmations_open: 'Confirmations Open',
+    completed: 'Completed',
+}
+
+/** Unrecognised and missing stages both read as the start of the lifecycle. */
+export function stageIndex(stage: AttendanceStage | null): number {
+    const i = STAGE_ORDER.indexOf(stage as never)
+    return i === -1 ? 0 : i
+}
+
+export function nextStage(stage: AttendanceStage | null): AttendanceStage | null {
+    const i = stageIndex(stage)
+    return i >= STAGE_ORDER.length - 1 ? null : STAGE_ORDER[i + 1]
+}
+
+export function stageLabel(stage: AttendanceStage | null): string {
+    return LABELS[stage as AttendanceStage] ?? LABELS.preparing
+}
+
+/** 1-based, for the deck's six-segment progress bar. */
+export function stageProgress(stage: AttendanceStage | null): number {
+    return stageIndex(stage) + 1
+}

--- a/apps/web/styles/command.css
+++ b/apps/web/styles/command.css
@@ -1,0 +1,31 @@
+/*
+ * The shared command palette. Ported out of the milpac personnel file
+ * (profile.module.css), which defined it first and still consumes it.
+ *
+ * --acc / --acc-rgb are deliberately NOT set here: every consumer injects them
+ * inline for the entity it renders — the member's Discord colour on a milpac,
+ * the operation's themeColor in the editor. That indirection is what lets one
+ * palette serve pages whose accent is per-row data.
+ */
+.command {
+    --bg: #08090a;
+    --s1: #0d0f11;
+    --s2: #12151a;
+    --s3: #181c22;
+    --line: #1e232b;
+    --line-2: #2a3038;
+
+    --ink: #e8eaed;
+    --ink-2: #a8b0ba;
+    --ink-3: #6b7480;
+
+    --good: #7fae5c;
+    --warn: #d4a03a;
+    --crit: #c05a48;
+
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Roboto Mono", Menlo, Consolas, monospace;
+    --sans: "Helvetica Neue", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+
+    --r: 3px;
+    --pad: clamp(16px, 3vw, 40px);
+}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -221,6 +221,49 @@ select option {
 	background: #474747;
 }
 
+/* Thin, fading overlay scrollbars — operations editor only (visual-fixes
+   spec). Opt in per-container with `.thin-scroll` rather than touching the
+   site-wide rule above, so every other page keeps the default chunky
+   scrollbar unless it happens to reuse a component that already carries
+   this class. Width is fixed at 8px regardless of the thumb's visibility,
+   so nothing reflows when it fades in/out — only its own background-color
+   ever changes. Track, corner and arrow buttons are fully transparent.
+   Firefox has no per-element fade or true overlay support, so it falls back
+   to a plain thin (non-overlay) scrollbar via scrollbar-width/-color. */
+.thin-scroll {
+	scrollbar-width: thin;
+	scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+}
+.thin-scroll::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+.thin-scroll::-webkit-scrollbar-track,
+.thin-scroll::-webkit-scrollbar-corner {
+	background: transparent;
+}
+.thin-scroll::-webkit-scrollbar-button {
+	display: none;
+	width: 0;
+	height: 0;
+}
+.thin-scroll::-webkit-scrollbar-thumb {
+	background-color: transparent;
+	border-radius: 4px;
+	transition: background-color 0.2s ease;
+}
+/* Fades in on hover, or while the scroll-fade hook (useThinScrollFade) has
+   marked the container as actively scrolling. Hover keeps working even
+   where the hook isn't wired up, per the CSS-only fallback the spec calls
+   out as acceptable. */
+.thin-scroll:hover::-webkit-scrollbar-thumb,
+.thin-scroll.is-scrolling::-webkit-scrollbar-thumb {
+	background-color: rgba(255, 255, 255, 0.18);
+}
+.thin-scroll::-webkit-scrollbar-thumb:hover {
+	background-color: rgba(255, 255, 255, 0.3);
+}
+
 
 /* ─── Operation Document Editor & Viewer ─────────────────────────────────── */
 

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -248,13 +248,22 @@ select option {
 
 /* ── Editor (always uses site red) ───────────────────────────────────────── */
 
+/* The editable region's own ground (visual-fixes spec §3) — a hairline
+   border plus a ground one step lighter than the column background so the
+   writable area reads as a distinct surface rather than blending into the
+   page, without going back to a heavy boxed card. The per-section rule in
+   CollabEditor.tsx (.op-editor-{sectionId}) layers the focus ring on top. */
 .op-editor {
     color: rgba(237, 237, 237, 0.85);
     font-size: 0.92rem;
     line-height: 1.75;
     outline: none;
     min-height: 80px;
-    padding: 36px 48px;
+    padding: 28px 36px;
+    background: var(--s1);
+    border: 1px solid var(--line);
+    border-radius: var(--r);
+    transition: box-shadow 0.15s, border-color 0.15s;
 }
 
 .op-editor h1 {

--- a/apps/web/tests/operations-editor.spec.ts
+++ b/apps/web/tests/operations-editor.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * The operations editor shell (`app/operations/[id]/edit`).
+ *
+ * Four behaviours, one per describe block below — see the plan's task-14
+ * brief for the full rationale. All four sign in the same way every other
+ * spec in this suite does (`pageAs`/`signIn` — a seeded Mongo user plus a
+ * `token` cookie, no OAuth), and each test seeds its own operation directly
+ * via `withDb()` rather than the `/api/operations/new` route, since that
+ * route requires `PERMISSIONS.operations.write` and this file only needs a
+ * known, stable `_id` to navigate to — not the creation flow itself.
+ *
+ * ── Who is "HQ" here ──────────────────────────────────────────────────────
+ * `app/operations/[id]/edit/layout.tsx` (the server redirect gate) and
+ * page.tsx's own `isHQ` client flag both read the exact same permission key —
+ * `PERMISSIONS.pages.operationsEdit` (`['HQ Staff', 'J2 - Mission Making']`,
+ * `lib/permissions.ts`) — via `client.hasRoles()`. That function's global
+ * bypass (any holder of the Discord role literally named `J4-Administration`,
+ * hardcoded in `lib/discord/index.ts`) is what lets the `j4` persona
+ * (tests/constants.ts) stand in for "HQ" below, exactly the way
+ * `dashboard.permissions.spec.ts` already relies on the same bypass for its
+ * own J4 assertions — no new persona needed.
+ *
+ * The `j3` persona holds neither `HQ Staff`/`J2 - Mission Making` nor the
+ * bypass role, so it is genuinely turned away at the layout gate. Because
+ * the gate and the client flag are the same check, there is currently no
+ * reachable state where a signed-in user sees the tab bar at all with
+ * `isHQ === false` — the "Attendance tab absent for non-HQ" spec below
+ * therefore proves absence via that redirect (the strongest form of
+ * "absent from the DOM": the DOM in question never contains an editor at
+ * all), with a positive-control HQ case alongside it so the redirect being
+ * asserted is known to actually gate something, not just be a slow load
+ * that never settles (same reasoning `dashboard.permissions.spec.ts` gives
+ * for its own positive controls).
+ *
+ * ── Why the tab-switch spec needs a live collab connection to pass ────────
+ * `components/editor/CollabEditor.tsx` seeds the operation's first section
+ * (title `defaultSectionTitle`, "Situation") only inside a
+ * `provider.on('synced', ...)` handler — and Hocuspocus's `synced` flag is
+ * set only after a real WebSocket handshake with the collab server
+ * completes (`@hocuspocus/provider`'s `synced` setter is fed by the sync
+ * protocol; there is no local/offline fallback). Until a section exists,
+ * `ActiveEditor` renders no `.ProseMirror` region at all — nothing to click
+ * into or type in.
+ *
+ * `playwright.config.ts`'s `webServer` runs `npm run dev` (`next dev`),
+ * which has no `/collab` route — that upgrade handler only exists in
+ * `server.mjs` (`npm run dev-collab`). So as configured today, this spec
+ * will time out waiting for the editor, not because tab-switching itself is
+ * broken. Deliberately not fixed by pointing `webServer` at `dev-collab`
+ * here: `server.mjs` also runs `cleanupOperationImages()` on startup, which
+ * deletes anything under the real repo `storage/uploads/operations` not
+ * referenced by an operation in whatever Mongo it's pointed at — and unlike
+ * the backups suite's `BACKUPS_STORAGE_ROOT`, there is no test-isolated
+ * override for that path. Pointing `dev-collab` at the tiny E2E database
+ * would make its very first run treat every real uploaded mission image as
+ * orphaned and delete it. That needs its own fix (an env-overridable uploads
+ * dir, mirroring `BACKUPS_STORAGE_ROOT`) before `webServer` can safely run
+ * `dev-collab`, and making that call isn't this task's to make silently.
+ */
+import { ObjectId } from 'mongodb'
+import { test, expect } from './fixtures/asot'
+import { withDb } from './seed'
+
+/** Minimal, valid `Operation` doc — see `types/operation.d.ts`. `status:
+ *  'Upcoming'` keeps it out of the `In Development` view-gate in
+ *  `app/api/operations/route.ts` (`GET ?id=`), which is irrelevant to what
+ *  these specs cover and would otherwise need its own HQ-only handling. */
+async function createOperation(overrides: Record<string, unknown> = {}): Promise<string> {
+    const id = new ObjectId()
+    await withDb(db =>
+        db.collection('operations').insertOne({
+            _id: id,
+            title: 'E2E Editor Op',
+            department: '1-0 HQ',
+            date: new Date('2026-12-01T00:00:00.000Z'),
+            loreDate: '',
+            status: 'Upcoming',
+            ...overrides,
+        } as never),
+    )
+    return id.toHexString()
+}
+
+/** Fresh operations collection before each test — these specs don't share
+ *  fixture ops with each other or with other spec files, and each test
+ *  seeds its own via `createOperation()` anyway; this just keeps a re-run
+ *  from accumulating stale ones. */
+test.beforeEach(async () => {
+    await withDb(db => db.collection('operations').deleteMany({}))
+})
+
+function editorTab(page: import('@playwright/test').Page, name: string) {
+    return page.getByRole('navigation', { name: 'Operation editor sections' })
+        .getByRole('button', { name, exact: true })
+}
+
+// ── Tab switching preserves the collaborative editor ───────────────────────
+//
+// See the module doc above for why this requires a live collab connection
+// to pass as written — it is written against the intended behaviour, not
+// against today's `webServer` command.
+
+test.describe('Tab switching preserves the collaborative editor', () => {
+    test('typed content and the connection indicator survive a Brief → Map → Brief round trip', async ({ pageAs }) => {
+        const opId = await createOperation()
+        const page = await pageAs('j4')
+        await page.goto(`/operations/${opId}/edit`)
+
+        // CollabEditor renders no `.ProseMirror` region until its first
+        // section is seeded on the Hocuspocus 'synced' event (see module
+        // doc) — a generous timeout here, not a race.
+        const editor = page.locator('.ProseMirror[contenteditable="true"]')
+        await expect(editor).toBeVisible({ timeout: 30_000 })
+
+        const marker = `e2e-marker-${Date.now()}`
+        await editor.click()
+        await page.keyboard.type(marker)
+        await expect(editor).toContainText(marker)
+
+        // Baseline, not an assertion that it reads "Live" — the property
+        // under test is that switching tabs alone doesn't change it, not
+        // that this environment's WebSocket happens to be reachable. See
+        // StatusBar.tsx's `data-testid` comment.
+        const connection = page.getByTestId('status-connection')
+        const connectionBefore = await connection.textContent()
+
+        await editorTab(page, 'MAP').click()
+        await expect(editorTab(page, 'MAP')).toHaveAttribute('aria-current', 'page')
+
+        await editorTab(page, 'BRIEF').click()
+        await expect(editorTab(page, 'BRIEF')).toHaveAttribute('aria-current', 'page')
+
+        // The regression this spec exists to catch: if EditorShell ever
+        // stops keeping Brief mounted (display:none) and instead unmounts
+        // it per tab, CollabEditor's `useState(() => new Y.Doc())` rebuilds
+        // from scratch on remount and this text is gone.
+        await expect(editor).toContainText(marker)
+        await expect(connection).toHaveText(connectionBefore ?? '')
+    })
+})
+
+// ── Deck collapse persists across a reload ──────────────────────────────────
+
+test.describe('Mission deck collapse state', () => {
+    test('collapsing the deck persists across a reload', async ({ pageAs }) => {
+        const opId = await createOperation()
+        const page = await pageAs('j4')
+        // >=1280px so MissionDeck treats collapse as the persisted push-layout
+        // preference rather than the narrow band's never-persisted overlay
+        // (deck/MissionDeck.tsx — `useIsWide`/`WIDE_QUERY`).
+        await page.setViewportSize({ width: 1440, height: 900 })
+        await page.goto(`/operations/${opId}/edit`)
+
+        const collapseBtn = page.getByRole('button', { name: 'Collapse mission deck' })
+        await expect(collapseBtn).toBeVisible({ timeout: 30_000 })
+        await collapseBtn.click()
+
+        const expandBtn = page.getByRole('button', { name: 'Expand mission deck' })
+        await expect(expandBtn).toBeVisible()
+        await expect.poll(() =>
+            page.evaluate(() => window.localStorage.getItem('asot.opsdeck.collapsed')),
+        ).toBe('1')
+
+        await page.reload()
+
+        await expect(page.getByRole('button', { name: 'Expand mission deck' })).toBeVisible({ timeout: 30_000 })
+        // The rail state, not just the storage key — proves the reload
+        // actually reads it back, not just that the write landed.
+        await expect(page.getByRole('button', { name: 'Collapse mission deck' })).toHaveCount(0)
+    })
+})
+
+// ── Editing the operation date in the timeline persists ────────────────────
+
+test.describe('Timeline op-date edit', () => {
+    test('changing the operation date via the Schedule card persists across a reload', async ({ pageAs }) => {
+        const opId = await createOperation()
+        const page = await pageAs('j4')
+        await page.setViewportSize({ width: 1440, height: 900 })
+        await page.goto(`/operations/${opId}/edit`)
+
+        const dateInput = page.getByTestId('schedule-op-date-input')
+        await expect(dateInput).toBeVisible({ timeout: 30_000 })
+
+        // scheduleSave (page.tsx) debounces ~1s before the write even starts —
+        // wait for StatusBar's savedAt cell to move rather than racing it
+        // (spec instruction). This cell is fed only by that debounced save,
+        // not by CollabEditor's WS-driven saveStatus, so it isn't muddied by
+        // the collab socket's own connect/reconnect cycle (see StatusBar.tsx
+        // comment).
+        const savedCell = page.getByTestId('status-saved-at')
+        const savedBefore = await savedCell.textContent()
+
+        // MUI's date-field sections accept keyboard entry directly: Home
+        // moves focus to the first (day) section, then typing digits fills
+        // each section and auto-advances once it's full — dd, mm, yyyy, HH,
+        // mm for the "DD/MM/YYYY HH:mm" format this picker uses.
+        await dateInput.click()
+        await page.keyboard.press('Home')
+        await page.keyboard.type('160120271030', { delay: 40 })
+
+        await expect(savedCell).not.toHaveText(savedBefore ?? '', { timeout: 10_000 })
+
+        await page.reload()
+
+        await expect(page.getByTestId('schedule-op-date-input')).toHaveValue('16/01/2027 10:30', { timeout: 30_000 })
+    })
+})
+
+// ── A non-HQ user has no Attendance tab ─────────────────────────────────────
+
+test.describe('Attendance tab visibility', () => {
+    test('a non-HQ user is redirected before any Attendance tab can exist', async ({ pageAs }) => {
+        const opId = await createOperation()
+        const page = await pageAs('j3')
+        await page.goto(`/operations/${opId}/edit`)
+
+        // See module doc: the layout gate and the client isHQ flag share one
+        // permission key, so a non-HQ session never reaches the tab bar —
+        // the settled URL is the observable proof, per this suite's own
+        // "a gated page returns 200 before it redirects" note (README.md).
+        await expect(page).toHaveURL(/\/operations\/?$/)
+
+        // Absent from the DOM outright, not merely unrendered because the
+        // whole page redirected away — this holds regardless of which page
+        // the user lands on.
+        await expect(page.getByRole('button', { name: 'ATTENDANCE', exact: true })).toHaveCount(0)
+    })
+
+    test('positive control: an HQ user does see the Attendance tab', async ({ pageAs }) => {
+        // Proves the redirect above is the gate actually doing the work,
+        // not a slow load that never settles anywhere — same reasoning
+        // dashboard.permissions.spec.ts gives for its own positive controls.
+        const opId = await createOperation()
+        const page = await pageAs('j4')
+        await page.goto(`/operations/${opId}/edit`)
+
+        await expect(editorTab(page, 'ATTENDANCE')).toBeVisible({ timeout: 30_000 })
+    })
+})

--- a/docs/superpowers/plans/2026-08-18-operations-editor-shell.md
+++ b/docs/superpowers/plans/2026-08-18-operations-editor-shell.md
@@ -1,0 +1,1717 @@
+# Operations Editor Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the operations editor's 2,464-line single-component scroll-stack with a full-height shell — tabs, a persistent mission deck, and a status bar — so the briefing editor is the first thing on screen instead of the last.
+
+**Architecture:** Pure logic moves to `lib/operations/*` where the existing vitest runner can reach it; thin React hooks in the edit route wrap it; the shell composes a header, tab strip, documents rail, editor, 340px deck and status bar. Existing panels stay mounted and working until the deck card that replaces each one lands, so every task leaves a usable page.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, vitest (node), Y.js/TipTap via Hocuspocus, CSS custom properties.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md`
+
+## Global Constraints
+
+- **Branch:** all work on `feat/operations-editor`. Never commit to `main` — `.github/workflows/deploy.yml` deploys every push to `main` with no CI gate. Commit freely; **do not push** (Koda pushes).
+- **Scope:** this plan is spec §12 phase 1, editor shell only (spec steps 1–7). The mission page (spec §10, steps 8–11) is a separate plan.
+- **Unit tests live in `lib/`.** `vitest.config.ts` includes only `lib/**/*.test.ts`, deliberately, so the Playwright suite in `tests/` is never picked up. Pure logic therefore goes in `lib/operations/`, not in the route folder.
+- **Do not run `npm run test:e2e`** — Playwright runs are Koda's call. Write specs, do not execute them.
+- **Design tokens** come from `styles/command.css` (Task 1). No new `rgba()` literals in shell components; use `var(--…)`.
+- **Token values, verbatim:** `--bg #08090a`, `--s1 #0d0f11`, `--s2 #12151a`, `--s3 #181c22`, `--line #1e232b`, `--line-2 #2a3038`, `--ink #e8eaed`, `--ink-2 #a8b0ba`, `--ink-3 #6b7480`, `--good #7fae5c`, `--warn #d4a03a`, `--crit #c05a48`, `--r 3px`.
+- **`--acc` / `--acc-rgb` are injected inline** per operation from `themeColor`, never hardcoded.
+- **Confirmations close 24 hours after opening**, not 48. The spec's density study says 48; the shipped code (`OperationStatusBar.tsx:70`) uses `24 * 3600000` and is authoritative.
+- **No file over ~400 lines.**
+- **Commit message convention:** `type(scope): summary`, e.g. `feat(operations): add the mission deck`. End with:
+  `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`
+
+---
+
+## File Structure
+
+**Created**
+
+| Path | Responsibility |
+|---|---|
+| `apps/web/styles/command.css` | The shared token block. Imported by milpac and the editor. |
+| `apps/web/lib/operations/schedule.ts` | Pure: countdown formatting, RSVP close time, timeline construction. |
+| `apps/web/lib/operations/schedule.test.ts` | Its tests. |
+| `apps/web/lib/operations/stage.ts` | Pure: attendance stage order, index, next, label. |
+| `apps/web/lib/operations/stage.test.ts` | Its tests. |
+| `apps/web/lib/operations/doc-stats.ts` | Pure: word and section counts over a ProseMirror doc. |
+| `apps/web/lib/operations/doc-stats.test.ts` | Its tests. |
+| `apps/web/app/operations/[id]/edit/shell.module.css` | Shell layout classes. |
+| `apps/web/app/operations/[id]/edit/hooks/useOperationStatus.ts` | Polls `live-status`, returns timeline + stage. |
+| `apps/web/app/operations/[id]/edit/hooks/useDocStats.ts` | Word/section counts from the live editor. |
+| `apps/web/app/operations/[id]/edit/EditorShell.tsx` | Layout, tab state, URL mirroring. |
+| `apps/web/app/operations/[id]/edit/Header.tsx` | Crumb, title, status pill, save state, publish, overflow. |
+| `apps/web/app/operations/[id]/edit/StatusBar.tsx` | Document/session state strip. |
+| `apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx` | Deck column + collapse. |
+| `apps/web/app/operations/[id]/edit/deck/CountdownStrip.tsx` | D-n and gate progress cells. |
+| `apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx` | The timeline. |
+| `apps/web/app/operations/[id]/edit/deck/StageCard.tsx` | Progress bar + Advance. |
+| `apps/web/app/operations/[id]/edit/deck/AttendanceCard.tsx` | Platoon chips, ping state. HQ only. |
+| `apps/web/app/operations/[id]/edit/deck/DetailsCard.tsx` | Owner, department, points, theme, map world. |
+| `apps/web/app/operations/[id]/edit/tabs/BriefTab.tsx` | Documents rail + CollabEditor. |
+| `apps/web/app/operations/[id]/edit/tabs/MapTab.tsx` | MapSection. |
+
+**Modified**
+
+| Path | Change |
+|---|---|
+| `apps/web/app/(landing)/milpacs/[username]/profile.module.css` | Drops its `:root` token block; imports `command.css`. |
+| `apps/web/app/operations/[id]/edit/page.tsx` | Shrinks from 2,464 lines to a thin container. |
+| `apps/web/components/operations/OperationStatusBar.tsx` | Uses `lib/operations/schedule` instead of its own copies. |
+| `apps/web/lib/colour.ts` | New home for `hexToRgb` (Task 1). |
+
+---
+
+## Task 1: Shared token stylesheet
+
+**Files:**
+- Create: `apps/web/styles/command.css`
+- Create: `apps/web/lib/colour.ts`
+- Modify: `apps/web/app/(landing)/milpacs/[username]/profile.module.css:16-60`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the `.command` class exposing every token above; `hexToRgb(hex: string): { r: number; g: number; b: number }` and `rgbTriplet(hex: string): string` from `@/lib/colour`.
+
+- [ ] **Step 1: Create the token stylesheet**
+
+`apps/web/styles/command.css`:
+
+```css
+/*
+ * The shared command palette. Ported out of the milpac personnel file
+ * (profile.module.css), which defined it first and still consumes it.
+ *
+ * --acc / --acc-rgb are deliberately NOT set here: every consumer injects them
+ * inline for the entity it renders — the member's Discord colour on a milpac,
+ * the operation's themeColor in the editor. That indirection is what lets one
+ * palette serve pages whose accent is per-row data.
+ */
+.command {
+    --bg: #08090a;
+    --s1: #0d0f11;
+    --s2: #12151a;
+    --s3: #181c22;
+    --line: #1e232b;
+    --line-2: #2a3038;
+
+    --ink: #e8eaed;
+    --ink-2: #a8b0ba;
+    --ink-3: #6b7480;
+
+    --good: #7fae5c;
+    --warn: #d4a03a;
+    --crit: #c05a48;
+
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Roboto Mono", Menlo, Consolas, monospace;
+    --sans: "Helvetica Neue", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+
+    --r: 3px;
+    --pad: clamp(16px, 3vw, 40px);
+}
+```
+
+- [ ] **Step 2: Create the colour helper**
+
+`apps/web/lib/colour.ts`:
+
+```ts
+/**
+ * One home for hex -> rgb. It was previously redefined in at least three
+ * files (the editor page, PageSidebar, PageNavClient), each with the same
+ * body, which is how two of them ended up disagreeing about what to do with
+ * a malformed value.
+ */
+export interface Rgb { r: number; g: number; b: number }
+
+export function hexToRgb(hex: string): Rgb {
+    const h = String(hex ?? '').replace('#', '')
+    if (h.length !== 6) return { r: 219, g: 0, b: 29 }
+    return {
+        r: parseInt(h.substring(0, 2), 16),
+        g: parseInt(h.substring(2, 4), 16),
+        b: parseInt(h.substring(4, 6), 16),
+    }
+}
+
+/** `"219,0,29"` — the form CSS custom properties want for rgba() tinting. */
+export function rgbTriplet(hex: string): string {
+    const { r, g, b } = hexToRgb(hex)
+    return `${r},${g},${b}`
+}
+```
+
+- [ ] **Step 3: Write the failing test**
+
+`apps/web/lib/colour.test.ts`:
+
+```ts
+import { describe, test, expect } from 'vitest'
+import { hexToRgb, rgbTriplet } from './colour'
+
+describe('hexToRgb', () => {
+    test('parses a six-digit hex with or without the hash', () => {
+        expect(hexToRgb('#db001d')).toEqual({ r: 219, g: 0, b: 29 })
+        expect(hexToRgb('db001d')).toEqual({ r: 219, g: 0, b: 29 })
+    })
+
+    test('falls back to ASOT red on anything malformed', () => {
+        expect(hexToRgb('')).toEqual({ r: 219, g: 0, b: 29 })
+        expect(hexToRgb('#fff')).toEqual({ r: 219, g: 0, b: 29 })
+    })
+})
+
+describe('rgbTriplet', () => {
+    test('formats for CSS custom properties', () => {
+        expect(rgbTriplet('#4dd0e1')).toBe('77,208,225')
+    })
+})
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `cd apps/web && npx vitest run lib/colour.test.ts`
+Expected: PASS (implementation was written in step 2).
+
+- [ ] **Step 5: Repoint the milpac stylesheet**
+
+In `profile.module.css`, add `@import '../../../../styles/command.css';` at the top, change `.shell {` to `.shell { composes: command from '../../../../styles/command.css';` and **delete** the token declarations from `--bg` through `--pad` in the `.shell` block. Leave every other declaration in `.shell` (background, color, font-family, font-size, line-height, font-smoothing, position, overflow-x) exactly as it is.
+
+- [ ] **Step 6: Verify no rendered change on milpac**
+
+Run: `cd apps/web && npx tsc --noEmit && npm run lint`
+Expected: clean. Then load a milpac page in dev and confirm colours are unchanged — this step is a visual diff, not an assertion.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/styles/command.css apps/web/lib/colour.ts apps/web/lib/colour.test.ts "apps/web/app/(landing)/milpacs/[username]/profile.module.css"
+git commit -m "refactor(styles): extract the milpac token block into styles/command.css
+
+Three consumers are coming — milpac, the operations editor shell and the
+mission page — and three copies of a palette is how palettes drift.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Schedule logic
+
+**Files:**
+- Create: `apps/web/lib/operations/schedule.ts`
+- Test: `apps/web/lib/operations/schedule.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type AttendanceStage = 'preparing' | 'rsvp_open' | 'rsvp_closed' | 'op_running' | 'confirmations_open' | 'completed'`
+  - `interface LiveStatus` — the `GET /api/operations/[id]/live-status` response shape
+  - `interface TimelineMoment { id; label; at: Date | null; detail: string; state: 'done' | 'current' | 'pending' }`
+  - `fmtCountdown(target: Date, now: Date): string | null`
+  - `rsvpCloseAt(operationDate: Date | null, offsetMins: number): Date | null`
+  - `buildTimeline(status: LiveStatus, now: Date): TimelineMoment[]`
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/lib/operations/schedule.test.ts`:
+
+```ts
+/**
+ * The editor's deck and the public status bar both render from these, so a
+ * disagreement between them is a bug users see as "the page says two things".
+ * All of it is pure and clock-injected, so it is tested directly.
+ */
+import { describe, test, expect } from 'vitest'
+import { fmtCountdown, rsvpCloseAt, buildTimeline, type LiveStatus } from './schedule'
+
+const base: LiveStatus = {
+    operationStatus: 'Upcoming',
+    operationDate: '2026-11-18T08:00:00.000Z',
+    rsvpOpen: false,
+    rsvpOpenAt: null,
+    rsvpCloseOffsetMins: 90,
+    confirmationOpen: false,
+    confirmationOpenedAt: null,
+    stage: 'preparing',
+}
+
+describe('fmtCountdown', () => {
+    const now = new Date('2026-08-18T00:00:00.000Z')
+
+    test('days and hours when more than a day out', () => {
+        expect(fmtCountdown(new Date('2026-08-20T05:00:00.000Z'), now)).toBe('2d 5h')
+    })
+
+    test('hours and minutes inside a day', () => {
+        expect(fmtCountdown(new Date('2026-08-18T03:30:00.000Z'), now)).toBe('3h 30m')
+    })
+
+    test('minutes and seconds inside an hour', () => {
+        expect(fmtCountdown(new Date('2026-08-18T00:02:05.000Z'), now)).toBe('2m 5s')
+    })
+
+    test('null once the target has passed, so callers can branch on it', () => {
+        expect(fmtCountdown(new Date('2026-08-17T23:59:59.000Z'), now)).toBeNull()
+        expect(fmtCountdown(now, now)).toBeNull()
+    })
+})
+
+describe('rsvpCloseAt', () => {
+    test('subtracts the offset from the operation date', () => {
+        expect(rsvpCloseAt(new Date('2026-11-18T08:00:00.000Z'), 90))
+            .toEqual(new Date('2026-11-18T06:30:00.000Z'))
+    })
+
+    test('null when the operation has no date yet', () => {
+        expect(rsvpCloseAt(null, 90)).toBeNull()
+    })
+})
+
+describe('buildTimeline', () => {
+    const now = new Date('2026-08-18T00:00:00.000Z')
+
+    test('returns the five moments in chronological order', () => {
+        expect(buildTimeline(base, now).map(m => m.id)).toEqual([
+            'rsvp_opens', 'rsvp_closes', 'op_starts', 'confirmations_open', 'completed',
+        ])
+    })
+
+    test('reports a manual RSVP as Manual rather than inventing a time', () => {
+        const m = buildTimeline(base, now)[0]
+        expect(m.at).toBeNull()
+        expect(m.detail).toBe('Manual')
+    })
+
+    test('uses the scheduled open time when one is set', () => {
+        const m = buildTimeline({ ...base, rsvpOpenAt: '2026-11-17T08:00:00.000Z' }, now)[0]
+        expect(m.at).toEqual(new Date('2026-11-17T08:00:00.000Z'))
+    })
+
+    test('marks the operation start as current once running', () => {
+        const t = buildTimeline({ ...base, stage: 'op_running' }, now)
+        expect(t.find(m => m.id === 'op_starts')!.state).toBe('current')
+        expect(t.find(m => m.id === 'rsvp_closes')!.state).toBe('done')
+    })
+
+    test('closes confirmations 24 hours after they open, not 48', () => {
+        const t = buildTimeline({
+            ...base,
+            stage: 'confirmations_open',
+            confirmationOpen: true,
+            confirmationOpenedAt: '2026-11-18T12:00:00.000Z',
+        }, now)
+        expect(t.find(m => m.id === 'completed')!.at)
+            .toEqual(new Date('2026-11-19T12:00:00.000Z'))
+    })
+
+    test('survives an operation with no date at all', () => {
+        const t = buildTimeline({ ...base, operationDate: null }, now)
+        expect(t).toHaveLength(5)
+        expect(t.find(m => m.id === 'op_starts')!.at).toBeNull()
+    })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd apps/web && npx vitest run lib/operations/schedule.test.ts`
+Expected: FAIL — `Failed to resolve import "./schedule"`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/web/lib/operations/schedule.ts`:
+
+```ts
+/**
+ * Everything the editor deck and the public status bar need to say *when*
+ * something happens. Pure and clock-injected: `now` is always a parameter so
+ * the whole timeline is testable without faking timers.
+ *
+ * Lifted from components/operations/OperationStatusBar.tsx, which computed all
+ * of this inline and is now a consumer.
+ */
+
+export type AttendanceStage =
+    | 'preparing' | 'rsvp_open' | 'rsvp_closed'
+    | 'op_running' | 'confirmations_open' | 'completed'
+
+/** The `GET /api/operations/[id]/live-status` response. */
+export interface LiveStatus {
+    operationStatus: string | null
+    operationDate: string | null
+    rsvpOpen: boolean
+    rsvpOpenAt: string | null
+    rsvpCloseOffsetMins: number
+    confirmationOpen: boolean
+    confirmationOpenedAt: string | null
+    stage: AttendanceStage | null
+}
+
+export type MomentId =
+    | 'rsvp_opens' | 'rsvp_closes' | 'op_starts'
+    | 'confirmations_open' | 'completed'
+
+export interface TimelineMoment {
+    id: MomentId
+    label: string
+    /** null when the moment has no computable time — a manual RSVP, or no op date yet. */
+    at: Date | null
+    /** One human sentence for the row: a formatted date, 'Manual', or a rule. */
+    detail: string
+    state: 'done' | 'current' | 'pending'
+}
+
+/** Confirmations stay open for a day. 24h, not 48 — see OperationStatusBar. */
+const CONFIRMATION_WINDOW_MS = 24 * 3600_000
+
+export function fmtCountdown(target: Date, now: Date): string | null {
+    const diff = target.getTime() - now.getTime()
+    if (diff <= 0) return null
+    const s = Math.floor(diff / 1000)
+    const m = Math.floor(s / 60)
+    const h = Math.floor(m / 60)
+    const d = Math.floor(h / 24)
+    if (d > 0) return `${d}d ${h % 24}h`
+    if (h > 0) return `${h}h ${m % 60}m`
+    return `${m}m ${s % 60}s`
+}
+
+export function rsvpCloseAt(operationDate: Date | null, offsetMins: number): Date | null {
+    if (!operationDate) return null
+    return new Date(operationDate.getTime() - offsetMins * 60_000)
+}
+
+const STAGE_BY_MOMENT: Record<MomentId, AttendanceStage> = {
+    rsvp_opens: 'rsvp_open',
+    rsvp_closes: 'rsvp_closed',
+    op_starts: 'op_running',
+    confirmations_open: 'confirmations_open',
+    completed: 'completed',
+}
+
+const ORDER: AttendanceStage[] = [
+    'preparing', 'rsvp_open', 'rsvp_closed',
+    'op_running', 'confirmations_open', 'completed',
+]
+
+function stateFor(moment: MomentId, stage: AttendanceStage | null): TimelineMoment['state'] {
+    const current = ORDER.indexOf(stage ?? 'preparing')
+    const mine = ORDER.indexOf(STAGE_BY_MOMENT[moment])
+    if (mine < current) return 'done'
+    if (mine === current) return 'current'
+    return 'pending'
+}
+
+function fmtAt(at: Date | null): string {
+    if (!at) return '—'
+    return at.toLocaleString('en-AU', {
+        weekday: 'short', day: 'numeric', month: 'short',
+        hour: '2-digit', minute: '2-digit', hour12: false,
+    })
+}
+
+export function buildTimeline(status: LiveStatus, now: Date): TimelineMoment[] {
+    void now  // reserved: callers format countdowns separately via fmtCountdown
+    const opDate = status.operationDate ? new Date(status.operationDate) : null
+    const openAt = status.rsvpOpenAt ? new Date(status.rsvpOpenAt) : null
+    const closeAt = rsvpCloseAt(opDate, status.rsvpCloseOffsetMins)
+    const confirmedAt = status.confirmationOpenedAt ? new Date(status.confirmationOpenedAt) : null
+    const completedAt = confirmedAt ? new Date(confirmedAt.getTime() + CONFIRMATION_WINDOW_MS) : null
+
+    return [
+        {
+            id: 'rsvp_opens',
+            label: 'RSVP opens',
+            at: openAt,
+            detail: openAt ? fmtAt(openAt) : 'Manual',
+            state: stateFor('rsvp_opens', status.stage),
+        },
+        {
+            id: 'rsvp_closes',
+            label: 'RSVP closes',
+            at: closeAt,
+            detail: closeAt ? fmtAt(closeAt) : '—',
+            state: stateFor('rsvp_closes', status.stage),
+        },
+        {
+            id: 'op_starts',
+            label: 'Operation starts',
+            at: opDate,
+            detail: opDate ? fmtAt(opDate) : 'No date set',
+            state: stateFor('op_starts', status.stage),
+        },
+        {
+            id: 'confirmations_open',
+            label: 'Confirmations open',
+            at: null,
+            detail: 'When the mission ends',
+            state: stateFor('confirmations_open', status.stage),
+        },
+        {
+            id: 'completed',
+            label: 'Completed',
+            at: completedAt,
+            detail: completedAt ? fmtAt(completedAt) : '24 hours after confirmations open',
+            state: stateFor('completed', status.stage),
+        },
+    ]
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run lib/operations/schedule.test.ts`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/operations/schedule.ts apps/web/lib/operations/schedule.test.ts
+git commit -m "feat(operations): extract schedule and timeline logic to lib
+
+Pure and clock-injected so the deck, the public status bar and their tests
+all agree about when things happen.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Stage logic
+
+**Files:**
+- Create: `apps/web/lib/operations/stage.ts`
+- Test: `apps/web/lib/operations/stage.test.ts`
+
+**Interfaces:**
+- Consumes: `AttendanceStage` from `./schedule`.
+- Produces: `STAGE_ORDER: readonly AttendanceStage[]`, `stageIndex(s): number`, `nextStage(s): AttendanceStage | null`, `stageLabel(s): string`, `stageProgress(s): number`.
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/lib/operations/stage.test.ts`:
+
+```ts
+/**
+ * The deck's Advance button is a manual override on top of the cron that
+ * normally drives these transitions, so "what comes next" has to be one
+ * answer both agree on.
+ */
+import { describe, test, expect } from 'vitest'
+import { STAGE_ORDER, stageIndex, nextStage, stageLabel, stageProgress } from './stage'
+
+describe('STAGE_ORDER', () => {
+    test('is the lifecycle in order', () => {
+        expect(STAGE_ORDER).toEqual([
+            'preparing', 'rsvp_open', 'rsvp_closed',
+            'op_running', 'confirmations_open', 'completed',
+        ])
+    })
+})
+
+describe('stageIndex', () => {
+    test('locates a stage', () => {
+        expect(stageIndex('preparing')).toBe(0)
+        expect(stageIndex('completed')).toBe(5)
+    })
+
+    test('treats null and anything unrecognised as preparing', () => {
+        expect(stageIndex(null)).toBe(0)
+        expect(stageIndex('nonsense' as never)).toBe(0)
+    })
+})
+
+describe('nextStage', () => {
+    test('advances one step', () => {
+        expect(nextStage('preparing')).toBe('rsvp_open')
+        expect(nextStage('op_running')).toBe('confirmations_open')
+    })
+
+    test('null at the end, so the button can disable itself', () => {
+        expect(nextStage('completed')).toBeNull()
+    })
+})
+
+describe('stageLabel', () => {
+    test('renders human labels', () => {
+        expect(stageLabel('rsvp_open')).toBe('RSVP Open')
+        expect(stageLabel('op_running')).toBe('Op Running')
+        expect(stageLabel(null)).toBe('Preparing')
+    })
+})
+
+describe('stageProgress', () => {
+    test('is a 1-based count for the six-segment bar', () => {
+        expect(stageProgress('preparing')).toBe(1)
+        expect(stageProgress('completed')).toBe(6)
+    })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd apps/web && npx vitest run lib/operations/stage.test.ts`
+Expected: FAIL — cannot resolve `./stage`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/web/lib/operations/stage.ts`:
+
+```ts
+import type { AttendanceStage } from './schedule'
+
+export const STAGE_ORDER = [
+    'preparing', 'rsvp_open', 'rsvp_closed',
+    'op_running', 'confirmations_open', 'completed',
+] as const satisfies readonly AttendanceStage[]
+
+const LABELS: Record<AttendanceStage, string> = {
+    preparing: 'Preparing',
+    rsvp_open: 'RSVP Open',
+    rsvp_closed: 'RSVP Closed',
+    op_running: 'Op Running',
+    confirmations_open: 'Confirmations Open',
+    completed: 'Completed',
+}
+
+/** Unrecognised and missing stages both read as the start of the lifecycle. */
+export function stageIndex(stage: AttendanceStage | null): number {
+    const i = STAGE_ORDER.indexOf(stage as never)
+    return i === -1 ? 0 : i
+}
+
+export function nextStage(stage: AttendanceStage | null): AttendanceStage | null {
+    const i = stageIndex(stage)
+    return i >= STAGE_ORDER.length - 1 ? null : STAGE_ORDER[i + 1]
+}
+
+export function stageLabel(stage: AttendanceStage | null): string {
+    return LABELS[stage as AttendanceStage] ?? LABELS.preparing
+}
+
+/** 1-based, for the deck's six-segment progress bar. */
+export function stageProgress(stage: AttendanceStage | null): number {
+    return stageIndex(stage) + 1
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run lib/operations/stage.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/operations/stage.ts apps/web/lib/operations/stage.test.ts
+git commit -m "feat(operations): extract attendance stage progression to lib
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Document statistics
+
+**Files:**
+- Create: `apps/web/lib/operations/doc-stats.ts`
+- Test: `apps/web/lib/operations/doc-stats.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `interface DocStats { words: number; sections: number }`, `docStats(doc: unknown): DocStats`.
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/lib/operations/doc-stats.test.ts`:
+
+```ts
+/**
+ * Feeds the status bar's "1,240 words · 6 sections". Takes a plain
+ * ProseMirror JSON document so it never needs a live editor to test.
+ */
+import { describe, test, expect } from 'vitest'
+import { docStats } from './doc-stats'
+
+const doc = {
+    type: 'doc',
+    content: [
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Situation' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Enemy forces hold the compound.' }] },
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Mission' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Seize and hold.' }] },
+    ],
+}
+
+describe('docStats', () => {
+    test('counts words across every text node, headings included', () => {
+        // Situation(1) + 5 + Mission(1) + 3
+        expect(docStats(doc).words).toBe(10)
+    })
+
+    test('counts headings as sections', () => {
+        expect(docStats(doc).sections).toBe(2)
+    })
+
+    test('collapses runs of whitespace rather than counting empties', () => {
+        const d = { type: 'doc', content: [
+            { type: 'paragraph', content: [{ type: 'text', text: '  spaced   out  ' }] },
+        ] }
+        expect(docStats(d).words).toBe(2)
+    })
+
+    test('returns zeroes for null, so the status bar renders before the doc loads', () => {
+        expect(docStats(null)).toEqual({ words: 0, sections: 0 })
+        expect(docStats(undefined)).toEqual({ words: 0, sections: 0 })
+    })
+
+    test('walks nested content such as lists and blockquotes', () => {
+        const d = { type: 'doc', content: [
+            { type: 'bulletList', content: [
+                { type: 'listItem', content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'one two three' }] },
+                ] },
+            ] },
+        ] }
+        expect(docStats(d).words).toBe(3)
+    })
+})
+```
+
+- [ ] **Step 2: Run it to make sure it fails**
+
+Run: `cd apps/web && npx vitest run lib/operations/doc-stats.test.ts`
+Expected: FAIL — cannot resolve `./doc-stats`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/web/lib/operations/doc-stats.ts`:
+
+```ts
+export interface DocStats {
+    words: number
+    sections: number
+}
+
+interface PmNode {
+    type?: string
+    text?: string
+    content?: PmNode[]
+}
+
+/**
+ * Word and section counts over a ProseMirror JSON document.
+ *
+ * Deliberately takes plain JSON rather than a TipTap Editor: the status bar
+ * gets its document from the Y.Doc, and keeping this free of editor types is
+ * what lets it be unit tested under the node-environment vitest runner.
+ */
+export function docStats(doc: unknown): DocStats {
+    let words = 0
+    let sections = 0
+
+    const walk = (node: PmNode | null | undefined): void => {
+        if (!node || typeof node !== 'object') return
+        if (node.type === 'heading') sections++
+        if (typeof node.text === 'string') {
+            const trimmed = node.text.trim()
+            if (trimmed) words += trimmed.split(/\s+/).length
+        }
+        node.content?.forEach(walk)
+    }
+
+    walk(doc as PmNode)
+    return { words, sections }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/web && npx vitest run lib/operations/doc-stats.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/lib/operations/doc-stats.ts apps/web/lib/operations/doc-stats.test.ts
+git commit -m "feat(operations): count words and sections from a ProseMirror doc
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Repoint OperationStatusBar at the shared logic
+
+**Files:**
+- Modify: `apps/web/components/operations/OperationStatusBar.tsx:1-90`
+
+**Interfaces:**
+- Consumes: `fmtCountdown`, `rsvpCloseAt`, `LiveStatus`, `AttendanceStage` from `@/lib/operations/schedule`.
+- Produces: nothing new. This task is proof the extraction is faithful.
+
+- [ ] **Step 1: Replace the local definitions**
+
+Delete the local `interface LiveStatus` (lines 5-14) and the local `fmtCountdown` (lines 26-36). Import both from `@/lib/operations/schedule`. Replace the inline close-date maths:
+
+```ts
+// was: const rsvpCloseDate = opDate ? new Date(opDate.getTime() - rsvpCloseOffsetMins * 60000) : null
+const rsvpCloseDate = rsvpCloseAt(opDate, rsvpCloseOffsetMins)
+```
+
+Leave every rendering decision, label and colour in this component untouched — this is a swap of computation, not of output.
+
+- [ ] **Step 2: Typecheck and lint**
+
+Run: `cd apps/web && npx tsc --noEmit && npm run lint`
+Expected: clean.
+
+- [ ] **Step 3: Verify the public page still renders the same bar**
+
+Load `/operations/<any id>` in dev and confirm the status bar shows the same items with the same countdowns. Visual check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/components/operations/OperationStatusBar.tsx
+git commit -m "refactor(operations): read schedule logic from lib in the status bar
+
+Proves the extraction is faithful before anything new consumes it.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: The editor hooks
+
+**Files:**
+- Create: `apps/web/app/operations/[id]/edit/hooks/useOperationStatus.ts`
+- Create: `apps/web/app/operations/[id]/edit/hooks/useDocStats.ts`
+- Create: `apps/web/app/operations/[id]/edit/hooks/useOperationMeta.ts`
+- Create: `apps/web/app/operations/[id]/edit/hooks/usePresence.ts`
+
+**Interfaces:**
+- Consumes: `LiveStatus`, `TimelineMoment`, `buildTimeline` from `@/lib/operations/schedule`; `docStats`, `DocStats` from `@/lib/operations/doc-stats`.
+- Produces:
+  - `useOperationStatus(operationId: string): { status: LiveStatus | null; timeline: TimelineMoment[]; now: Date; daysUntil: number | null; refresh: () => void }`
+  - `useDocStats(ydoc: Y.Doc | null, activePage: string): DocStats`
+  - `useOperationMeta(operationId: string, initial: MetaFields): { meta: MetaFields; setField: (k: keyof MetaFields, v: string) => void; saveStatus: 'saved' | 'saving' | 'unsaved'; savedAt: Date | null }`
+  - `usePresence(provider: HocuspocusProvider | null): number` — the count of connected editors, from Y.js awareness.
+
+- [ ] **Step 1: Write the hook**
+
+```ts
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { buildTimeline, type LiveStatus, type TimelineMoment } from '@/lib/operations/schedule'
+
+/**
+ * Polls the same endpoint the public status bar uses, on the same 30s cadence,
+ * and ticks a 1s clock so countdowns move without another network call.
+ */
+export function useOperationStatus(operationId: string): {
+    status: LiveStatus | null
+    timeline: TimelineMoment[]
+    now: Date
+    daysUntil: number | null
+    refresh: () => void
+} {
+    const [status, setStatus] = useState<LiveStatus | null>(null)
+    const [now, setNow] = useState(() => new Date())
+
+    const refresh = useCallback(() => {
+        if (!operationId) return
+        fetch(`/api/operations/${operationId}/live-status`)
+            .then(res => res.json())
+            .then(setStatus)
+            .catch(() => {})
+    }, [operationId])
+
+    useEffect(() => {
+        refresh()
+        const id = setInterval(refresh, 30_000)
+        return () => clearInterval(id)
+    }, [refresh])
+
+    useEffect(() => {
+        const id = setInterval(() => setNow(new Date()), 1_000)
+        return () => clearInterval(id)
+    }, [])
+
+    const timeline = status ? buildTimeline(status, now) : []
+
+    const opDate = status?.operationDate ? new Date(status.operationDate) : null
+    const daysUntil = opDate
+        ? Math.max(0, Math.ceil((opDate.getTime() - now.getTime()) / 86_400_000))
+        : null
+
+    return { status, timeline, now, daysUntil, refresh }
+}
+```
+
+- [ ] **Step 2: Write the doc-stats hook**
+
+`useDocStats.ts` — reads the ProseMirror JSON out of the Y.Doc so it needs no
+editor instance, and recomputes only when the document actually changes:
+
+```ts
+'use client'
+
+import { useEffect, useState } from 'react'
+import type * as Y from 'yjs'
+import { docStats, type DocStats } from '@/lib/operations/doc-stats'
+
+export function useDocStats(ydoc: Y.Doc | null, activePage: string): DocStats {
+    const [stats, setStats] = useState<DocStats>({ words: 0, sections: 0 })
+
+    useEffect(() => {
+        if (!ydoc) return
+        const frag = ydoc.getXmlFragment(activePage)
+
+        const recompute = () => {
+            // toJSON() on the fragment yields the ProseMirror-shaped tree.
+            try { setStats(docStats(JSON.parse(JSON.stringify(frag.toJSON())))) }
+            catch { setStats({ words: 0, sections: 0 }) }
+        }
+
+        recompute()
+        frag.observeDeep(recompute)
+        return () => frag.unobserveDeep(recompute)
+    }, [ydoc, activePage])
+
+    return stats
+}
+```
+
+- [ ] **Step 3: Write the meta hook**
+
+`useOperationMeta.ts` — lifts the debounced save at `page.tsx:360-373` out of the
+component unchanged in behaviour, and additionally records *when* the save
+landed so the status bar can show it:
+
+```ts
+'use client'
+
+import { useRef, useState } from 'react'
+
+export interface MetaFields {
+    title: string
+    department: string
+    date: string
+    loreDate: string
+}
+
+export function useOperationMeta(operationId: string, initial: MetaFields) {
+    const [meta, setMeta] = useState<MetaFields>(initial)
+    const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'unsaved'>('saved')
+    const [savedAt, setSavedAt] = useState<Date | null>(null)
+    const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+    function setField(key: keyof MetaFields, value: string) {
+        setMeta(m => ({ ...m, [key]: value }))
+        setSaveStatus('unsaved')
+        clearTimeout(timer.current)
+        timer.current = setTimeout(async () => {
+            setSaveStatus('saving')
+            const qs = `${key}=${encodeURIComponent(value)}`
+            try {
+                await fetch(`/api/operations/update?id=${operationId}&${qs}`)
+                setSaveStatus('saved')
+                setSavedAt(new Date())
+            } catch {
+                setSaveStatus('unsaved')
+            }
+        }, 1000)
+    }
+
+    return { meta, setField, saveStatus, savedAt }
+}
+```
+
+- [ ] **Step 4: Write the presence hook**
+
+`usePresence.ts` — the status bar's "n editing" comes from the awareness
+protocol `CollabEditor` already maintains for its collaborative cursors, so
+this reads it rather than opening a second channel:
+
+```ts
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { HocuspocusProvider } from '@hocuspocus/provider'
+
+export function usePresence(provider: HocuspocusProvider | null): number {
+    const [count, setCount] = useState(0)
+
+    useEffect(() => {
+        if (!provider) return
+        const awareness = provider.awareness
+        if (!awareness) return
+
+        const update = () => setCount(awareness.getStates().size)
+        update()
+        awareness.on('change', update)
+        return () => awareness.off('change', update)
+    }, [provider])
+
+    return count
+}
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "apps/web/app/operations/[id]/edit/hooks/"
+git commit -m "feat(operations): add the editor hooks for status, stats, meta and presence
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: The shell layout, header and status bar
+
+**Files:**
+- Create: `apps/web/app/operations/[id]/edit/shell.module.css`
+- Create: `apps/web/app/operations/[id]/edit/Header.tsx`
+- Create: `apps/web/app/operations/[id]/edit/StatusBar.tsx`
+- Create: `apps/web/app/operations/[id]/edit/EditorShell.tsx`
+- Modify: `apps/web/app/operations/[id]/edit/page.tsx`
+
+**Interfaces:**
+- Consumes: `useOperationStatus` (Task 6), `rgbTriplet` (Task 1), `docStats` (Task 4).
+- Produces:
+  - `type EditorTab = 'brief' | 'map' | 'development' | 'attendance'`
+  - `<EditorShell operationId themeColor isHQ tab onTabChange header deck statusBar>{children}</EditorShell>`
+  - `<Header …>` and `<StatusBar …>` as below.
+
+- [ ] **Step 1: Create the shell stylesheet**
+
+`shell.module.css` — grid regions only; all colour via tokens:
+
+```css
+.shell {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    overflow: hidden;
+}
+.body { display: flex; flex: 1; min-height: 0; }
+.main { flex: 1; min-width: 0; display: flex; flex-direction: column; position: relative; }
+.deck { width: 340px; flex-shrink: 0; border-left: 1px solid var(--line); overflow-y: auto; }
+.deckCollapsed { width: 44px; }
+
+@media (max-width: 1279px) { .deck { position: absolute; right: 0; top: 0; bottom: 0; z-index: 20; } }
+@media (max-width: 1023px) { .deck { width: 300px; } }
+```
+
+- [ ] **Step 2: Write the tab state with URL mirroring**
+
+In `EditorShell.tsx`. **Tabs must not use the Next router** — see spec §7: `next/link` navigation on the milpac page committed on the first click only 11 times in 18, and a full document load would tear down the Hocuspocus socket and rebuild the Y.Doc.
+
+```tsx
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+
+export type EditorTab = 'brief' | 'map' | 'development' | 'attendance'
+
+const TABS: readonly EditorTab[] = ['brief', 'map', 'development', 'attendance']
+
+function tabFromLocation(): EditorTab {
+    if (typeof window === 'undefined') return 'brief'
+    const t = new URLSearchParams(window.location.search).get('tab')
+    return (TABS as readonly string[]).includes(t ?? '') ? (t as EditorTab) : 'brief'
+}
+
+export function useEditorTab(): [EditorTab, (t: EditorTab) => void] {
+    const [tab, setTab] = useState<EditorTab>('brief')
+
+    // Read the deep link after mount — the server render has no location.
+    useEffect(() => { setTab(tabFromLocation()) }, [])
+
+    const change = (next: EditorTab) => {
+        setTab(next)
+        const url = new URL(window.location.href)
+        url.searchParams.set('tab', next)
+        // replaceState, not router.push: no navigation, so the collab socket lives.
+        window.history.replaceState(null, '', url)
+    }
+
+    return [tab, change]
+}
+```
+
+- [ ] **Step 3: Write the status bar**
+
+`StatusBar.tsx` — document and session state only. It must not repeat the deck's mission facts (spec §5).
+
+```tsx
+'use client'
+
+interface Props {
+    connected: boolean
+    activeDocTitle: string
+    words: number
+    sections: number
+    savedAt: Date | null
+    editorCount: number
+    department: string
+}
+
+export default function StatusBar({
+    connected, activeDocTitle, words, sections, savedAt, editorCount, department,
+}: Props) {
+    const cell: React.CSSProperties = {
+        display: 'flex', alignItems: 'center', gap: 9,
+        padding: '0 16px', height: '100%',
+        borderRight: '1px solid var(--line)',
+        color: 'var(--ink-2)',
+    }
+    return (
+        <div style={{
+            display: 'flex', alignItems: 'center', height: 32, flexShrink: 0,
+            borderTop: '1px solid var(--line)',
+            background: 'linear-gradient(180deg, var(--s1), var(--bg))',
+            fontFamily: 'var(--mono)', fontSize: 10,
+            letterSpacing: '0.12em', textTransform: 'uppercase',
+        }}>
+            <div style={{ ...cell, color: connected ? 'var(--good)' : 'var(--crit)' }}>
+                <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'currentColor' }} />
+                {connected ? 'Live' : 'Offline'}
+            </div>
+            <div style={cell}><span style={{ color: 'var(--ink-3)' }}>Doc</span> {activeDocTitle}</div>
+            <div style={cell}>{words.toLocaleString()} words</div>
+            <div style={cell}>{sections} sections</div>
+            <div style={{ ...cell, color: 'var(--ink-3)' }}>
+                {savedAt ? `Saved ${savedAt.toLocaleTimeString('en-AU', { hour: '2-digit', minute: '2-digit', hour12: false })}` : 'Not saved'}
+            </div>
+            <div style={{ flexGrow: 1 }} />
+            <div style={{ ...cell, borderRight: 'none', borderLeft: '1px solid var(--line)' }}>
+                {editorCount} editing
+            </div>
+            <div style={{ ...cell, borderRight: 'none', borderLeft: '1px solid var(--line)', color: 'var(--ink-3)' }}>
+                {department}
+            </div>
+        </div>
+    )
+}
+```
+
+- [ ] **Step 4: Mount the shell around the existing page**
+
+In `page.tsx`, wrap the current content in `<EditorShell>` with the new `Header` and `StatusBar`, passing `className="command"` on the shell root so the tokens resolve, and `style={{ ['--acc' as string]: themeColor, ['--acc-rgb' as string]: rgbTriplet(themeColor) }}`.
+
+**Leave all five existing panels rendering, unchanged, inside the Brief tab's scroll area.** They are removed one at a time in Tasks 8–12. The page must work at the end of this task.
+
+- [ ] **Step 5: Typecheck, lint, and load the page**
+
+Run: `cd apps/web && npx tsc --noEmit && npm run lint`
+Expected: clean. Then load `/operations/<id>/edit` in dev: header, status bar and the old panels all present; editing and saving still work.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "apps/web/app/operations/[id]/edit/"
+git commit -m "feat(operations): add the editor shell, header and status bar
+
+Tabs are client state with the URL mirrored via replaceState — routing them
+would reload the document and tear down the Hocuspocus socket (spec §7).
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Deck container and countdown strip
+
+**Files:**
+- Create: `apps/web/app/operations/[id]/edit/deck/MissionDeck.tsx`
+- Create: `apps/web/app/operations/[id]/edit/deck/CountdownStrip.tsx`
+- Create: `apps/web/app/operations/[id]/edit/deck/Panel.tsx`
+
+**Interfaces:**
+- Consumes: `useOperationStatus` (Task 6).
+- Produces:
+  - `<Panel title tag>{children}</Panel>` — the 36px-accent-tick panel used by every deck card and by later tasks.
+  - `<CountdownStrip daysUntil checksDone checksTotal />`
+  - `<MissionDeck operationId isHQ collapsed onToggleCollapsed>{cards}</MissionDeck>`
+
+- [ ] **Step 1: Write the shared panel primitive**
+
+```tsx
+interface PanelProps {
+    title: string
+    tag?: string
+    children: React.ReactNode
+}
+
+/** The milpac panel: hairline box, 36px accent tick on the top-left corner. */
+export default function Panel({ title, tag, children }: PanelProps) {
+    return (
+        <div style={{
+            position: 'relative',
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r)',
+            background: 'linear-gradient(180deg, var(--s1) 0%, var(--bg) 100%)',
+        }}>
+            <div style={{
+                position: 'absolute', top: 0, left: 0,
+                width: 36, height: 2, background: 'var(--acc)', opacity: 0.75,
+            }} />
+            <div style={{
+                display: 'flex', alignItems: 'center', gap: 12,
+                padding: '14px 18px', borderBottom: '1px solid var(--line)',
+            }}>
+                <span style={{
+                    fontSize: 11, letterSpacing: '0.22em', textTransform: 'uppercase',
+                    fontWeight: 700, color: 'var(--ink)',
+                }}>{title}</span>
+                {tag && (
+                    <span style={{
+                        marginLeft: 'auto', fontFamily: 'var(--mono)',
+                        fontSize: 9.5, color: 'var(--ink-3)', letterSpacing: '0.12em',
+                    }}>{tag}</span>
+                )}
+            </div>
+            <div>{children}</div>
+        </div>
+    )
+}
+```
+
+- [ ] **Step 2: Write the countdown strip**
+
+```tsx
+interface StripProps {
+    daysUntil: number | null
+    checksDone: number
+    checksTotal: number
+}
+
+function Cell({ value, unit, label, tone }: {
+    value: string; unit?: string; label: string; tone: string
+}) {
+    return (
+        <div style={{ padding: '16px 18px', borderRight: '1px solid var(--line)' }}>
+            <div style={{ fontFamily: 'var(--mono)', fontSize: 26, fontWeight: 600, lineHeight: 1.1, color: tone }}>
+                {value}
+                {unit && <small style={{ fontSize: '0.5em', color: 'var(--ink-3)', marginLeft: 3, letterSpacing: '0.1em' }}>{unit}</small>}
+            </div>
+            <div style={{ marginTop: 5, fontSize: 9.5, letterSpacing: '0.22em', textTransform: 'uppercase', color: 'var(--ink-3)', fontWeight: 600 }}>
+                {label}
+            </div>
+        </div>
+    )
+}
+
+export default function CountdownStrip({ daysUntil, checksDone, checksTotal }: StripProps) {
+    const allDone = checksTotal > 0 && checksDone === checksTotal
+    return (
+        <div style={{
+            display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)',
+            borderBottom: '1px solid var(--line)',
+            background: 'linear-gradient(180deg, var(--s1), var(--bg))',
+            flexShrink: 0,
+        }}>
+            <Cell
+                value={daysUntil === null ? '—' : String(daysUntil)}
+                unit={daysUntil === null ? undefined : 'DAYS'}
+                label="Until Op"
+                tone="var(--acc)"
+            />
+            <Cell
+                value={String(checksDone)}
+                unit={`/${checksTotal}`}
+                label="Dev Checks"
+                tone={allDone ? 'var(--good)' : 'var(--warn)'}
+            />
+        </div>
+    )
+}
+```
+
+- [ ] **Step 3: Write the deck container**
+
+```tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'asot.opsdeck.collapsed'
+
+export default function MissionDeck({ strip, children }: {
+    strip: React.ReactNode
+    children: React.ReactNode
+}) {
+    const [collapsed, setCollapsed] = useState(false)
+
+    useEffect(() => {
+        setCollapsed(window.localStorage.getItem(STORAGE_KEY) === '1')
+    }, [])
+
+    function toggle() {
+        setCollapsed(c => {
+            window.localStorage.setItem(STORAGE_KEY, c ? '0' : '1')
+            return !c
+        })
+    }
+
+    if (collapsed) {
+        return (
+            <aside style={{ width: 44, flexShrink: 0, borderLeft: '1px solid var(--line)', background: 'var(--bg)' }}>
+                <button
+                    type="button" onClick={toggle} aria-label="Expand mission deck"
+                    style={{ width: 44, height: 44, background: 'none', border: 'none', color: 'var(--ink-3)', cursor: 'pointer' }}
+                >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <path d="M15 18l-6-6 6-6" />
+                    </svg>
+                </button>
+            </aside>
+        )
+    }
+
+    return (
+        <aside style={{
+            width: 340, flexShrink: 0,
+            borderLeft: '1px solid var(--line)',
+            background: 'var(--bg)',
+            display: 'flex', flexDirection: 'column',
+            overflowY: 'auto',
+        }}>
+            {strip}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16, padding: 16 }}>
+                {children}
+            </div>
+        </aside>
+    )
+}
+```
+
+- [ ] **Step 4: Mount the deck in the shell with only the countdown strip**
+
+The deck appears; the old panels remain below the editor. Page still works.
+
+- [ ] **Step 5: Typecheck, lint, load**
+
+Run: `cd apps/web && npx tsc --noEmit && npm run lint`
+Expected: clean, and the deck renders with a live countdown.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "apps/web/app/operations/[id]/edit/deck/"
+git commit -m "feat(operations): add the mission deck and its countdown strip
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Schedule card — the timeline
+
+**Files:**
+- Create: `apps/web/app/operations/[id]/edit/deck/ScheduleCard.tsx`
+- Modify: `apps/web/app/operations/[id]/edit/page.tsx` — delete the Schedule & Automation panel
+
+**Interfaces:**
+- Consumes: `TimelineMoment` and `buildTimeline` (Task 2), `Panel` (Task 8).
+- Produces: `<ScheduleCard timeline onChangeDate onChangeRsvpMode onChangeCloseOffset />`.
+
+- [ ] **Step 1: Render the timeline**
+
+Rows stack their label, detail and control rather than laying them across — the
+deck is 340px wide, which is not enough for a three-column row (spec §4).
+
+```tsx
+'use client'
+
+import Panel from './Panel'
+import type { TimelineMoment } from '@/lib/operations/schedule'
+
+interface Props {
+    timeline: TimelineMoment[]
+    onChangeDate: () => void
+    onChangeRsvpMode: () => void
+    onChangeCloseOffset: (mins: number) => void
+}
+
+const CLOSE_OFFSETS = [30, 60, 90, 120, 180]
+
+export default function ScheduleCard({
+    timeline, onChangeDate, onChangeRsvpMode, onChangeCloseOffset,
+}: Props) {
+    return (
+        <Panel title="Timeline">
+            <div style={{ padding: '20px 16px 16px' }}>
+                <div style={{ position: 'relative', paddingLeft: 24 }}>
+                    <div style={{
+                        position: 'absolute', left: 4, top: 8, bottom: 8,
+                        width: 1, background: 'var(--line-2)',
+                    }} />
+
+                    {timeline.map((m, i) => (
+                        <div key={m.id} style={{ position: 'relative', paddingBottom: i === timeline.length - 1 ? 0 : 20 }}>
+                            <div style={{
+                                position: 'absolute', left: -24, top: 4,
+                                width: 9, height: 9, borderRadius: '50%',
+                                background: 'var(--bg)',
+                                border: `2px solid ${m.state === 'current' ? 'var(--acc)' : 'var(--line-2)'}`,
+                                boxShadow: m.state === 'current' ? '0 0 0 4px rgba(var(--acc-rgb), 0.12)' : undefined,
+                            }} />
+
+                            <div style={{
+                                fontSize: 13.5, fontWeight: 600,
+                                color: m.state === 'pending' ? 'var(--ink-2)' : 'var(--ink)',
+                            }}>
+                                {m.label}
+                            </div>
+
+                            <div style={{
+                                fontFamily: 'var(--mono)', fontSize: 12,
+                                color: m.state === 'current' ? 'var(--acc)' : 'var(--ink-3)',
+                                marginTop: 3,
+                            }}>
+                                {m.detail}
+                            </div>
+
+                            {m.id === 'rsvp_opens' && (
+                                <button type="button" onClick={onChangeRsvpMode} style={controlStyle}>
+                                    {m.at ? 'Switch to manual' : 'Schedule it'}
+                                </button>
+                            )}
+
+                            {m.id === 'rsvp_closes' && (
+                                <select
+                                    onChange={e => onChangeCloseOffset(Number(e.target.value))}
+                                    style={{ ...controlStyle, appearance: 'none' }}
+                                >
+                                    {CLOSE_OFFSETS.map(o => (
+                                        <option key={o} value={o}>{o} min before</option>
+                                    ))}
+                                </select>
+                            )}
+
+                            {m.id === 'op_starts' && (
+                                <button type="button" onClick={onChangeDate} style={controlStyle}>
+                                    Change date
+                                </button>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </Panel>
+    )
+}
+
+const controlStyle: React.CSSProperties = {
+    display: 'inline-flex', alignItems: 'center', gap: 7,
+    marginTop: 8,
+    border: '1px solid var(--line-2)', background: 'var(--s2)',
+    borderRadius: 'var(--r)', padding: '6px 11px',
+    fontFamily: 'var(--mono)', fontSize: 9.5,
+    letterSpacing: '0.14em', textTransform: 'uppercase',
+    color: 'var(--ink-2)', cursor: 'pointer',
+}
+```
+
+`confirmations_open` and `completed` are derived from the stage and carry no
+control — do not add one.
+
+- [ ] **Step 2: Delete the old Schedule & Automation panel**
+
+Remove the panel block from `page.tsx` **and** its now-unused state: `scheduleOpen`, `draftRsvpCloseOffsetMins`, `draftRsvpCloseMode`, and the schedule half of `scheduleSave`. Keep the save endpoint calls — they move into the card's handlers.
+
+- [ ] **Step 3: Typecheck, lint, and verify the round trip**
+
+Run: `cd apps/web && npx tsc --noEmit && npm run lint`
+Expected: clean. Then in dev: change the operation date in the deck, reload, and confirm it persisted; confirm the timeline's computed RSVP close time moved with it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/web/app/operations/[id]/edit/"
+git commit -m "feat(operations): replace Schedule & Automation with the deck timeline
+
+The panel stated each moment twice — a form on the left, a status column
+restating it as a countdown on the right. One timeline says it once.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Stage card
+
+**Files:**
+- Create: `apps/web/app/operations/[id]/edit/deck/StageCard.tsx`
+
+**Interfaces:**
+- Consumes: `stageLabel`, `stageProgress`, `nextStage`, `STAGE_ORDER` (Task 3), `Panel` (Task 8).
+- Produces: `<StageCard stage onAdvance advancing />`.
+
+- [ ] **Step 1: Render the bar and the control**
+
+```tsx
+'use client'
+
+import Panel from './Panel'
+import { STAGE_ORDER, stageLabel, stageProgress, nextStage } from '@/lib/operations/stage'
+import type { AttendanceStage } from '@/lib/operations/schedule'
+
+interface Props {
+    stage: AttendanceStage | null
+    onAdvance: (to: AttendanceStage) => void
+    advancing: boolean
+}
+
+export default function StageCard({ stage, onAdvance, advancing }: Props) {
+    const filled = stageProgress(stage)
+    const next = nextStage(stage)
+
+    return (
+        <Panel title="Stage" tag={`${filled} of ${STAGE_ORDER.length}`}>
+            <div style={{ padding: 16 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 12 }}>
+                    {STAGE_ORDER.map((s, i) => (
+                        <span key={s} style={{
+                            flex: '1 1 0', height: 3, borderRadius: 2,
+                            background: i < filled ? 'var(--acc)' : 'var(--line)',
+                        }} />
+                    ))}
+                </div>
+
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                    <span style={{
+                        fontFamily: 'var(--mono)', fontSize: 12,
+                        letterSpacing: '0.14em', textTransform: 'uppercase',
+                        color: 'var(--acc)',
+                    }}>
+                        {stageLabel(stage)}
+                    </span>
+
+                    <button
+                        type="button"
+                        disabled={!next || advancing}
+                        onClick={() => next && onAdvance(next)}
+                        style={{
+                            border: '1px solid var(--line-2)', background: 'var(--s2)',
+                            borderRadius: 'var(--r)', padding: '6px 11px',
+                            fontFamily: 'var(--mono)', fontSize: 9.5,
+                            letterSpacing: '0.14em', textTransform: 'uppercase',
+                            color: next ? 'var(--ink-2)' : 'var(--ink-3)',
+                            cursor: next ? 'pointer' : 'default',
+                            opacity: next ? 1 : 0.5,
+                        }}
+                    >
+                        {advancing ? 'Advancing…' : next ? `Advance to ${stageLabel(next)}` : 'Complete'}
+                    </button>
+                </div>
+            </div>
+        </Panel>
+    )
+}
+```
+
+- [ ] **Step 2: Wire Advance to the existing endpoint**
+
+`POST /api/operations/${operationId}/attendance` with the new stage, then call `refresh()` from `useOperationStatus` so the deck and timeline both update. Do not add a new endpoint.
+
+- [ ] **Step 3: Typecheck, lint, verify**
+
+Run: `cd apps/web && npx tsc --noEmit && npm run lint`
+Expected: clean. In dev, advance a test operation one stage and confirm both the bar and the timeline's `current` marker move.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/web/app/operations/[id]/edit/deck/StageCard.tsx"
+git commit -m "feat(operations): add the stage card, replacing the six-step stepper
+
+The cron drives these transitions; the manual control is an override, so it
+is one button rather than a labelled stepper.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Attendance and details cards
+
+**Files:**
+- Create: `apps/web/app/operations/[id]/edit/deck/AttendanceCard.tsx`
+- Create: `apps/web/app/operations/[id]/edit/deck/DetailsCard.tsx`
+- Modify: `apps/web/app/operations/[id]/edit/page.tsx` — delete the Operation Details panel
+
+**Interfaces:**
+- Consumes: `Panel` (Task 8).
+- Produces: `<AttendanceCard platoons selected onToggle pingEnabled onTogglePing />`, `<DetailsCard owner department billetPoints themeColor mapWorld onChange />`.
+
+- [ ] **Step 1: Write the attendance card**
+
+Platoon chips in the milpac `chip` idiom, selected chips bordered `rgba(var(--acc-rgb), 0.42)` with an `var(--acc)` dot. A `+ Custom unit` chip opens the existing custom-units editor inline. Then one labelled toggle row for the Discord ping.
+
+**Gate on `isHQ` by not rendering the card at all** — not by disabling it (spec §1).
+
+- [ ] **Step 2: Write the details card**
+
+`rw`/`rwK`/`rwV` rows: owner (with the existing picker), department, billet points, theme colour, map world. Reuse the existing `MapWorldPicker` from `page.tsx` by extracting it to its own file rather than duplicating it.
+
+- [ ] **Step 3: Delete the Operation Details panel from `page.tsx`**
+
+- [ ] **Step 4: Typecheck, lint, verify**
+
+Run: `cd apps/web && npx tsc --noEmit && npm run lint`
+Expected: clean. In dev, confirm as a non-HQ user that the attendance card is absent from the DOM, and that title/department/theme edits still save.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/app/operations/[id]/edit/"
+git commit -m "feat(operations): move details and attendance into the deck
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Tabs
+
+**Files:**
+- Create: `apps/web/app/operations/[id]/edit/tabs/BriefTab.tsx`
+- Create: `apps/web/app/operations/[id]/edit/tabs/MapTab.tsx`
+- Create: `apps/web/app/operations/[id]/edit/tabs/DevelopmentTab.tsx`
+- Create: `apps/web/app/operations/[id]/edit/tabs/AttendanceTab.tsx`
+- Modify: `apps/web/app/operations/[id]/edit/page.tsx` — delete the Mission Development and Custom Units panels
+
+**Interfaces:**
+- Consumes: `useEditorTab` (Task 7); `CollabEditor` (`documentId`, `themeColor`, `initialContent`, `metaHandleRef`, `onSaveStatusChange`, `allowedTypes`); `MapSection` (`operationId`, `canEdit`, `world`); `PageSidebar` (`ydoc`, `activePage`, `onSelectPage`, `themeColor`, `orientation`, `synced`, `allowedTypes`).
+- Produces: the four tab panels.
+
+- [ ] **Step 1: Split the four panels out**
+
+`BriefTab` holds the documents rail and `CollabEditor`. `MapTab` renders `MapSection` with `canEdit={isHQ}`. `DevelopmentTab` takes the Mission Development gate timeline and its completion modal from `page.tsx` verbatim. `AttendanceTab` takes who-attends, notifications and acknowledgements.
+
+- [ ] **Step 2: Keep Brief and Map mounted once visited**
+
+Render visited tabs with `display: none` rather than unmounting, so the Hocuspocus connection and the map's Y.js state survive a tab switch (spec §7). Development and Attendance may unmount freely — they hold no socket.
+
+- [ ] **Step 3: Delete the Mission Development and Custom Attendance Units panels from `page.tsx`**
+
+- [ ] **Step 4: Typecheck, lint, verify**
+
+Run: `cd apps/web && npx tsc --noEmit && npm run lint`
+Expected: clean. In dev: type in the editor, switch to Map and back, confirm the text is still there and the presence indicator never dropped. Confirm `?tab=map` deep-links, and that a non-HQ user has no Attendance tab in the DOM.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/app/operations/[id]/edit/"
+git commit -m "feat(operations): split the editor into Brief, Map, Development and Attendance tabs
+
+Brief and Map stay mounted once visited so the collab socket survives a
+switch.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Responsive behaviour and cleanup
+
+**Files:**
+- Modify: `apps/web/app/operations/[id]/edit/shell.module.css`
+- Modify: `apps/web/app/operations/[id]/edit/page.tsx`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: a `page.tsx` under ~200 lines.
+
+- [ ] **Step 1: Implement the four breakpoints from spec §8**
+
+≥1600px both rails open; 1280–1599px documents rail collapses to 44px icons; 1024–1279px deck collapses to a 44px rail expanding as an overlay; <1024px both become overlay drawers and the tab strip scrolls horizontally. The status bar drops cells from the left as width falls, keeping sync state and save time longest.
+
+- [ ] **Step 2: Delete the dead code**
+
+From `page.tsx`: the five panel blocks (now empty), every `[−]`/`[+]` toggle, the `VIEW →` and `MAP ↗` header links, the local `hexToRgb`, and the `sideBorders`/`bottomBorder`/`sectionToggleStyle` helpers added by commit `1032f5c2` — the elements they styled are gone. Move Delete Mission into the header overflow menu.
+
+- [ ] **Step 3: Confirm the file shrank**
+
+Run: `cd apps/web && wc -l "app/operations/[id]/edit/page.tsx"`
+Expected: under 200 lines (from 2,464).
+
+- [ ] **Step 4: Full check**
+
+Run: `cd apps/web && npx tsc --noEmit && npm run lint && npx vitest run`
+Expected: all clean, all unit tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/app/operations/[id]/edit/"
+git commit -m "feat(operations): add shell breakpoints and delete the old panel code
+
+page.tsx goes from 2,464 lines to under 200.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: Playwright specs (written, not run)
+
+**Files:**
+- Create: `apps/web/tests/operations-editor.spec.ts`
+
+**Interfaces:**
+- Consumes: `tests/fixtures/asot.ts`, `tests/constants.ts` — follow the existing suite's fixture pattern.
+
+- [ ] **Step 1: Write the specs**
+
+Cover: switching Brief → Map → Brief preserves typed content and the connection indicator stays `Live`; the deck collapse state survives a reload; editing the operation date in the timeline persists; a non-HQ user sees no Attendance tab.
+
+- [ ] **Step 2: Typecheck only**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: clean.
+
+**Do not run `npm run test:e2e`.** Running Playwright is Koda's call — ask first.
+
+**Known deviation from spec §11.** The spec asks for component-level tests
+asserting the permission gates (Attendance absent, not disabled, for a non-HQ
+user; Publish only for HQ on an `In Development` operation). This plan covers
+those with Playwright specs and a manual dev check instead, because
+`vitest.config.ts` runs in the `node` environment and includes only
+`lib/**/*.test.ts` — a deliberate choice, documented in that file, that keeps
+the two runners from picking up each other's files. Real component tests would
+need a second vitest project plus `jsdom` and `@testing-library/react` as new
+devDependencies. That is a dependency decision for Koda, not one to make
+silently inside this plan. If wanted, it becomes Task 15 and the permission
+assertions move there.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/tests/operations-editor.spec.ts
+git commit -m "test(operations): add editor shell e2e specs
+
+Not run here — Playwright execution is Koda's call.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md
@@ -116,6 +116,13 @@ tabs.
 **Preview** is a floating button at the editor's bottom-right, opening the
 existing drawer. It is not a tab and not a header button.
 
+The drawer frames its iframe rather than letting it sit flush: a 10px gutter of
+`--bg`, a `--line` hairline and a soft shadow, with the active theme's name in
+the drawer header. The previewed page then reads as a document under
+inspection instead of a panel of the editor that changed colour — which matters
+most for Dispatch (§10.1), a light page inside a dark tool, but is applied to
+all three themes rather than special-casing one.
+
 ### Why not tabs for everything
 
 The deck is the design's one real bet, so state the trade plainly: it costs
@@ -449,6 +456,10 @@ ruled left margin, and a signature block in place of a bare acknowledge button.
 paper design is the only one of the three that prints honestly rather than
 flooding a page with ink.
 
+The site navbar and footer stay dark under it. They do not currently vary by
+page, and making them do so is out of scope — a light document under dark site
+chrome is accepted as-is rather than being a reason to abandon the theme.
+
 **Tactical** (`scifi`, shown as "Tactical"). Also reimagined: the starfield
 wallpaper behind Courier is replaced by a console — cold blue-black ground, a
 fine technical grid, corner brackets instead of full panel borders, a tick rail
@@ -534,13 +545,26 @@ Sequencing, each step leaving both pages working:
    view without changing output.
 9. `modern/` — port today's `modern` branch onto the new structure, so the
    default theme is proven against the container before anything is redesigned.
-10. `dispatch/` and `tactical/`, each new work rather than a port.
-11. Delete the `isOF`/`isSF` ternaries and rename the editor's theme dropdown
-    labels to Modern / Dispatch / Tactical.
+10. Restyle `modern/` onto `styles/command.css`, and delete the `isOF`/`isSF`
+    ternaries. `oldfashioned` and `scifi` resolve to their existing markup,
+    lifted verbatim into `dispatch/` and `tactical/` folders as-is — moved, not
+    redesigned, so nothing regresses while they wait.
 
-Step 9 before step 10 matters: it separates "did the new architecture break the
-page" from "do we like the new designs", which are otherwise diagnosed
-together.
+### Phase 2 — the alternate themes
+
+**Modern is roughly 90% of operations; the other two are uncommon.** Building
+two full theme modules to new designs is therefore speculative work sitting in
+front of the shell that fixes the daily complaint. It ships as its own branch
+after this one:
+
+11. `dispatch/` rebuilt to the Dispatch design.
+12. `tactical/` rebuilt to the Tactical design.
+13. Rename the editor's theme dropdown labels to Modern / Dispatch / Tactical.
+
+Step 9 before step 10 matters, and step 10 before phase 2 matters more: they
+separate "did the new architecture break the page" from "do we like the new
+designs", which are otherwise diagnosed together. Splitting the phases also
+means the 165 ternaries die on schedule regardless of when the redesigns land.
 
 ---
 
@@ -556,14 +580,8 @@ together.
   panels (`OcapLinkPanel`, `OcapStatsPanel`, 568 and 520 lines) on the public
   view. Whether the editor's OCAP page should surface sync status is unresolved
   and deferred.
-- **Dispatch is a light theme inside a dark app.** The site chrome (navbar,
-  footer) is dark and does not currently vary by page. Whether Dispatch should
-  suppress or invert that chrome, as `FullscreenPage` already does for the map,
-  needs deciding before it ships.
-- **How many operations use each theme.** Unknown from the code. It does not
-  change the architecture, but if `oldfashioned` and `scifi` are effectively
-  unused, building two full theme modules is speculative work and Dispatch and
-  Tactical could land after the shell instead of with it.
-- **The Preview iframe under Dispatch.** Preview renders the mission page inside
-  a dark editor. A light page in a 40vw drawer may need a framing treatment
-  rather than sitting flush against the deck.
+Resolved since the first draft, recorded so they are not reopened: the site
+chrome stays dark under Dispatch (§10.1); the Preview drawer frames its iframe
+for every theme rather than special-casing Dispatch (§1); and Dispatch and
+Tactical move to a phase 2 branch because Modern carries ~90% of operations
+(§12).

--- a/docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md
@@ -299,7 +299,7 @@ moments, each a row carrying its own control:
 | RSVP closes | computed datetime | offset select |
 | Operation starts | datetime, and `in 92 days` | date picker |
 | Confirmations open | when the mission ends | — |
-| Completed | 48h after confirmations | — |
+| Completed | 24h after confirmations open | — |
 
 The current moment carries the accent ring. Nothing is stated twice.
 

--- a/docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md
@@ -1,0 +1,410 @@
+# Operations Editor Redesign — Design
+
+Replaces the operation editing page — one 2,464-line client component at
+`apps/web/app/operations/[id]/edit/page.tsx` — with a full-height application
+shell that separates writing a briefing from administering an operation, and
+rebuilds the schedule and attendance surfaces at roughly half their current
+information density.
+
+## Goal
+
+The page does two unrelated jobs in one vertical scroll, in the wrong order.
+
+A J2 member opens it to **write**: the briefing is a tree of documents in a
+single Y.Doc — `main`, plus typed `intel`, `orders`, `zeus`, `ocap`,
+`staff_orders` and `aar` pages that nest, take colour codes, drag to reorder
+and import sections from other operations. That is the daily work, and it sits
+at the very bottom of the page.
+
+Above it sit five stacked collapsible panels that exist to **administer**:
+Mission Development gates, Operation Details, Schedule & Automation, Attendance
+Settings and Custom Attendance Units. Two of them are `isHQ`-gated, so an
+ordinary author scrolls past locked or empty chrome to reach the thing they
+came for. Three more surfaces live elsewhere again — the map at
+`/operations/[id]/map`, the public view at `/operations/[id]`, and Preview and
+Activity as slide-over drawers — reachable only through `VIEW →` and `MAP ↗`
+links in the header, each a context switch that loses your place.
+
+Three problems follow from that shape, and the design is mostly about them:
+
+- **The primary task is below the fold.** Everything a writer needs is
+  reachable only after everything they do not.
+- **The same facts are printed twice.** Schedule & Automation is a form on the
+  left and a status column on the right restating the same four moments as
+  countdowns. Whichever you read, you must reconcile it against the other.
+- **Nothing is glanceable.** The op date, the stage, the RSVP mode and the
+  development-gate progress are the facts an author checks constantly, and each
+  one costs a scroll or a panel expansion to see.
+
+## Non-Goals
+
+- **Rewriting `CollabEditor.tsx` or `PageSidebar.tsx`.** They are 1,070 and
+  949 lines respectively and they work. This redesign changes where they sit
+  and what surrounds them, not what they do. Their props gain nothing beyond
+  what the shell must pass down.
+- **Changing the Y.js document model, the Hocuspocus server, or
+  `GET /api/auth/collab`.** Document naming (`{operationId}`, `sop-{id}`,
+  `ws-{id}`) and per-document permission resolution are untouched.
+- **Changing the operations lifecycle.** Status progression, attendance stages
+  and the `cron/operations` transitions keep their current behaviour. This
+  redesign changes how the stage is *displayed and manually overridden*, not
+  when it advances.
+- **The public view page** at `app/operations/[id]/page.tsx`, its paged view,
+  section nav or print path.
+- **The standalone map route.** `/operations/[id]/map` stays exactly as it is —
+  `app/operations/list.tsx` links into it from three places (lines 530, 578 and
+  908) and it provides a genuine fullscreen mode. The Map *tab* embeds the same
+  `MapSection` component; it does not replace the route.
+- **`IntelPackageEditor` / `IntelPackageViewer`** (1,300 and 1,410 lines). The
+  Intel Package is one of the document types in the rail and opens as it does
+  today.
+- **Merging the two design systems.** See §2 — this ports milpac's tokens into
+  the editor and accepts one duplication, deliberately.
+
+---
+
+## 1. The shell
+
+A full-height, four-region application shell. The page itself never scrolls;
+each region scrolls internally.
+
+```
+┌────────────────────────────────────────────────────────────────────┐ 54px
+│ ← J2 Operations │ NEW MISSION 18/08/2026 │ IN DEVELOPMENT          │
+│      BRIEF  MAP  DEVELOPMENT  ATTENDANCE      ✓ Saved  Publish  ⋯  │
+├──────────┬──────────────────────────────────────┬──────────────────┤
+│ 196px    │  flex                                │ 340px            │
+│          │                                      │                  │
+│ DOCUMENTS│  editor toolbar                      │  D-92 │ 0/5      │
+│  Main    │  ──────────────────────────────────  │  ─────┴────      │
+│  Intel   │                                      │  SCHEDULE        │
+│  CHQ     │  the document                        │  STAGE           │
+│   HQ     │                                      │  ATTENDANCE      │
+│   1 PLT  │                                      │  DETAILS         │
+│  Zeus    │                            ┌────────┐│                  │
+│  OCAP    │                            │ Preview││                  │
+├──────────┴────────────────────────────┴────────┴┴──────────────────┤ 32px
+│ ● Live │ Doc Main │ 1,240 words │ Saved 14:32 │  2 editing │ 1-0 HQ │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+**Header (54px, sticky).** Back crumb, operation title, status pill, save
+state, Publish (HQ, `In Development` only), and an overflow menu holding Delete
+Mission, Activity and Duplicate. Delete leaves the top level: today it sits
+immediately beside Publish, which puts the destructive action next to the
+primary one.
+
+**Tabs.** `BRIEF · MAP · DEVELOPMENT · ATTENDANCE`. Attendance is `isHQ`-only
+and is not rendered otherwise — not rendered disabled. There is no Settings
+tab; Operation Details and Schedule are edited in the deck (§4).
+
+**Documents rail (196px).** `PageSidebar` with `orientation='sidebar'`,
+unchanged, restyled to the shell's tokens. Persists across the Brief and Map
+tabs.
+
+**Mission deck (340px, persistent).** §4.
+
+**Status bar (32px).** §5.
+
+**Preview** is a floating button at the editor's bottom-right, opening the
+existing drawer. It is not a tab and not a header button.
+
+### Why not tabs for everything
+
+The deck is the design's one real bet, so state the trade plainly: it costs
+340px of editor width permanently. The alternative — Development and Attendance
+as tabs with nothing persistent — was drawn as Option A and rejected because it
+leaves an author unable to see the op date while writing, which is the specific
+complaint that started this work. The deck is what buys "nothing is hidden and
+nothing blocks the editor". §8 covers what happens when the window is too
+narrow to afford it.
+
+---
+
+## 2. Design system
+
+The editor's current styling is ad-hoc `rgba()` literals — `c(0.15)`,
+`rgba(237,237,237,0.3)` — recomputed per component from a `hexToRgb` helper
+that appears in at least three files.
+
+The milpac personnel file already solved this. `app/(landing)/milpacs/
+[username]/profile.module.css` defines a real token set, and its central idea
+maps one-to-one onto operations: `--acc` and `--acc-rgb` are injected inline
+per member, exactly as each operation carries its own `themeColor`.
+
+Ported values, unchanged:
+
+| Token | Value | Use |
+|---|---|---|
+| `--bg` | `#08090a` | page ground |
+| `--s1` `--s2` `--s3` | `#0d0f11` `#12151a` `#181c22` | panel, control, hover |
+| `--line` `--line-2` | `#1e232b` `#2a3038` | hairline, control border |
+| `--ink` `--ink-2` `--ink-3` | `#e8eaed` `#a8b0ba` `#6b7480` | text ramp |
+| `--good` `--warn` `--crit` | `#7fae5c` `#d4a03a` `#c05a48` | stage, gates, delete |
+| `--r` | `3px` | radius |
+| `--acc` `--acc-rgb` | operation `themeColor` | accent |
+
+And the primitives that carry the look: the **36px accent tick** on a panel's
+top-left corner (not the current full-width 2px top rule), `panelHeader` at
+`14px 18px` with an 11px/`0.22em` uppercase label, the `rw`/`rwK`/`rwV` data
+row, `chip`, `btn`, `pill`, the mono tab with its 2px underline and glow, and
+the film-grain overlay.
+
+These land in a new `app/operations/[id]/edit/shell.module.css`.
+
+**This duplicates `profile.module.css`'s token block, knowingly.** Extracting a
+shared stylesheet means editing a shipped, well-tested page in the same change
+that rewrites another one, and the two will want to diverge while this settles.
+Merging them into one `styles/` module is a follow-up, worth doing once the
+editor has been in use for a few operations — recorded here so it is not
+rediscovered as an accident.
+
+---
+
+## 3. Component decomposition
+
+`page.tsx` currently holds 2,464 lines and roughly 90 `useState` calls in one
+component. The target is that no file in the feature exceeds ~400 lines.
+
+```
+app/operations/[id]/edit/
+  page.tsx                    thin: params, permissions, initial fetch, <EditorShell>
+  shell.module.css
+  EditorShell.tsx             layout, tab state, save orchestration
+  Header.tsx                  crumb, title, status pill, publish, overflow menu
+  StatusBar.tsx               §5
+  DocumentsRail.tsx           wraps PageSidebar
+  activity-log.tsx            unchanged
+  deck/
+    MissionDeck.tsx           column container, collapse behaviour
+    CountdownStrip.tsx        D-n and gate progress
+    ScheduleCard.tsx          summary + inline edits
+    StageCard.tsx             progress bar, current stage, Advance
+    AttendanceCard.tsx        platoon chips, ping toggle        (HQ)
+    DetailsCard.tsx           owner, department, billet points, theme, map world
+  tabs/
+    BriefTab.tsx              CollabEditor
+    MapTab.tsx                MapSection
+    DevelopmentTab.tsx        the gate timeline + completion modal
+    AttendanceTab.tsx         §6                                 (HQ)
+  hooks/
+    useOperationMeta.ts       meta fields + Y.js sync + debounced save
+    useOperationStatus.ts     §5
+    useDocStats.ts            word/section counts from the editor
+```
+
+`hexToRgb` moves to `lib/` — it is currently redefined in `page.tsx`,
+`PageSidebar.tsx` and elsewhere.
+
+---
+
+## 4. The deck
+
+Persistent right column, 340px. It answers "what is the state of this
+operation" without leaving the document, and takes the edits that are one
+control wide. Anything larger opens its tab.
+
+**Countdown strip.** Two cells in the milpac `strip`/`cell` idiom: days until
+the operation (accent), and development gates as `0/5` (warn). These are the
+two numbers that decide whether an author needs to do anything today.
+
+**Schedule card.** The full timeline from §6, not a summary of it — compressed
+to the deck's width by stacking each moment's label, value and control rather
+than laying them across. Five moments at roughly 70px each is ~400px of the
+deck's ~938px budget, so the deck scrolls; that is expected and is why every
+region scrolls internally.
+
+Keeping the whole timeline here rather than splitting a summary from a detail
+view is deliberate: a summary that must be reconciled against a fuller version
+elsewhere is precisely the failure this redesign is removing.
+
+**Stage card.** A six-segment progress bar, the current stage in accent, and a
+single `Advance` button. The six-step labelled stepper the page has today is
+replaced: `cron/operations` drives the transitions, so the manual control is an
+override, not a primary input.
+
+**Attendance card (HQ).** Platoon chips and the Discord ping state. Selection
+is editable here; anything more opens the Attendance tab.
+
+**Details card.** Owner, department, billet points, theme colour, map world.
+Confirmed placement — these do not get a tab.
+
+**Collapse.** The deck collapses to a 44px rail of icons, with state in
+`localStorage`. §8 makes this automatic below a breakpoint.
+
+---
+
+## 5. The status bar
+
+32px, full width, bottom. It carries **document and session** state, and
+deliberately does not repeat the mission facts the deck is already showing a
+few hundred pixels to the right — sync status, active document, word and
+section counts, last save time, who else is editing, and the department.
+
+Two data sources, both already present:
+
+- **Presence** (`2 editing`) comes from the Hocuspocus awareness protocol that
+  `CollabEditor` already maintains for its collaborative cursors.
+- **Doc stats** come from the TipTap editor instance, via `useDocStats`.
+
+Live operation status — used by the deck, not the status bar — comes from
+`components/operations/OperationStatusBar.tsx`, which already polls the
+operation and formats countdowns (`fmtCountdown`, `LiveStatus`). Its fetching
+logic is extracted into `hooks/useOperationStatus.ts` and consumed by both that
+component and the deck, so the public view page and the editor cannot drift.
+
+---
+
+## 6. Density: schedule and attendance
+
+The named complaint, and a change that stands on its own regardless of shell.
+
+**Schedule becomes one timeline.** Today: a form (date picker, RSVP open
+manual/scheduled, RSVP close offset, a confirm button) beside a status column
+restating RSVP opens / RSVP closes / mission active / confirmations as
+countdowns. The two must be read against each other to answer "when does
+anything happen".
+
+They collapse into a single vertical timeline in the milpac `tl` idiom — five
+moments, each a row carrying its own control:
+
+| Moment | Value | Control |
+|---|---|---|
+| RSVP opens | Manual, or a computed datetime | mode toggle |
+| RSVP closes | computed datetime | offset select |
+| Operation starts | datetime, and `in 92 days` | date picker |
+| Confirmations open | when the mission ends | — |
+| Completed | 48h after confirmations | — |
+
+The current moment carries the accent ring. Nothing is stated twice.
+
+**The timeline lives in the deck, not a tab** (§4). Schedule was never asked to
+be a tab, and the deck is where Details and Schedule were confirmed to belong.
+
+**Attendance loses the stepper.** The six-step labelled stage stepper becomes
+the deck's thin progress bar plus one `Advance` control.
+
+**Custom Attendance Units stops being a panel.** It becomes a `+ Custom unit`
+chip in the platoon row, opening the existing editor inline. It is a rarely
+used feature currently occupying a top-level collapsible.
+
+**Notifications get grouped.** Discord ping and the orders reminder become two
+labelled toggle rows in one card, instead of a bare `Disabled` switch whose
+scope is not stated.
+
+The Attendance tab is then: Who attends, Notifications, Acknowledgements —
+everything about *people*. Timeline and Stage stay in the deck, so the tab set
+holds at four and nothing about *time* is split across two places.
+
+---
+
+## 7. Tab navigation is client state
+
+**Tabs must not be routes.** `app/(landing)/milpacs/[username]/tabs.tsx`
+carries a measured finding: with `next/link`, tab navigation committed on the
+first click 11 times out of 18 in production, and the milpac page deliberately
+fell back to plain `<a>` full document loads to get reliability. Query params,
+the `loading.tsx` boundary, `prefetch`, `scroll={false}` and the middleware
+matcher were each deployed and ruled out.
+
+A full document load per tab is unacceptable here: it tears down the Hocuspocus
+websocket and rebuilds the Y.Doc on every switch between Brief and Map.
+
+So tab state is React state in `EditorShell`, mirrored to the URL with
+`history.replaceState` so refreshes and deep links work without involving the
+Next router. All four tab panels mount within one client tree; Brief and Map
+stay mounted once visited so the editor and the map keep their connections.
+
+---
+
+## 8. Responsive behaviour
+
+The deck's 340px is the design's real cost, and 1366×768 laptops are common in
+the unit.
+
+| Viewport | Behaviour |
+|---|---|
+| ≥ 1600px | Rail 196 + deck 340, both open |
+| 1280–1599px | Deck open, documents rail collapses to 44px icons |
+| 1024–1279px | Deck collapses to a 44px rail; expands as an overlay on click |
+| < 1024px | Deck and rail both become overlay drawers; tabs scroll horizontally |
+
+The status bar drops cells from the left as width falls, keeping sync state and
+save time longest. Below 768px the editor is usable but not a target: this is a
+staff authoring tool used at a desk.
+
+---
+
+## 9. What is deleted
+
+- The five top-level collapsible panels and their `[−]`/`[+]` toggles.
+- The Schedule status column (folded into the timeline).
+- The six-step labelled stage stepper (folded into the progress bar).
+- The `VIEW →` and `MAP ↗` header links (Map is a tab; View moves to overflow).
+- Delete Mission's top-level placement (moves to overflow).
+- The three per-file `hexToRgb` copies (moves to `lib/`).
+
+---
+
+## 10. Testing
+
+**Unit (`vitest`, `npm run test:unit`).** The extracted logic is where the real
+risk sits and it is all pure:
+
+- `useOperationStatus` schedule computation — RSVP close offsets against an
+  operation date, DST boundaries, and the "manual" case where no open time
+  exists.
+- `fmtCountdown` at day, hour and minute boundaries, and past-due.
+- Stage progression: which stage is current for a given operation, and which
+  `Advance` targets.
+- `useDocStats` word and section counts over a known ProseMirror document.
+
+**Component.** The permission gates are worth asserting directly: the
+Attendance tab and deck card are absent — not disabled — for a non-HQ user, and
+Publish renders only for HQ on an `In Development` operation.
+
+**End-to-end (`playwright`).** Specs are written for tab switching preserving
+the collab connection, deck collapse persistence, and the timeline editing a
+date. **These are not run as part of this work without asking** — running
+`npm run test:e2e` is the user's call.
+
+---
+
+## 11. Rollout
+
+Work happens on `feat/operations-editor`, already branched off `main` at
+`63526821`, and carrying one unrelated commit-pending fix (the React
+shorthand/longhand border warning).
+
+No feature flag. This is a staff-only page behind `pages.operationsEdit`, the
+change is not incremental, and a flag would mean maintaining both shells
+against one Y.Doc. Because `.github/workflows/deploy.yml` deploys every push to
+`main` with no CI gate, the branch merges only when the whole shell is
+finished — per the repo's standing rule on large features.
+
+Sequencing, each step leaving the page working:
+
+1. `shell.module.css` and the token port.
+2. Extract `useOperationMeta`, `useOperationStatus`, `useDocStats` from
+   `page.tsx` — behaviour-preserving, page still renders as today.
+3. `EditorShell` + Header + StatusBar, with the existing panels stacked
+   underneath unchanged.
+4. Deck cards, moving content out of the panels one at a time.
+5. Tabs, once the panels are empty.
+6. Density rebuild of Schedule and Attendance.
+7. Delete the dead panel code.
+
+---
+
+## 12. Open questions
+
+- **`billetPoints` on the Details card.** It is awarded to the owner on
+  completion. Whether it should be editable after publish is a policy question
+  for J2, not a layout one.
+- **Deck contents when an operation is `Completed`.** The countdown strip
+  becomes meaningless. Likely it flips to attendance results, but that is a
+  design pass of its own once the shell exists.
+- **Zeus Notes and OCAP** are document types in the rail, but OCAP also has
+  panels (`OcapLinkPanel`, `OcapStatsPanel`, 568 and 520 lines) on the public
+  view. Whether the editor's OCAP page should surface sync status is unresolved
+  and deferred.

--- a/docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md
@@ -6,6 +6,11 @@ shell that separates writing a briefing from administering an operation, and
 rebuilds the schedule and attendance surfaces at roughly half their current
 information density.
 
+It then covers the other half of the same surface: the public mission page at
+`/operations/[id]` — which is also what the editor's Preview drawer renders —
+whose three per-operation themes are replaced by theme modules and redesigned
+(§10).
+
 ## Goal
 
 The page does two unrelated jobs in one vertical scroll, in the wrong order.
@@ -49,8 +54,9 @@ Three problems follow from that shape, and the design is mostly about them:
   and the `cron/operations` transitions keep their current behaviour. This
   redesign changes how the stage is *displayed and manually overridden*, not
   when it advances.
-- **The public view page** at `app/operations/[id]/page.tsx`, its paged view,
-  section nav or print path.
+- **The public view page's *behaviour*.** §10 restyles it and restructures how
+  its three themes are expressed. Its routing, content model, acknowledgement
+  flow, paged view and print path keep their current behaviour.
 - **The standalone map route.** `/operations/[id]/map` stays exactly as it is —
   `app/operations/list.tsx` links into it from three places (lines 530, 578 and
   908) and it provides a genuine fullscreen mode. The Map *tab* embeds the same
@@ -58,8 +64,9 @@ Three problems follow from that shape, and the design is mostly about them:
 - **`IntelPackageEditor` / `IntelPackageViewer`** (1,300 and 1,410 lines). The
   Intel Package is one of the document types in the rail and opens as it does
   today.
-- **Merging the two design systems.** See §2 — this ports milpac's tokens into
-  the editor and accepts one duplication, deliberately.
+- **Refactoring the milpac page itself.** §2 extracts the tokens it defines
+  into a shared stylesheet that milpac then imports; its components, layout and
+  behaviour are not touched.
 
 ---
 
@@ -150,14 +157,25 @@ top-left corner (not the current full-width 2px top rule), `panelHeader` at
 row, `chip`, `btn`, `pill`, the mono tab with its 2px underline and glow, and
 the film-grain overlay.
 
-These land in a new `app/operations/[id]/edit/shell.module.css`.
+**These are extracted, not copied.** An earlier draft of this spec accepted
+duplicating the token block into the editor, on the grounds that there were
+only two consumers and that editing a shipped page mid-rewrite was a risk worth
+avoiding. Adding the mission page (§10) makes three consumers across two
+feature areas, and three copies of a palette is how palettes drift.
 
-**This duplicates `profile.module.css`'s token block, knowingly.** Extracting a
-shared stylesheet means editing a shipped, well-tested page in the same change
-that rewrites another one, and the two will want to diverge while this settles.
-Merging them into one `styles/` module is a follow-up, worth doing once the
-editor has been in use for a few operations — recorded here so it is not
-rediscovered as an accident.
+So the token block moves to `styles/command.css` — plain CSS custom properties
+on a class, no module scoping, importable anywhere:
+
+- `profile.module.css` imports it and drops its own `:root` block. Its
+  components, layout and behaviour do not change; this is a
+  find-and-delete of duplicated declarations, verifiable by diffing rendered
+  colour values.
+- The editor shell imports it as `app/operations/[id]/edit/shell.module.css`.
+- Each mission-page theme imports it and overrides what it needs (§10).
+
+`--acc` / `--acc-rgb` stay injected inline by whichever page owns the entity —
+per member on milpac, per operation here. That indirection is what makes one
+palette serve both.
 
 ---
 
@@ -343,10 +361,110 @@ staff authoring tool used at a desk.
 - The `VIEW →` and `MAP ↗` header links (Map is a tab; View moves to overflow).
 - Delete Mission's top-level placement (moves to overflow).
 - The three per-file `hexToRgb` copies (moves to `lib/`).
+- All 165 `isOF`/`isSF` ternaries across the five view files (§10).
+- `profile.module.css`'s `:root` token block (moves to `styles/command.css`).
+- The scifi starfield background and the `#140f07` brass palette, replaced by
+  the Tactical and Dispatch designs.
 
 ---
 
-## 10. Testing
+## 10. The mission page and its themes
+
+The public view at `app/operations/[id]/page.tsx` is the same surface as the
+editor's Preview: **Preview is an `<iframe>` of this page**, refreshed by
+resetting `src` with a cache-busting `_t` param. There is no separate preview
+page to restyle, and restyling this one fixes both.
+
+### The problem
+
+Each operation picks a `pageTheme` — `modern`, `oldfashioned` or `scifi` —
+which the view renders through inline `isOF ? … : isSF ? … : …` ternaries:
+
+| File | Branches |
+|---|---|
+| `page.tsx` | 86 |
+| `paged-view.tsx` | 44 |
+| `PageNavClient.tsx` | 17 |
+| `OcapStatsPanel.tsx` | 10 |
+| `section-nav.tsx` | 8 |
+| **Total** | **165** |
+
+Every visual decision is written three times, at its point of use. That is why
+the page resists change, and it caps how different a theme is allowed to be:
+a theme can only vary what someone remembered to branch on.
+
+### Theme modules, not token swaps
+
+Themes become modules that own their markup. One container resolves the data;
+each theme decides what to draw with it.
+
+```
+app/operations/[id]/
+  page.tsx              loads the operation, resolves permissions and theme
+  view/
+    model.ts            OperationView — the contract every theme receives
+    registry.ts         pageTheme -> module, and the editor's dropdown labels
+    shared/             DocBody, acknowledgement, print hooks, OCAP panels
+    modern/
+    dispatch/
+    tactical/
+```
+
+`OperationView` is the whole contract: title, department, dates, status,
+sections, page tree, OCAP summary, acknowledgement state, and viewer
+capability flags. A theme is a pure function of it. Adding a theme is a new
+folder, an entry in `registry.ts`, and nothing else edited.
+
+**Why not fully separate pages,** which was the first instinct: the data
+loading, permission resolution, acknowledgement mutation and print wiring would
+be triplicated, and a change to any of them would need making three times, with
+the third discovered missing in production. The split is presentation-only.
+
+**Why not token sets,** which this spec previously chose: token swaps hold only
+while themes differ by colour and type. The designs in §10.1 differ
+structurally — hanging numerals, a chop stamp and a signature block have no
+counterpart in the others. A mechanism that cannot express them is the wrong
+mechanism.
+
+Tokens still do the work *inside* a theme; they are no longer how a theme is
+selected.
+
+### 10.1 The three themes
+
+Stored `pageTheme` values are unchanged — `modern`, `oldfashioned`, `scifi` —
+so no data migration is required. Only display names and designs change.
+
+**Modern** (`modern`). The `styles/command.css` palette applied to a briefing:
+cool near-black, the 36px accent tick per panel, mono micro-labels, film grain.
+The operation's theme colour is the accent. The default.
+
+**Dispatch** (`oldfashioned`, shown as "Dispatch"). Reimagined rather than
+ported — the current brass-on-`#140f07` with Courier chrome is replaced by a
+printed operations order: warm stock, ink-black serif body, a rotated
+double-ruled chop stamp for status, hanging clause numerals in a margin, a
+ruled left margin, and a signature block in place of a bare acknowledge button.
+
+**It is the one light theme, deliberately.** This page has a real print path
+(`PrintButton`, `data-print-section`, and a `bgColor` passed per theme), and a
+paper design is the only one of the three that prints honestly rather than
+flooding a page with ink.
+
+**Tactical** (`scifi`, shown as "Tactical"). Also reimagined: the starfield
+wallpaper behind Courier is replaced by a console — cold blue-black ground, a
+fine technical grid, corner brackets instead of full panel borders, a tick rail
+down the edge, scanlines, and bracketed mono readouts. The operation's own
+colour remains the accent, used as the alert hue against cyan chrome, so an
+operation keeps its identity in every theme.
+
+### 10.2 Print
+
+Each theme module exports a `printBackground` and its own print stylesheet,
+replacing the `bgColor={isOF ? '#140f07' : isSF ? '#01050a' : 'rgb(10,10,10)'}`
+ternary currently passed to `PrintButton`. `data-print-section` markers stay on
+section wrappers — the print path selects them and must keep working unchanged
+for all three themes.
+
+## 11. Testing
 
 **Unit (`vitest`, `npm run test:unit`).** The extracted logic is where the real
 risk sits and it is all pure:
@@ -363,6 +481,14 @@ risk sits and it is all pure:
 Attendance tab and deck card are absent — not disabled — for a non-HQ user, and
 Publish renders only for HQ on an `In Development` operation.
 
+**Theme modules (§10).** Each theme renders from the same `OperationView`
+fixture, which is what stops one theme quietly losing a field the others show.
+Per theme, assert: every section renders, the acknowledgement control is
+present and reflects acknowledged state, `data-print-section` markers survive,
+and an unknown `pageTheme` value falls back to Modern rather than throwing.
+A snapshot of the milpac page before and after the `styles/command.css`
+extraction must show no rendered colour change.
+
 **End-to-end (`playwright`).** Specs are written for tab switching preserving
 the collab connection, deck collapse persistence, and the timeline editing a
 date. **These are not run as part of this work without asking** — running
@@ -370,10 +496,10 @@ date. **These are not run as part of this work without asking** — running
 
 ---
 
-## 11. Rollout
+## 12. Rollout
 
-Work happens on `feat/operations-editor`, already branched off `main` at
-`63526821`, and carrying one unrelated commit-pending fix (the React
+Work happens on `feat/operations-editor`, branched off `main` at `63526821`,
+which already carries one unrelated fix as `1032f5c2` (the React
 shorthand/longhand border warning).
 
 No feature flag. This is a staff-only page behind `pages.operationsEdit`, the
@@ -382,9 +508,17 @@ against one Y.Doc. Because `.github/workflows/deploy.yml` deploys every push to
 `main` with no CI gate, the branch merges only when the whole shell is
 finished — per the repo's standing rule on large features.
 
-Sequencing, each step leaving the page working:
+Two bodies of work — the editor shell and the mission page — sharing only
+`styles/command.css`. They are independent after step 1 and can land in either
+order.
 
-1. `shell.module.css` and the token port.
+Sequencing, each step leaving both pages working:
+
+1. `styles/command.css`: extract the token block, repoint `profile.module.css`
+   at it, confirm no rendered change on milpac.
+
+**Editor shell**
+
 2. Extract `useOperationMeta`, `useOperationStatus`, `useDocStats` from
    `page.tsx` — behaviour-preserving, page still renders as today.
 3. `EditorShell` + Header + StatusBar, with the existing panels stacked
@@ -394,9 +528,23 @@ Sequencing, each step leaving the page working:
 6. Density rebuild of Schedule and Attendance.
 7. Delete the dead panel code.
 
+**Mission page**
+
+8. `view/model.ts` and `view/registry.ts`; extract `shared/` from the current
+   view without changing output.
+9. `modern/` — port today's `modern` branch onto the new structure, so the
+   default theme is proven against the container before anything is redesigned.
+10. `dispatch/` and `tactical/`, each new work rather than a port.
+11. Delete the `isOF`/`isSF` ternaries and rename the editor's theme dropdown
+    labels to Modern / Dispatch / Tactical.
+
+Step 9 before step 10 matters: it separates "did the new architecture break the
+page" from "do we like the new designs", which are otherwise diagnosed
+together.
+
 ---
 
-## 12. Open questions
+## 13. Open questions
 
 - **`billetPoints` on the Details card.** It is awarded to the owner on
   completion. Whether it should be editable after publish is a policy question
@@ -408,3 +556,14 @@ Sequencing, each step leaving the page working:
   panels (`OcapLinkPanel`, `OcapStatsPanel`, 568 and 520 lines) on the public
   view. Whether the editor's OCAP page should surface sync status is unresolved
   and deferred.
+- **Dispatch is a light theme inside a dark app.** The site chrome (navbar,
+  footer) is dark and does not currently vary by page. Whether Dispatch should
+  suppress or invert that chrome, as `FullscreenPage` already does for the map,
+  needs deciding before it ships.
+- **How many operations use each theme.** Unknown from the code. It does not
+  change the architecture, but if `oldfashioned` and `scifi` are effectively
+  unused, building two full theme modules is speculative work and Dispatch and
+  Tactical could land after the shell instead of with it.
+- **The Preview iframe under Dispatch.** Preview renders the mission page inside
+  a dark editor. A light page in a 40vw drawer may need a framing treatment
+  rather than sitting flush against the deck.


### PR DESCRIPTION
Replaces the operation editing page — one 2,464-line client component at `app/operations/[id]/edit/page.tsx` — with a full-height application shell that separates **writing a briefing** from **administering an operation**.

Design: `docs/superpowers/specs/2026-08-18-operations-editor-redesign-design.md`
Plan: `docs/superpowers/plans/2026-08-18-operations-editor-shell.md`

## The problem

The page did two unrelated jobs in one vertical scroll, in the wrong order.

A J2 member opens it to **write** — the briefing is a tree of documents in a single Y.Doc that nest, take colour codes, drag to reorder and import sections from other operations. That is the daily work, and it sat at the very bottom of the page.

Above it sat five stacked collapsible panels that exist to **administer**: Mission Development gates, Operation Details, Schedule & Automation, Attendance Settings, Custom Attendance Units. Two are `isHQ`-gated, so an ordinary author scrolled past locked or empty chrome to reach the thing they came for. Three more surfaces lived elsewhere again — the map, the public view, Preview and Activity as slide-overs — each reachable only through a header link that lost your place.

Three consequences, and the redesign is mostly about them:

- **The primary task was below the fold.** Everything a writer needs was reachable only after everything they don't.
- **The same facts were printed twice.** Schedule & Automation was a form on the left and a status column on the right restating the same four moments as countdowns. Whichever you read, you had to reconcile it against the other.
- **Nothing was glanceable.** Op date, stage, RSVP mode and development-gate progress are the facts an author checks constantly, and each cost a scroll or a panel expansion.

## The shape now

A four-region shell that never scrolls itself — each region scrolls internally. Header, status bar, a mission deck, and the work surface split into **Brief / Map / Development / Attendance** tabs.

The **mission deck** replaces the five stacked panels: a countdown strip, a stage card (which also replaced the six-step stepper and kept arbitrary stage jumps behind confirms), a schedule card, details, attendance, and a map/world picker. Schedule stopped printing itself twice.

The collab editor stays **mounted across tabs**, so switching to Map and back doesn't tear down the Y.js connection or lose your cursor.

## Logic out of the component, into `lib` with tests

The old page held its scheduling, stage progression and document statistics inline. Those are now `lib/operations/{schedule,stage,doc-stats}.ts` and `lib/colour.ts`, each with unit tests — and the status bar reads schedule logic from `lib` rather than recomputing it.

`styles/command.css` extracts the token block the milpac page had been defining privately, so the editor and milpac share one source. The milpac page's own components, layout and behaviour are untouched.

## Editor fixes along the way

`CollabEditor.tsx` took the largest single diff: the per-section toolbars consolidated into one with measurement-driven overflow, toolbar dropdowns portalled out so they stop being clipped, focus retained in the editor on toolbar clicks (which had been silently dropping the selection), the full formatting control set restored, and thin fading overlay scrollbars on the scroll regions via `useThinScrollFade.ts`.

## Deliberately not in scope

Called out in the design doc, and unchanged here:

- **`CollabEditor` and `PageSidebar` are not rewritten.** This changes where they sit and what surrounds them, not what they do.
- **The Y.js document model, Hocuspocus, and `GET /api/auth/collab`** — document naming and per-document permission resolution are untouched.
- **The operations lifecycle** — status progression, attendance stages and the `cron/operations` transitions keep their behaviour. This changes how the stage is *displayed and manually overridden*, not when it advances.
- **`/operations/[id]/map`** stays as it is; the Map tab embeds the same component rather than replacing the route.
- **`IntelPackageEditor` / `IntelPackageViewer`** — the Intel Package is one document type in the rail and opens as it does today.

## Not done

**§10 of the design — the public mission page and its three themes — is specced but not implemented.** The token extraction it depends on (§2) has landed; the restyle and the theme-module restructure have not. The public page behaves and looks as it did.

## Verification

`tsc --noEmit` clean.

`tests/operations-editor.spec.ts` is new (240 lines) and covers the editor shell. **It has not been run in this session** — the suite spawns a real `next dev` server, so I'd rather you kick it off than have it race against edits. `npm run build` has likewise not been run on this branch.

## Merge notes

Branched before #88 (the dashboard redesign) merged into `feat/navbar-redesign`, so it is 34 ahead / 16 behind. Four files are touched on both sides — `app/layout.tsx`, `styles/globals.css`, and the two milpac profile files — but a test-merge comes out clean, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
