### PR TITLE
chore(web): drop eslint-disable directives for rules that never run

### DIFF
--- a/apps/web/app/(landing)/join/info/InfoPageClient.tsx
+++ b/apps/web/app/(landing)/join/info/InfoPageClient.tsx
@@ -203,7 +203,6 @@ function StepBody({ step, onViewRoles }: {
                 </p>
             ))}
             {step.intro && (
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 <p dangerouslySetInnerHTML={{ __html: step.intro as any }} style={{ color: MUTED, fontSize: '0.86rem', lineHeight: 1.75, fontFamily: 'Arial, sans-serif', marginBottom: 14 }} />
             )}
             {step.gridItems.length > 0 && (

--- a/apps/web/app/(landing)/join/info/page.tsx
+++ b/apps/web/app/(landing)/join/info/page.tsx
@@ -16,7 +16,6 @@ export default async function JoinInfoPage() {
     // If the info page is disabled, skip straight to the application
     if (config && config.showInfoPage === false) redirect('/join')
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const info: RecruitmentInfoContent = (config as any)?.recruitmentInfo ?? DEFAULT_RECRUITMENT_INFO
 
     return <InfoPageClient info={sanitizeRecruitmentInfo(info)} />

--- a/apps/web/app/api/admin/j1/recruit-video/upload/route.ts
+++ b/apps/web/app/api/admin/j1/recruit-video/upload/route.ts
@@ -86,7 +86,6 @@ export async function POST(req: NextRequest) {
         // Only error when no file was found at all — if fileStarted is true, ws.on('close') will resolve
         bb.on('finish', () => { if (!fileStarted && !settled) done(NextResponse.json({ error: 'No file received' }, { status: 400 })) })
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         Readable.fromWeb(req.body as any).pipe(bb)
     })
 }

--- a/apps/web/app/api/admin/recruitment-info/route.ts
+++ b/apps/web/app/api/admin/recruitment-info/route.ts
@@ -13,7 +13,6 @@ export async function GET() {
         return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
 
     const config = await Db.recruitVideoConfig.findOne({ _id: 'main' }).catch(() => null)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const info = (config as any)?.recruitmentInfo ?? DEFAULT_RECRUITMENT_INFO
     return NextResponse.json(sanitizeRecruitmentInfo(info))
 }

--- a/apps/web/app/api/training-videos/upload/route.ts
+++ b/apps/web/app/api/training-videos/upload/route.ts
@@ -73,7 +73,6 @@ export async function POST(req: NextRequest) {
         bb.on('error', (err: Error) => done(NextResponse.json({ error: `Parse error: ${err.message}` }, { status: 400 })))
         bb.on('finish', () => { if (!fileStarted && !settled) done(NextResponse.json({ error: 'No file received' }, { status: 400 })) })
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         Readable.fromWeb(req.body as any).pipe(bb)
     })
 }

--- a/apps/web/app/dashboard/j2/tabs/IntelImagesTab.tsx
+++ b/apps/web/app/dashboard/j2/tabs/IntelImagesTab.tsx
@@ -287,7 +287,6 @@ const ImageViewport = forwardRef<ImageViewportHandle, {
                     <CompositeCanvas imageUrl={imageUrl} onReady={onCanvasReady} cssFilter={cssFilter || undefined} />
                 </div>
                 {/* Overlay is outside the zoom transform — stays full-viewport during zoom/pan */}
-                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                     src={OVERLAY_PATHS[overlayStyle]}
                     alt=''
@@ -501,7 +500,6 @@ function ScreenshotUpload({
             />
             {value ? (
                 <>
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                         src={`data:image/png;base64,${value}`}
                         alt='source screenshot'
@@ -629,7 +627,6 @@ function CreatorPanel({
 
     function playGenerationChime() {
         try {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const AC: typeof AudioContext = window.AudioContext ?? (window as any).webkitAudioContext
             const ac = new AC()
             function note(freq: number, t: number, dur: number) {
@@ -1096,14 +1093,12 @@ function ImageCard({
                 aspectRatio: image.aspectRatio === 'portrait' ? '2/3' : image.aspectRatio === 'landscape' ? '3/2' : '1/1',
             }}
         >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
                 src={`/api/ai/images/${image._id?.toString()}/file`}
                 alt='Generated intel image'
                 style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
                 loading='lazy'
             />
-            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
                 src={OVERLAY_PATHS[image.cameraStyle]}
                 alt=''
@@ -1230,13 +1225,11 @@ function ImageLibraryPanel({ onSelect }: { onSelect?: (image: AiGeneratedImage) 
                 >
                     <DialogContent style={{ padding: 0, position: 'relative' }}>
                         <div style={{ position: 'relative', lineHeight: 0 }}>
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
                             <img
                                 src={`/api/ai/images/${selectedImage._id?.toString()}/file`}
                                 alt='Generated intel image'
                                 style={{ display: 'block', maxWidth: '80vw', maxHeight: '80vh', objectFit: 'contain' }}
                             />
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
                             <img
                                 src={OVERLAY_PATHS[selectedImage.cameraStyle]}
                                 alt=''

--- a/apps/web/app/dashboard/j4/tabs/AIAdminTab.tsx
+++ b/apps/web/app/dashboard/j4/tabs/AIAdminTab.tsx
@@ -312,7 +312,6 @@ function BudgetDialog({ open, initial, onClose, onSaved }: {
                 .map(s => parseFloat(s.trim()) / 100)
                 .filter(n => !isNaN(n))
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const body: any = {
                 _id: form._id,
                 scopeType: form.scopeType,

--- a/apps/web/app/dashboard/unit/training-docs/TrainingHub.tsx
+++ b/apps/web/app/dashboard/unit/training-docs/TrainingHub.tsx
@@ -673,7 +673,6 @@ export default function TrainingHub({ isJ3Lead, isTrainer, isJ3Trainer, myId, is
             const restored = deletedGuidesCache.find(g => String(g._id) === guideId)
             if (restored) {
                 setDeletedGuidesCache(prev => prev.filter(g => String(g._id) !== guideId))
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { deletedAt, deletedById, deletedByName, ...rest } = restored
                 setAllGuides(prev => [...prev, rest as TrainingGuide])
             }

--- a/apps/web/app/dashboard/unit/training-hub/course/[id]/tabs/CandidateFeedbackTab.tsx
+++ b/apps/web/app/dashboard/unit/training-hub/course/[id]/tabs/CandidateFeedbackTab.tsx
@@ -89,7 +89,6 @@ function FieldPresenceAvatars({ users }: { users: PresenceUser[] }) {
                     }}
                 >
                     {u.avatar ? (
-                        // eslint-disable-next-line @next/next/no-img-element
                         <img src={u.avatar} alt={u.name} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
                     ) : (
                         <span style={{ fontSize: '0.38rem', fontWeight: 800, color: '#fff', lineHeight: 1 }}>{getInitials(u.name)}</span>

--- a/apps/web/lib/ai/budget.ts
+++ b/apps/web/lib/ai/budget.ts
@@ -73,7 +73,6 @@ export async function checkBudget(ctx: BudgetCheckContext): Promise<BudgetCheckR
     ]
 
     const budgets = await Db.aiBudgets.find({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         $or: scopeKeys as any,
         enabled: true,
     }).toArray()


### PR DESCRIPTION
Clears all 16 `Unused eslint-disable directive` warnings from the build output. Comment deletions only — no behaviour change.

> [!WARNING]
> Merging this deploys. `.github/workflows/deploy.yml` fires on every push to `main` and runs `docker compose up -d --build` on the server, with no CI gate in front of it.

## What these actually were

Not stale comments left behind by a refactor. Every line they guarded still contains exactly the thing they suppress — the `as any` is still there, the `<img>` is still there. They were reported as unused because **neither rule is switched on**:

- `@next/next/no-img-element` is explicitly `'off'` in `apps/web/eslint.config.mjs` — a deliberate project decision.
- `@typescript-eslint/no-explicit-any` and `@typescript-eslint/no-unused-vars` are never enabled at all. The config registers `tseslint.plugin` but pulls in none of its rulesets, so both resolve to *not set* (confirmed with `eslint --print-config`).

## Why delete rather than enable the rules

Enabling either rule isn't a warning fix, it's a large refactor:

| | suppressed | actually in `apps/web` |
|---|---|---|
| `any` annotations | 8 comments | **276** across 129 files |
| `<img>` tags | 7 comments | **112** |

The comments were the outliers — a handful of spots where someone suppressed a rule this project doesn't run. Removing them is the change that matches how the config is actually set up.

## Files

10 files, 16 deletions, 0 insertions:

- `app/(landing)/join/info/InfoPageClient.tsx`, `app/(landing)/join/info/page.tsx`
- `app/api/admin/j1/recruit-video/upload/route.ts`, `app/api/admin/recruitment-info/route.ts`, `app/api/training-videos/upload/route.ts`
- `app/dashboard/j2/tabs/IntelImagesTab.tsx` (7)
- `app/dashboard/j4/tabs/AIAdminTab.tsx`, `app/dashboard/unit/training-docs/TrainingHub.tsx`
- `app/dashboard/unit/training-hub/course/[id]/tabs/CandidateFeedbackTab.tsx`
- `lib/ai/budget.ts`

Seven of them are JSX-comment form (`{/* … */}`) rather than `//`. Each deletion was asserted to be a standalone disable directive before being made, so the diff is 16 removed lines and nothing else.

## Verification

- `npm run lint` — **No ESLint warnings or errors**
- `npx tsc --noEmit` — clean
- `npm run build` — succeeded

Playwright E2E was not run. This PR touches no page gate, permission key, route or API surface, so there is nothing here for the suite to cover.

## Relationship to #91

No file overlap with `feat/navbar-redesign` (`git diff --name-only` intersection is empty), so the two can merge in either order.

## Aside, not addressed here

The build warns that `next lint` is deprecated and removed in Next.js 16, with a codemod to migrate to the ESLint CLI (`npx @next/codemod@canary next-lint-to-eslint-cli .`). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)