### PR TITLE
perf(web): animate milpac avatars and covers only on hover

### DIFF
--- a/apps/web/app/(landing)/milpacs/card.tsx
+++ b/apps/web/app/(landing)/milpacs/card.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 
 import Avatar from '@/components/member/avatar'
+import { animatedAvatarURL, stillAvatarURL } from '@/lib/discord/avatar'
 import { resolveMemberAccent } from '@/lib/military/accent'
 import type { MilpacKitLine } from '@/lib/milpac-kits'
 import s from './roster.module.css'
@@ -20,8 +21,12 @@ import s from './roster.module.css'
  * A server component now. The old one was `'use client'` solely to run a
  * mouse-tilt effect; the hover treatment is CSS, so 163 of these no longer ship
  * a component's worth of JavaScript each.
+ *
+ * Animated avatars and covers are stills until the pointer is on the card. That
+ * is not a stylistic choice — see `--anim-avatar` below and `roster.module.css`
+ * for what it costs when they all animate at once.
  */
-export default function Card({ member, role, href, kit, coverUrl }: {
+export default function Card({ member, role, href, kit, coverUrl, coverAnimated }: {
     member: User
     role?: string
     /** The member's canonical milpac path; without it the username URL still
@@ -33,6 +38,10 @@ export default function Card({ member, role, href, kit, coverUrl }: {
      *  Deliberately not the Discord banner: this is the image the member chose
      *  for their own file, and the one they can actually change. */
     coverUrl?: string
+    /** Whether that cover is a GIF. Sniffed from the file's bytes by
+     *  `animatedCoverIds`, because every cover is stored under a `.png` name
+     *  regardless of what was uploaded. */
+    coverAnimated?: boolean
 }) {
     const accent = resolveMemberAccent(member)
 
@@ -47,16 +56,42 @@ export default function Card({ member, role, href, kit, coverUrl }: {
 
     const bio = member.bio?.content?.trim()
 
+    /*
+       Animated media, split into "what is painted" and "what is painted on
+       hover".
+
+       Both animated forms are handed to CSS as custom properties rather than
+       rendered as elements, and the stylesheet only resolves them inside a
+       `:hover`/`:focus-within` rule. A `url()` sitting unused in a custom
+       property is never fetched — the browser requests the image the moment the
+       rule first applies to a rendered element, and not before. So an idle
+       roster downloads no GIFs and paints no animation, and a hovered card
+       fetches exactly one.
+
+       The alternative — rendering both and toggling `display` — would have
+       downloaded every GIF on the page up front, which for this roster was
+       measured at 1.76 MB for a single avatar.
+    */
+    const stillAvatar = stillAvatarURL(member.avatarURL) || member.avatarURL
+    const animAvatar = animatedAvatarURL(member.avatarURL)
+
+    const animCover = coverAnimated ? coverUrl : null
+    const stillCover = animCover ? `${coverUrl}&still=1` : coverUrl
+
     return (
         <Link
             href={href ?? `/milpacs/${member.username}`}
             className={s.card}
-            style={{ ['--acc' as string]: accent }}
+            style={{
+                ['--acc' as string]: accent,
+                ...(animAvatar ? { ['--anim-avatar' as string]: `url("${animAvatar}")` } : {}),
+                ...(animCover ? { ['--anim-cover' as string]: `url("${animCover}")` } : {}),
+            }}
         >
             <div className={s.banner}>
-                {coverUrl && (
+                {stillCover && (
                     <Image
-                        src={coverUrl}
+                        src={stillCover}
                         alt=''
                         width={480}
                         height={136}
@@ -72,11 +107,15 @@ export default function Card({ member, role, href, kit, coverUrl }: {
                         loading='lazy'
                     />
                 )}
+                {animCover && <span className={s.bannerAnim} aria-hidden='true' />}
             </div>
 
             <div className={s.avatarWrap}>
                 <div className={s.avatar}>
-                    <Avatar user={{ id: member.id, avatarURL: member.avatarURL }} />
+                    {/* 64px, not the component's default: this circle is 54px, and
+                        the default is sized for the much larger milpac hero. */}
+                    <Avatar user={{ id: member.id, avatarURL: stillAvatar }} sizes='64px' />
+                    {animAvatar && <span className={s.avatarAnim} aria-hidden='true' />}
                 </div>
             </div>
 

--- a/apps/web/app/(landing)/milpacs/page.tsx
+++ b/apps/web/app/(landing)/milpacs/page.tsx
@@ -19,7 +19,7 @@ import Masthead from '@/components/ui/Masthead'
 import shell from '@/styles/shell.module.css'
 import ui from '@/styles/ui.module.css'
 import { fetchDefaultKitLines } from '@/lib/milpac-kits'
-import { coverIds } from '@/lib/military/milpac-cover'
+import { animatedCoverIds, coverIds } from '@/lib/military/milpac-cover'
 import r from './roster.module.css'
 import { buildSlugIndex, canonicalSegment, toSlugCandidate } from '@/lib/military/milpac-slug'
 import MilpacsNav from './nav'
@@ -65,6 +65,9 @@ export default async function Page() {
 
 	// One readdir for the whole roster rather than an existsSync per card.
 	const covers = coverIds()
+	// Which of those are GIFs, so the card can serve a still and hold the
+	// animation back until hover. One 6-byte read per cover, not per card.
+	const animatedCovers = animatedCoverIds(covers)
 	const coverUrl = (id: string) => covers.has(id) ? `/api/uploads/cover?id=${id}` : undefined
 
 	// fetchAllMembers() returns raw Mongo documents — departmentRoleIds (ObjectId[])
@@ -148,7 +151,7 @@ export default async function Page() {
 						<div className={r.grid}>
 							{[orbat.companyHQ.senior, ...orbat.companyHQ.members].map(m => {
 								const member = lookup(m.name)
-								return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} /> : null
+								return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} coverAnimated={animatedCovers.has(member.id)} /> : null
 							})}
 						</div>
 					</SubSection>
@@ -164,7 +167,7 @@ export default async function Page() {
 								<div className={r.grid}>
 									{section.members.map(m => {
 										const member = lookup(m.name)
-										return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} /> : null
+										return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} coverAnimated={animatedCovers.has(member.id)} /> : null
 									})}
 								</div>
 							</SubSection>
@@ -182,7 +185,7 @@ export default async function Page() {
 								<div className={r.grid}>
 									{section.members.map(m => {
 										const member = lookup(m.name)
-										return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} /> : null
+										return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} coverAnimated={animatedCovers.has(member.id)} /> : null
 									})}
 								</div>
 							</SubSection>
@@ -200,7 +203,7 @@ export default async function Page() {
 								<div className={r.grid}>
 									{section.members.map(m => {
 										const member = lookup(m.name)
-										return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} /> : null
+										return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} coverAnimated={animatedCovers.has(member.id)} /> : null
 									})}
 								</div>
 							</SubSection>
@@ -222,7 +225,7 @@ export default async function Page() {
 							<div className={r.grid}>
 								{orbat.gamemasters.map(m => {
 									const member = lookup(m.name)
-									return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} /> : null
+									return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role={m.role} kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} coverAnimated={animatedCovers.has(member.id)} /> : null
 								})}
 							</div>
 						</SubSection>
@@ -236,7 +239,7 @@ export default async function Page() {
 							<div className={r.grid}>
 								{orbat.activeReservists.map(name => {
 									const member = lookup(name)
-									return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role='Active Reservist' kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} /> : null
+									return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role='Active Reservist' kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} coverAnimated={animatedCovers.has(member.id)} /> : null
 								})}
 							</div>
 						</SubSection>
@@ -246,7 +249,7 @@ export default async function Page() {
 							<div className={r.grid} style={{ opacity: 0.5 }}>
 								{orbat.inactiveReservists.map(name => {
 									const member = lookup(name)
-									return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role='Inactive Reservist' kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} /> : null
+									return member ? <Card key={member.id} member={member} href={milpacPaths.get(member.id)} role='Inactive Reservist' kit={kitLines.get(member.id)} coverUrl={coverUrl(member.id)} coverAnimated={animatedCovers.has(member.id)} /> : null
 								})}
 							</div>
 						</SubSection>

--- a/apps/web/app/(landing)/milpacs/roster.module.css
+++ b/apps/web/app/(landing)/milpacs/roster.module.css
@@ -230,6 +230,65 @@
     }
 }
 
+/* ---------- animated media, on hover only -------------------------------- */
+
+/*
+   Animated avatars and covers, held back until the pointer is on the card.
+
+   The roster paints stills. Members with a Nitro avatar cluster at the top of
+   this page (Command first), and every one of those avatars is an animated GIF
+   that next/image refuses to optimise — it passes animated images through
+   byte-for-byte, so a 54px circle was being fed a 1.76 MB GIF and repainting it
+   forever. Ten of those in the first screen is a compositor commit every frame
+   for as long as the page is open, which is exactly what it looked like in a
+   performance trace: a steady drumbeat of long tasks that stopped the moment
+   the top of the roster was scrolled away.
+
+   The mechanism matters. The animated URL is handed in as a custom property and
+   only ever resolved inside these rules, because a `url()` parked in an unused
+   custom property is never fetched — the request happens when the declaration
+   first applies to a rendered element. Rendering both images and toggling
+   `display` would have downloaded every GIF on the page up front; this
+   downloads one, when someone asks for it.
+
+   `hover: hover` keeps it off touch devices, where `:hover` sticks after a tap
+   and there is no way to un-hover a card.
+*/
+.avatarAnim,
+.bannerAnim {
+    position: absolute;
+    inset: 0;
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    /* The card is one big link — these must never eat its clicks. */
+    pointer-events: none;
+}
+
+.avatarAnim {
+    border-radius: 50%;
+}
+
+@media (hover: hover) {
+    .card:hover .avatarAnim { background-image: var(--anim-avatar); }
+    .card:hover .bannerAnim { background-image: var(--anim-cover); }
+}
+
+/* Keyboard users get the same thing, on any input type. */
+.card:focus-visible .avatarAnim { background-image: var(--anim-avatar); }
+.card:focus-visible .bannerAnim { background-image: var(--anim-cover); }
+
+/* Asked not to animate: never resolve the URL at all, so it is not even
+   fetched. The still underneath is what stays on show. */
+@media (prefers-reduced-motion: reduce) {
+    .card:hover .avatarAnim,
+    .card:hover .bannerAnim,
+    .card:focus-visible .avatarAnim,
+    .card:focus-visible .bannerAnim {
+        background-image: none;
+    }
+}
+
 /* ============================================================================
    Roster layout
    ----------------------------------------------------------------------------

--- a/apps/web/app/api/uploads/cover/route.ts
+++ b/apps/web/app/api/uploads/cover/route.ts
@@ -2,19 +2,68 @@ import { NextRequest, NextResponse } from 'next/server'
 import client from '@/lib/discord'
 import fs from 'fs'
 
+import { MAX_COVER_BYTES } from '@/lib/military/milpac-cover'
 
+
+/** GIF magic — "GIF87a" / "GIF89a". Covers are stored under a .png name
+ *  whatever was uploaded, so the bytes are the only honest source. */
+function isGif(buf: Buffer): boolean {
+    return buf.subarray(0, 6).toString('latin1').startsWith('GIF8')
+}
+
+/**
+ * A cover.
+ *
+ * `?still=1` returns the first frame of an animated cover as a real PNG. The
+ * roster asks for that: 163 cards each repainting a full-size GIF forever is
+ * the difference between a page that scrolls and one that doesn't, and
+ * next/image is no help because it passes animated images through untouched.
+ * The card holds the animation back until hover, and this is where it gets
+ * something to show in the meantime. Non-animated covers ignore the flag and
+ * take the normal path — no decode, no re-encode.
+ */
 export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const id = searchParams.get('id')
+
+    // A Discord snowflake and nothing else. `id` is interpolated straight into
+    // a filesystem path below, so an unchecked value here is a path traversal:
+    // `?id=../../../../etc/passwd` resolved happily before this guard.
+    if (!id || !/^\d{5,25}$/.test(id)) return NextResponse.json('Not found', { status: 404 })
 
     const path = `../../storage/uploads/cover/${id}.png`
     if (!fs.existsSync(path)) return NextResponse.json('Not found', { status: 404 })
 
     const output = fs.readFileSync(path)
+    const gif = isGif(output)
+
+    if (gif && searchParams.get('still') && output.length <= MAX_COVER_BYTES) {
+        try {
+            // Imported here rather than at module scope so the ordinary path —
+            // which is the overwhelming majority of requests — never pulls a
+            // native binary in behind it.
+            const { createCanvas, loadImage } = await import('@napi-rs/canvas')
+            const image = await loadImage(output)
+
+            const canvas = createCanvas(image.width, image.height)
+            canvas.getContext('2d').drawImage(image, 0, 0)
+
+            return new NextResponse(canvas.toBuffer('image/png') as BodyInit, {
+                status: 200,
+                headers: { 'Content-Type': 'image/png', 'Cache-Control': 'no-cache' },
+            })
+        } catch {
+            // A cover that will not decode falls through to the raw bytes
+            // rather than 500ing the card it belongs to.
+        }
+    }
+
     return new NextResponse(output as BodyInit, {
         status: 200,
         headers: {
-            'Content-Type': 'image/png',
+            // Sniffed, not assumed. This route claimed `image/png` for every
+            // file it served, including the GIFs it demonstrably holds.
+            'Content-Type': gif ? 'image/gif' : 'image/png',
             'Cache-Control': 'no-cache',
         },
     })

--- a/apps/web/components/member/avatar.tsx
+++ b/apps/web/components/member/avatar.tsx
@@ -21,7 +21,19 @@ function resolveAvatar(user?: AvatarUser): string | StaticImageData {
  */
 type AvatarUser = Pick<User, 'id' | 'avatarURL'>
 
-export default function Avatar({ user, borderRadius = '100%' }: { user?: AvatarUser, borderRadius?: string }) {
+export default function Avatar({ user, borderRadius = '100%', sizes = '160px' }: {
+    user?: AvatarUser,
+    borderRadius?: string,
+    /**
+     * How wide this avatar actually renders. `fill` with no `sizes` makes
+     * next/image assume `100vw` and emit a srcset all the way up to 3840w, so
+     * the browser was picking a ~2048px raster to paint a 54px circle. Every
+     * avatar on the site is a small chip or circle; the default covers the
+     * largest of them (the milpac hero, 148px at its widest) and callers with
+     * something smaller should say so.
+     */
+    sizes?: string,
+}) {
 
     const [image, setImage] = useState<string | StaticImageData>(() => resolveAvatar(user))
 
@@ -32,6 +44,7 @@ export default function Avatar({ user, borderRadius = '100%' }: { user?: AvatarU
             src={image}
             alt='Profile Picture'
             fill
+            sizes={sizes}
             className='object-cover'
             style={{ borderRadius }}
             onError={() => setImage(user?.id ? defaultAvatarURL(user.id) : Fallback)}

--- a/apps/web/docs/map/d-misc-api.md
+++ b/apps/web/docs/map/d-misc-api.md
@@ -205,7 +205,7 @@ Public J1 recruitment/application flow (unauthenticated except `dev-login`).
 - **POST** — uploads/overwrites the caller's own bio photo (`./uploads/bio/<me.id>.jpg`). Auth: `hasPermission(user, 'uploads.bio')`.
 
 #### /api/uploads/cover
-- **GET** — `?id=` serves `./uploads/cover/<id>.png` cover photo. Auth: public/no auth (read).
+- **GET** — `?id=` serves `./uploads/cover/<id>.png` cover photo. Auth: public/no auth (read). `id` must be a Discord snowflake — it is interpolated into a filesystem path, and before that check `?id=../../../../etc/passwd` resolved. `Content-Type` is sniffed from the bytes rather than assumed `image/png`, because covers are stored under a `.png` name whatever was uploaded and some are GIFs. `?still=1` returns the first frame of an animated cover as a real PNG (decoded via `@napi-rs/canvas`, imported lazily; falls through to the raw bytes if it will not decode) — the /milpacs roster asks for that so it can hold animation back until hover.
 - **POST** — uploads/overwrites the caller's own cover photo. Auth: any authenticated user.
 - **DELETE** — deletes the caller's own cover photo file. Auth: any authenticated user.
 

--- a/apps/web/docs/map/g-public-pages.md
+++ b/apps/web/docs/map/g-public-pages.md
@@ -371,6 +371,18 @@ gradient built from their own accent rather than a blank plate; the same applies
 written by that same login path and reading `#888888` via `ensureVisible` for anyone who has never
 signed in. Styles in `roster.module.css`.
 
+**Animated avatars and covers are stills until hover.** Members with a Nitro avatar cluster at the
+top of this page (Command first), and `next/image` passes animated images through unoptimised, so the
+roster was painting full-size GIFs behind every 54px circle and repainting them for as long as the
+page stayed open — a performance trace showed a steady drumbeat of long compositor commits that
+stopped the moment the top of the roster scrolled away. The card renders stills (`stillAvatarURL`,
+and `?still=1` for GIF covers) and hands the animated URL to CSS as `--anim-avatar` / `--anim-cover`,
+which `roster.module.css` resolves *only* inside its `:hover`/`:focus-visible` rules. That placement
+is the mechanism, not a detail: a `url()` parked in an unused custom property is never fetched, so an
+idle roster downloads no GIFs at all and a hovered card fetches exactly one. Rendering both images
+and toggling `display` would have downloaded every GIF up front. Gated behind `hover: hover` (on
+touch, `:hover` sticks after a tap) and disabled under `prefers-reduced-motion`.
+
 #### app/(landing)/milpacs/nav.tsx
 Client sticky nav bar with dropdown sub-sections; smooth-scrolls to `#section-id` anchors on the
 milpacs index page.

--- a/apps/web/docs/map/h-lib-types-components.md
+++ b/apps/web/docs/map/h-lib-types-components.md
@@ -38,6 +38,10 @@ This map documents every file under `lib/**` (60 files), `types/**` (32 files), 
 - Default export `convertColorToHex(color: number): string` — decimal → `#rrggbb`.
 - `ensureVisible(hex, minLuminance=0.25)` — WCAG-luminance-based brightener; near-black → grey fallback, otherwise scales channels up to meet threshold. Used by `resolveMilpacProfile` for accent colors.
 
+### lib/discord/avatar.ts
+- `defaultAvatarURL(userId)` / `avatarURL(userId, avatarHash?, size?)` — Discord CDN URLs; the extension is `.gif` when the hash starts with `a_` (Discord's marker for an animated avatar), else `.png`.
+- `isAnimatedAvatarURL(url)` / `stillAvatarURL(url, size=128)` / `animatedAvatarURL(url, size=128)` — the still and animated spellings of one avatar. Discord serves the same hash under either extension, so no second stored field is needed. **Why they exist:** `next/image` does not optimise animated images, it passes them through byte-for-byte — the /milpacs roster was therefore serving full-size GIFs (one measured at 1.76MB) behind 54px circles and repainting all of them forever. The `.png` of that same avatar is 14KB. The URL pattern is deliberately strict rather than an `.endsWith('.gif')`: the result is interpolated into a CSS `url()` by the roster card. Unit-tested in `avatar.test.ts`, including the injection cases.
+
 ### lib/discord/index.ts
 - Exports `Client` class + default singleton instance (`client`), auto-calls `updateRoles()` on module load.
   - `updateRoles()` — refreshes `this.roles` from `Db.roles`.
@@ -258,6 +262,7 @@ This map documents every file under `lib/**` (60 files), `types/**` (32 files), 
 ### lib/military/milpac-cover.ts
 - `coverPath(memberId)` / `hasCover(memberId)` — the member's uploaded cover photo at `storage/uploads/cover/{id}.png`. Used by the milpac page (banner) and its `opengraph-image.tsx` (share-card ground). `app/api/uploads/cover/route.ts` still writes via its own cwd-relative string.
 - `coverIds(): Set<string>` — every id with a cover, from one `readdirSync`. What the /milpacs roster uses: `hasCover` is right for one member and wrong for 163, where it becomes 163 filesystem questions to answer one. Missing directory yields an empty set rather than throwing.
+- `animatedCoverIds(ids): Set<string>` — which of those covers are GIFs, by reading six magic bytes per file. Needed because the upload route writes every cover as `{id}.png` and served it as `image/png` whatever was uploaded, so the extension says nothing and browsers sniff and animate the real format regardless. GIF only (the format members actually upload); animated WebP/APNG would need real container parsing. `coverIds()` additionally filters to snowflake-shaped ids, since they reach a CSS `url()`.
 - `fitCover(srcW, srcH, boxW, boxH): CropRect` — `object-fit: cover` as a centred source rectangle. Pure; unit-tested in `milpac-cover.test.ts`.
 - `readCoverImage(memberId, box?): Promise<string|null>` — decodes the cover with `@napi-rs/canvas` (which sniffs the real format, since the upload route names every file `.png` whatever it was), crops via `fitCover`, re-encodes to a JPEG data URI at the card's 1300×630. Data URI because satori resolves neither relative paths nor `background-image: url()`; re-encoded because covers are stored unresized and base64 inflates by a third. Returns `null` on any failure — the OG route must degrade to its drawn card, never 500. `MAX_COVER_BYTES` (25MB) bounds what reaches the decoder.
 
@@ -670,7 +675,7 @@ component so the active-cell rule is unit-testable on its own.
 - Default export `InfoCard({title, children, icon?, accentColor='var(--red)', accentRgb='219,0,29'})` — bordered card with icon+uppercase title header.
 
 #### components/member/avatar.tsx
-- Default export `Avatar({user?, borderRadius='100%'})` — Discord CDN avatar `next/image` with fallback-to-`public/images/fallback_pfp.png` on load error.
+- Default export `Avatar({user?, borderRadius='100%', sizes='160px'})` — Discord CDN avatar `next/image` with fallback-to-`public/images/fallback_pfp.png` on load error. `sizes` is not optional in practice: this uses `fill`, and `fill` with no `sizes` makes next/image assume `100vw` and emit a srcset up to **3840w**, so browsers were fetching a ~2048px raster to paint a 54px circle. The default covers the largest avatar on the site (the milpac hero, 148px); callers with something smaller should say so.
 
 #### components/member/banner.tsx
 - Default export `Banner({user?})` — **currently a no-op stub** (body fully commented out, returns `undefined`). Do not assume it renders anything.

--- a/apps/web/lib/discord/avatar.test.ts
+++ b/apps/web/lib/discord/avatar.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import { animatedAvatarURL, avatarURL, isAnimatedAvatarURL, stillAvatarURL } from './avatar'
+
+const ID = '1506218564414345386'
+const ANIM = `https://cdn.discordapp.com/avatars/${ID}/a_324d6f38e3df4f475e33297a09f04077.gif`
+const STATIC = `https://cdn.discordapp.com/avatars/${ID}/324d6f38e3df4f475e33297a09f04077.png`
+
+describe('isAnimatedAvatarURL', () => {
+    it('recognises an animated Discord avatar', () => {
+        expect(isAnimatedAvatarURL(ANIM)).toBe(true)
+        expect(isAnimatedAvatarURL(`${ANIM}?size=128`)).toBe(true)
+    })
+
+    it('rejects a static avatar', () => {
+        expect(isAnimatedAvatarURL(STATIC)).toBe(false)
+    })
+
+    it('rejects absent values', () => {
+        expect(isAnimatedAvatarURL(undefined)).toBe(false)
+        expect(isAnimatedAvatarURL(null)).toBe(false)
+        expect(isAnimatedAvatarURL('')).toBe(false)
+    })
+
+    /*
+       These URLs are interpolated into a CSS `url("…")` by the roster card, so
+       the guard is a security boundary and not only a format check: anything
+       that could close the quote, close the url(), or start a new declaration
+       must not be reported as animated.
+    */
+    it('rejects anything that is not a Discord avatar URL', () => {
+        expect(isAnimatedAvatarURL('https://evil.test/x.gif')).toBe(false)
+        expect(isAnimatedAvatarURL('https://cdn.discordapp.com.evil.test/avatars/1/a_ff.gif')).toBe(false)
+        expect(isAnimatedAvatarURL('http://cdn.discordapp.com/avatars/1/a_ff.gif')).toBe(false)
+        expect(isAnimatedAvatarURL(`${ANIM}");background:url("https://evil.test/x.gif`)).toBe(false)
+        expect(isAnimatedAvatarURL(`https://cdn.discordapp.com/avatars/${ID}/a_ff.gif") no-repeat`)).toBe(false)
+        expect(isAnimatedAvatarURL(`https://cdn.discordapp.com/avatars/${ID}/../../a_ffffffff.gif`)).toBe(false)
+    })
+})
+
+describe('stillAvatarURL', () => {
+    it('swaps an animated avatar to its first frame', () => {
+        expect(stillAvatarURL(ANIM)).toBe(`https://cdn.discordapp.com/avatars/${ID}/a_324d6f38e3df4f475e33297a09f04077.png?size=128`)
+    })
+
+    it('honours an explicit size', () => {
+        expect(stillAvatarURL(ANIM, 64)).toMatch(/\.png\?size=64$/)
+    })
+
+    it('replaces rather than appends an existing size', () => {
+        expect(stillAvatarURL(`${ANIM}?size=1024`)).toMatch(/\.png\?size=128$/)
+    })
+
+    it('leaves anything else untouched', () => {
+        expect(stillAvatarURL(STATIC)).toBe(STATIC)
+        expect(stillAvatarURL(undefined)).toBeUndefined()
+        expect(stillAvatarURL(null)).toBeNull()
+    })
+})
+
+describe('animatedAvatarURL', () => {
+    it('bounds the animation to a size', () => {
+        // The unbounded original of this very avatar is 1.76 MB; the point of
+        // the size cap is that a hover can afford to fetch it.
+        expect(animatedAvatarURL(ANIM)).toBe(`https://cdn.discordapp.com/avatars/${ID}/a_324d6f38e3df4f475e33297a09f04077.gif?size=128`)
+        expect(animatedAvatarURL(ANIM, 256)).toMatch(/\.gif\?size=256$/)
+    })
+
+    it('is null when there is nothing to animate', () => {
+        expect(animatedAvatarURL(STATIC)).toBeNull()
+        expect(animatedAvatarURL(undefined)).toBeNull()
+    })
+})
+
+describe('avatarURL still agrees with the helpers', () => {
+    it('builds a .gif for an a_ hash that the helpers then recognise', () => {
+        const built = avatarURL(ID, 'a_324d6f38e3df4f475e33297a09f04077')
+        expect(isAnimatedAvatarURL(built)).toBe(true)
+        expect(stillAvatarURL(built)).toMatch(/\.png\?size=128$/)
+    })
+
+    it('builds a .png for a normal hash, which is left alone', () => {
+        const built = avatarURL(ID, '324d6f38e3df4f475e33297a09f04077')
+        expect(isAnimatedAvatarURL(built)).toBe(false)
+        expect(stillAvatarURL(built)).toBe(built)
+    })
+})

--- a/apps/web/lib/discord/avatar.ts
+++ b/apps/web/lib/discord/avatar.ts
@@ -12,3 +12,50 @@ export function avatarURL(userId: string, avatarHash?: string | null, size?: num
     const ext = avatarHash.startsWith('a_') ? 'gif' : 'png'
     return `https://cdn.discordapp.com/avatars/${userId}/${avatarHash}.${ext}${size ? `?size=${size}` : ''}`
 }
+
+/**
+ * Animated avatars, and how to ask Discord for a still of one.
+ *
+ * Discord encodes "this avatar is animated" in the hash (`a_` prefix), and
+ * serves the *same* hash under either extension: `.gif` animates, `.png` is the
+ * first frame. That is how Discord's own client shows a still avatar in a
+ * member list and animates it on hover, and it is why none of this needs a
+ * second stored field — the still and the animation are two spellings of one
+ * URL we already have.
+ *
+ * Why it matters here: `next/image` does not optimise animated images, it
+ * passes them through byte-for-byte. A roster of 163 members was therefore
+ * shipping full-size GIFs — one measured at 1.76 MB — and repainting every one
+ * of them forever behind a 54px circle. The `.png` of that same avatar is 14 KB.
+ *
+ * The pattern is deliberately strict rather than a `.endsWith('.gif')`: these
+ * URLs are interpolated into a CSS `url()` by the roster card, so anything that
+ * is not recognisably a Discord avatar must fall out here rather than reach a
+ * stylesheet.
+ */
+const ANIMATED_AVATAR = /^https:\/\/cdn\.discordapp\.com\/avatars\/\d{5,25}\/a_[0-9a-fA-F]{8,64}\.gif(?:\?[\w=&-]*)?$/
+
+export function isAnimatedAvatarURL(url?: string | null): boolean {
+    return typeof url === 'string' && ANIMATED_AVATAR.test(url)
+}
+
+/**
+ * The non-animating form of an avatar URL — the first frame, at a sane size.
+ *
+ * Anything that is not an animated Discord avatar is returned untouched, so
+ * this is safe to wrap around every avatar rather than only the animated ones.
+ */
+export function stillAvatarURL(url?: string | null, size = 128): string | null | undefined {
+    if (!isAnimatedAvatarURL(url)) return url
+    return url!.replace(/\.gif(?:\?.*)?$/, `.png?size=${size}`)
+}
+
+/**
+ * The animating form, bounded to `size`, or null when there is nothing to
+ * animate. The size cap is not cosmetic: it is the difference between the
+ * 1.76 MB original and something a hover can afford to fetch.
+ */
+export function animatedAvatarURL(url?: string | null, size = 128): string | null {
+    if (!isAnimatedAvatarURL(url)) return null
+    return url!.replace(/\.gif(?:\?.*)?$/, `.gif?size=${size}`)
+}

--- a/apps/web/lib/military/milpac-cover.ts
+++ b/apps/web/lib/military/milpac-cover.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync, readFileSync } from 'fs'
+import { existsSync, readdirSync, statSync, readFileSync, openSync, readSync, closeSync } from 'fs'
 import { join } from 'path'
 
 /**
@@ -37,7 +37,14 @@ export function coverIds(): Set<string> {
         return new Set(
             readdirSync(coverDir())
                 .filter(name => name.endsWith('.png'))
-                .map(name => name.slice(0, -'.png'.length)),
+                .map(name => name.slice(0, -'.png'.length))
+                // Snowflakes only. Covers are written as `{me.id}.png` by an
+                // authenticated upload, so anything else in this directory is
+                // not a member's cover — and these ids are interpolated into a
+                // URL that the roster card hands to CSS `url()`, which is not a
+                // place to forward an arbitrary filename. The serving route
+                // rejects the same shape, so such a file is unreachable anyway.
+                .filter(id => /^\d{5,25}$/.test(id)),
         )
     } catch {
         return new Set()
@@ -129,4 +136,47 @@ export async function readCoverImage(memberId: string, box = CARD): Promise<stri
     } catch {
         return null
     }
+}
+
+/**
+ * Which of those covers are animated.
+ *
+ * The upload route writes every cover to `{id}.png` and serves it as
+ * `image/png` whatever was actually uploaded, so the extension says nothing —
+ * a member who uploads a GIF gets a GIF stored under a .png name, and browsers
+ * sniff the real format and animate it regardless of the header we send.
+ *
+ * The roster needs to know because an animated cover is the same problem as an
+ * animated avatar: next/image passes animated images straight through, so the
+ * card ends up repainting a full-size GIF behind every visible tile forever.
+ * Knowing which covers animate lets the card ask for a still and hold the
+ * animation back until hover.
+ *
+ * GIF only, deliberately. It is the format members actually upload and the only
+ * one Discord itself produces; animated WebP and APNG would need real container
+ * parsing to detect and would still be served correctly here, just without the
+ * hover treatment.
+ */
+export function animatedCoverIds(ids: Iterable<string>): Set<string> {
+    const animated = new Set<string>()
+
+    for (const id of ids) {
+        // Six bytes per cover, not the whole file: this runs for every member
+        // with a cover on every render of the roster, and the magic number is
+        // the first six bytes of a GIF ("GIF87a" / "GIF89a").
+        let fd: number | undefined
+        try {
+            fd = openSync(coverPath(id), 'r')
+            const head = Buffer.alloc(6)
+            readSync(fd, head, 0, 6, 0)
+            if (head.toString('latin1').startsWith('GIF8')) animated.add(id)
+        } catch {
+            // Unreadable or vanished between the readdir and here — not
+            // animated as far as the page is concerned.
+        } finally {
+            if (fd !== undefined) try { closeSync(fd) } catch { }
+        }
+    }
+
+    return animated
 }


### PR DESCRIPTION
Fixes the client-side stall on `/milpacs`. A performance trace showed a steady drumbeat of long tasks, each ending in a `Commit`, that stopped the moment the top of the roster scrolled out of view.

> [!WARNING]
> Merging this deploys. `.github/workflows/deploy.yml` fires on every push to `main` and runs `docker compose up -d --build` on the server, with no CI gate in front of it.

## Cause

`next/image` **does not optimise animated images — it passes them through byte-for-byte.** Measured against production, not assumed:

| | bytes | content-type |
|---|---|---|
| Next serving one roster avatar | **1,763,361** | `image/gif` |
| Discord's original | **1,763,361** | `image/gif` — *identical* |
| `.png` of the same hash, `?size=128` | **14,349** | `image/png` |

That 1.76 MB GIF was being decoded and resampled into a **54px circle**, continuously, for as long as the page stayed open. Members with a Nitro avatar cluster at the top of the roster (Command renders first), so the first screen carried nearly all of them — which is exactly why the lag disappeared after scrolling past.

## Fix

Discord serves an animated avatar's hash under either extension: `.gif` animates, `.png` is the first frame. It is how Discord's own client shows a still in a member list and animates on hover, and it means no new stored field.

The roster paints stills and hands the animated URL to CSS as a custom property that is resolved **only** inside the `:hover` / `:focus-visible` rule. That placement is the mechanism, not a detail: a `url()` parked in an unused custom property is never fetched, so an **idle roster downloads no GIFs at all** and a hovered card fetches exactly one, size-capped. Rendering both images and toggling `display` would have downloaded every GIF on the page up front.

Covers get the same treatment. They are stored as `{id}.png` whatever was uploaded, so the extension says nothing and browsers sniff and animate the real bytes regardless — **1 of the 28 live covers is a GIF**. `animatedCoverIds` finds them from six magic bytes each, and `/api/uploads/cover` grew `?still=1` to return a decoded first frame.

Gated behind `hover: hover` (on touch, `:hover` sticks after a tap) and disabled under `prefers-reduced-motion`.

## Two further problems found while measuring

Both were costing independently of the GIFs, so they are fixed here:

- **`Avatar` used `fill` with no `sizes`**, so next/image assumed `100vw` and emitted a srcset up to **3840w**. Browsers were picking a ~2048px raster to paint a 54px circle — on every avatar on the site, animated or not, on every page that renders one. This should help well beyond `/milpacs`.
- **`/api/uploads/cover` had a path traversal.** `?id=` was interpolated straight into a filesystem path, so `?id=../../../../etc/passwd` resolved. Now snowflakes only, and `Content-Type` is sniffed rather than always claiming `image/png` for files that are demonstrably GIFs.

## Verification

- `npm run lint` — no warnings or errors
- `npx tsc --noEmit` — clean
- `npx vitest run` — **412 passed** (12 new in `lib/discord/avatar.test.ts`)
- `npm run build` — compiled successfully

The new URL parser is deliberately strict rather than an `.endsWith('.gif')`, because its output is interpolated into a CSS `url()` by the roster card. The injection cases (quote-breaking, `url()`-closing, lookalike hosts, scheme downgrade) are covered by tests.

Playwright E2E was not run. This touches no page gate, permission key or sidebar visibility; `/api/uploads/cover` gained input validation but no auth change.

## Not addressed

- Covers are served `Cache-Control: no-cache`, so they refetch on every navigation. Worth revisiting, but it trades against a member seeing their own upload immediately — a product call rather than a perf one.
- The improvement is reasoned and measured at the byte level, **not re-traced**. Confirmation is loading `/milpacs` and recording again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)