### PR TITLE
copy(web): stop advertising a recruiting status that never changes

### DIFF
--- a/apps/web/app/(landing)/_components/EnlistBand.tsx
+++ b/apps/web/app/(landing)/_components/EnlistBand.tsx
@@ -56,7 +56,7 @@ export default function EnlistBand() {
                 </div>
 
                 <div className={s.enlistCta}>
-                    <div className={s.t}>Applications are open.</div>
+                    <div className={s.t}>Ready when you are.</div>
                     <div className={s.btns}>
                         <EnlistButton>Enlist now <ArrowIcon /></EnlistButton>
                         <Button variant='discord' href='https://discord.gg/asot' external>

--- a/apps/web/app/(landing)/_components/Hero.tsx
+++ b/apps/web/app/(landing)/_components/Hero.tsx
@@ -173,7 +173,7 @@ export default function Hero({ sotm, roster, opCard }: {
                     <div className={s.heroFacts}>
                         {roster != null && <span><Pulse /> <b>{roster}</b> active members</span>}
                         <span><b>2</b> ops per week</span>
-                        <span><b>Applications open</b></span>
+                        <span><b>17+</b> to enlist</span>
                     </div>
                 </div>
 

--- a/apps/web/app/(landing)/_components/Platoons.tsx
+++ b/apps/web/app/(landing)/_components/Platoons.tsx
@@ -15,26 +15,24 @@ import s from '@/styles/landing.module.css'
  * The three platoons.
  *
  * The member and section counts are live off the ORBAT rather than written
- * into the copy, so a card can't quietly go stale — and together with the
- * recruiting chip they answer the question the old cards didn't: "can I
- * actually join this one".
+ * into the copy, so a card can't quietly go stale. There is no recruiting
+ * status chip: every platoon is permanently open, so the slot only ever said
+ * one thing, and the ORBAT holds no establishment ceiling to make it a real
+ * figure instead.
  */
 
 const PLATOONS = [
     {
         id: 'platoon11', number: '1-1', role: 'Infantry', image: Droneteam7,
         body: 'Our primary infantry platoon and the main fighting force of the taskforce — three eight-man sections and a four-man headquarters, across a wide range of weapons, vehicles and equipment.',
-        recruiting: 'Open',
     },
     {
         id: 'platoon12', number: '1-2', role: 'Infantry', image: SPEAR_OVERCAST_Final,
         body: 'Mirrors the structure and role of 1-1 as a second core infantry platoon. Three eight-man sections and a four-man headquarters handling tactical operations across every environment.',
-        recruiting: 'Open',
     },
     {
         id: 'support', number: '1-3', role: 'Support', image: Mike1440,
         body: 'The support platoon — combat engineering, indirect fire, rotary air support, medical and armoured cavalry. Specialised teams that give every mission its operational flexibility.',
-        recruiting: 'Open',
     },
 ]
 
@@ -69,7 +67,6 @@ export default function Platoons({ stats }: { stats: PlatoonStat[] }) {
                                     <div className={s.stats}>
                                         <span><b>{stat?.members ?? '—'}</b>Members</span>
                                         <span><b>{stat?.sections ?? '—'}</b>Sections</span>
-                                        <span><b>{p.recruiting}</b>Recruiting</span>
                                     </div>
                                     <Button variant='red' size='sm' href={`/about/callsigns#${p.number}`}>
                                         Learn more <ArrowIcon />

--- a/apps/web/app/footer.tsx
+++ b/apps/web/app/footer.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import Image from 'next/image'
 
 import Button from '@/components/ui/Button'
-import Pulse from '@/components/ui/Pulse'
 import { CrateIcon, DiscordIcon, SteamIcon, YouTubeIcon, MailIcon } from '@/components/ui/icons'
 import Signature from '@/components/signature'
 import CreditsModal from '@/components/credits-modal'
@@ -134,10 +133,6 @@ export default async function Footer() {
                         <div className={s.r}>
                             <span>Active</span>
                             <b>{roster ?? '—'}</b>
-                        </div>
-                        <div className={s.r}>
-                            <span>Applications</span>
-                            <b className={s.g}><Pulse />Open</b>
                         </div>
                         <Button variant='amber' size='sm' href='/donate' block>
                             <CrateIcon /> Support the unit

--- a/apps/web/styles/footer.module.css
+++ b/apps/web/styles/footer.module.css
@@ -224,10 +224,6 @@
     gap: 7px;
 }
 
-.status .r b.g {
-    color: var(--live);
-}
-
 .status .r b.a {
     color: var(--amber);
 }


### PR DESCRIPTION
Four places on the public site asserted that applications were open — a status that has never been anything else and never will be. Stating it spends a slot on nothing, and implies it could flip.

### Changes

| Where | Before | After |
|---|---|---|
| `_components/Hero.tsx` | `Applications open` | **17+** to enlist |
| `_components/EnlistBand.tsx` | "Applications are open." | "Ready when you are." |
| `_components/Platoons.tsx` | `Open` / Recruiting ×3 | chip removed |
| `app/footer.tsx` | `Applications` / ● Open | row removed |

**Hero** gains a hard requirement stated nowhere else on the page, and `<b>17+</b> to enlist` restores the `<b>value</b> label` shape its two siblings already use — `Applications open` was the only chip bolded whole, which is why it read as a banner rather than a fact.

**The enlist band's** CTA line becomes a prompt rather than a fact. Everything true and useful that could go there — no experience needed, the 48-hour reply — is already on screen in the lede and Step 01 directly above it.

**The platoon cards** drop the chip outright. `PlatoonStat` carries only `members` and `sections`, so with no establishment ceiling anywhere in the ORBAT there is no honest figure to put in its place.

**The footer** is the one worth a second look. That panel is a live board — next op, sign-ons and active headcount all come from the `lib/landing` loaders. The Applications row sat among them showing a constant while wearing the green `Pulse` dot the ops board uses to mean "happening right now", borrowing the visual grammar of live data for something static. Removed rather than reworded: the panel is titled *Unit status*, and a permanent entry requirement is not a status. The hero carries the 17+ figure and the Joining column already links to Enlist, so neither the fact nor the path is lost. Takes the footer's only `Pulse` import and the now-dead `.status .r b.g` rule with it.

### Testing

Copy and markup only — no data-layer, type or prop changes. `tsc --noEmit` and lint both clean. `s.heroFacts` and `s.stats` are flex rows that reflow on their own, so no layout CSS needed touching.

### Not in scope

- `join/page.tsx` carries the same `Applications` / `Open` masthead status. Left for a follow-up.
- That same aside lists `Location: AU / NZ`, while `WhySection.tsx` says recruits join "from across Australia, New Zealand and **Asia**." Those two disagree and someone should decide which is the real policy — it's the kind of thing an applicant in Singapore reads as "not for me."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
