### PR TITLE
Public pages: donate, contact, and a topo backdrop that actually moves

### DIFF
--- a/apps/web/app/(landing)/about/contact/next-op-figure.tsx
+++ b/apps/web/app/(landing)/about/contact/next-op-figure.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { formatUntil } from '@/lib/contact/countdown'
+
+/**
+ * The countdown tile's figure.
+ *
+ * The server renders one value and hands it over as `initial`, which is also
+ * this component's first state — so the server HTML and the first client render
+ * are identical and there is no hydration mismatch to dodge. `Countdown` in
+ * components/ui solves the same problem by rendering an empty box until it
+ * mounts, which is right for a four-cell clock and wrong for the largest number
+ * on the panel: it would pop in.
+ *
+ * Thirty seconds, matching the navbar rail. The figure loses its minutes past
+ * the first day anyway, so a faster tick would repaint the same string.
+ */
+export default function NextOpFigure({ target, initial }: {
+    target: string
+    initial: string
+}) {
+    const [figure, setFigure] = useState(initial)
+
+    useEffect(() => {
+        const tick = () => setFigure(formatUntil(target, Date.now()) ?? initial)
+        tick()
+        const id = setInterval(tick, 30_000)
+        return () => clearInterval(id)
+    }, [target, initial])
+
+    return <>{figure}</>
+}

--- a/apps/web/app/(landing)/about/contact/page.tsx
+++ b/apps/web/app/(landing)/about/contact/page.tsx
@@ -3,85 +3,151 @@ import Link from 'next/link'
 import React from 'react'
 
 import SectionHead from '@/components/ui/SectionHead'
+import Topo from '@/components/ui/Topo'
+import Pulse from '@/components/ui/Pulse'
+import { DiscordIcon } from '@/components/ui/icons'
+import { formatUntil } from '@/lib/contact/countdown'
+import { getFeaturedOp, getRosterCount } from '@/lib/landing'
+import { getOnlineCache } from '@/lib/teamspeak/cache'
 import s from '@/styles/shell.module.css'
 import AboutShell from '../shell'
+import NextOpFigure from './next-op-figure'
 
 export const metadata: Metadata = {
-	title: "Contact | Australian Special Operations Taskforce",
-	description: "Get in touch with the Australian Special Operations Taskforce leadership and staff team.",
+	title: 'Contact | Australian Special Operations Taskforce',
+	description: 'Get in touch with the Australian Special Operations Taskforce leadership and staff team.',
 }
 
-function Channel({ mark, title, accent, href, label, description, external }: {
-	mark: string
-	title: string
-	accent: string
-	href: string
-	label: string
-	description: string
-	external?: boolean
-}) {
-	return (
-		<Link
-			href={href as any}
-			target={external ? '_blank' : '_self'}
-			className={s.channel}
-			style={{ '--acc': accent } as React.CSSProperties}
-		>
-			<div className={s.channelH}><i aria-hidden='true'>{mark}</i><b>{title}</b></div>
-			<p>{description}</p>
-			<span className={s.channelV}>{label}</span>
-		</Link>
-	)
-}
+/*
+   The page opened on an embedded Discord widget: a third-party iframe carrying
+   Discord's blurple, Discord's type, Discord's button and a scrolling list of
+   our members' display names, published to anyone who loaded the page. It was
+   also the only element doing any visual work, which is why everything around
+   it read as thin.
 
-export default function Tab() {
+   What it genuinely provided was proof the place is alive, and that is worth
+   keeping — so it is replaced by the same proof told in our own numbers. All
+   three already exist for the navbar rail (app/api/nav/status), and this page
+   is a server component, so it reads the loaders directly rather than going
+   back out through the route.
+*/
+
+export const dynamic = 'force-dynamic'
+
+export default async function Tab() {
+	const [nextOp, roster] = await Promise.all([
+		getFeaturedOp().catch(() => null),
+		getRosterCount().catch(() => null),
+	])
+
+	// In-process cache filled by the teamspeak-cache cron. Cold on a fresh boot,
+	// which is a different thing from "nobody is connected" — null renders the
+	// tile as unknown rather than as an honest-looking zero.
+	const online = getOnlineCache()?.clients.length ?? null
+
+	const until = nextOp ? formatUntil(nextOp.date, Date.now()) : null
+
 	return (
 		<AboutShell page='contact'>
-		<section>
-			<SectionHead kicker='Get in touch' title='Contact us' />
 
-			<div className={s.channels}>
-				<Channel
-					mark='TS'
-					title='TeamSpeak'
-					accent='#00bcd4'
-					href='ts3server://ts.asotmilsim.com'
-					label='ts.asotmilsim.com'
-					description='Join our TeamSpeak server for real-time voice communications during operations.'
-				/>
-				<Channel
-					mark='f'
-					title='Facebook'
-					accent='#1877F2'
-					href='https://www.facebook.com/AustralianSpecialOperationsTaskforce'
-					label='AustralianSpecialOperationsTaskforce'
-					description='Follow us on Facebook for updates, event announcements, and community news.'
-					external
-				/>
-				<Channel
-					mark='@'
-					title='Email'
-					accent='rgb(219,0,29)'
-					href='mailto:australianspecialoperationstaskforce@hotmail.com'
-					label='australianspecialoperationstaskforce@hotmail.com'
-					description='Send us a direct message for any inquiries, applications, or general questions.'
-				/>
-			</div>
-		</section>
+			<section>
+				<div className={s.presence}>
+					<Topo opacity={0.06} driftSeconds={900} mask='fade' />
 
-		<section className={s.widget}>
-			<div className={s.channelH}>
-				<i aria-hidden='true' style={{ color: 'var(--discord)' }}>D</i>
-				<div>
-					<b>Discord</b>
-					<p style={{ marginTop: 2 }}>Our primary community hub — join to connect with members, ask questions, and stay up to date.</p>
+					<div className={s.presenceH}>
+						<Pulse tone={online ? 'live' : 'idle'} />
+						<span>Right now</span>
+						<b>Live from our own servers</b>
+					</div>
+
+					<div className={s.presenceGrid}>
+						<div className={s.presenceCell}>
+							<div className={s.presenceK}>On TeamSpeak</div>
+							<div className={`${s.presenceN} ${online ? s.presenceNLive : s.presenceNIdle}`}>
+								{online ?? '—'}
+							</div>
+							<p>
+								{online
+									? 'Members in voice as you read this. Anyone can drop in and listen.'
+									: 'Nobody in voice at the moment. Post in the Discord — someone picks it up.'}
+							</p>
+						</div>
+
+						<div className={s.presenceCell}>
+							<div className={s.presenceK}>Active roster</div>
+							<div className={s.presenceN}>{roster ?? '—'}</div>
+							<p>Members holding a posting in the ORBAT, reservists excluded.</p>
+						</div>
+
+						<div className={s.presenceCell}>
+							<div className={s.presenceK}>Next operation</div>
+							<div className={`${s.presenceN} ${until ? s.presenceNAmber : s.presenceNIdle}`}>
+								{nextOp && until
+									? <NextOpFigure target={nextOp.date} initial={until} />
+									: '—'}
+							</div>
+							<p>
+								{nextOp
+									? <>{nextOp.title} — <Link href={`/operations/${nextOp.id}` as any}>see the board</Link>.</>
+									: 'Nothing on the board yet. Two run most weeks, posted a few days out.'}
+							</p>
+						</div>
+					</div>
 				</div>
-			</div>
-			<iframe
-				title='ASOT Discord'
-				src='https://discord.com/widget?id=744518510092484660&theme=dark'
-			/>
-		</section>
+
+				<p className={s.presenceLede}>
+					There is almost always someone about. The fastest way to reach us is to walk in
+					and say hello — and if it is about joining, <Link href='/join'>J1 would rather
+					have your application</Link> than a message.
+				</p>
+			</section>
+
+			<section>
+				<SectionHead kicker='Ways in' title='Walk in anywhere' />
+
+				<div className={s.channels}>
+					<Link href='https://discord.gg/asot' target='_blank' className={s.channel} style={{ '--acc': 'var(--discord)' } as React.CSSProperties}>
+						<div className={s.channelH}>
+							<i aria-hidden='true'><DiscordIcon /></i>
+							<b>Discord</b>
+							<em>Start here</em>
+						</div>
+						<p>Our primary community hub — join to connect with members, ask questions, and stay up to date.</p>
+						<span className={s.channelV}>discord.gg/asot</span>
+					</Link>
+
+					<Link href={'ts3server://ts.asotmilsim.com' as any} className={s.channel} style={{ '--acc': '#00bcd4' } as React.CSSProperties}>
+						<div className={s.channelH}>
+							<i aria-hidden='true'>TS</i>
+							<b>TeamSpeak</b>
+							{online != null && online > 0 && (
+								<em className={s.channelLive}><Pulse />{online} online</em>
+							)}
+						</div>
+						<p>Join our TeamSpeak server for real-time voice communications during operations.</p>
+						<span className={s.channelV}>ts.asotmilsim.com</span>
+					</Link>
+
+					<Link href='mailto:australianspecialoperationstaskforce@hotmail.com' className={s.channel} style={{ '--acc': 'var(--red)' } as React.CSSProperties}>
+						<div className={s.channelH}>
+							<i aria-hidden='true'>@</i>
+							<b>Email</b>
+						</div>
+						<p>Send us a direct message for any inquiries, applications, or general questions.</p>
+						<span className={s.channelV}>australianspecialoperationstaskforce@hotmail.com</span>
+					</Link>
+
+					<Link href='https://www.facebook.com/AustralianSpecialOperationsTaskforce' target='_blank' className={s.channel} style={{ '--acc': 'var(--line-2)' } as React.CSSProperties}>
+						<div className={s.channelH}>
+							<i aria-hidden='true'>f</i>
+							<b>Facebook</b>
+						</div>
+						<p>Follow us on Facebook for updates, event announcements, and community news.</p>
+						<span className={s.channelV}>AustralianSpecialOperationsTaskforce</span>
+					</Link>
+				</div>
+			</section>
+
 		</AboutShell>
 	)
 }

--- a/apps/web/app/(landing)/donate/page.tsx
+++ b/apps/web/app/(landing)/donate/page.tsx
@@ -1,49 +1,59 @@
-import { Metadata } from "next"
-import Link from 'next/link'
+import { Metadata } from 'next'
+import Image from 'next/image'
 
-import { Typography, Button, Divider } from '@mui/material'
-import { VolunteerActivism, FavoriteBorder, InfoOutlined, AccountBalance, HelpOutline, CardGiftcard, Gavel } from '@mui/icons-material'
-
-import Container from "@/components/container"
+import Button from '@/components/ui/Button'
+import List from '@/components/ui/List'
+import QaRow, { QaStack } from '@/components/ui/QaRow'
+import SectionHead, { Kicker } from '@/components/ui/SectionHead'
+import Topo from '@/components/ui/Topo'
+import { CrateIcon } from '@/components/ui/icons'
 
 import Banner from '@/public/images/home/Rooftopincert.jpg'
-
-
+import s from '@/styles/donate.module.css'
 
 export const metadata: Metadata = {
-	title: "Donate | Australian Special Operations Taskforce",
-	description: "Support the Australian Special Operations Taskforce — contributions help cover server and community infrastructure costs.",
+	title: 'Donate | Australian Special Operations Taskforce',
+	description: 'Support the Australian Special Operations Taskforce — contributions help cover server and community infrastructure costs.',
 }
 
-const infoCards = [
+/*
+   The one page that asks for something.
+
+   It does not render Container: see the note at the top of donate.module.css
+   for why the shared masthead is the wrong shell for a page that is pitched at
+   rather than read. Everything else on it is the standard vocabulary — the
+   notched button, the Q&A rows the FAQ uses, the real list Rules uses.
+*/
+
+const PAYPAL = 'https://www.paypal.com/donate?business=JLAN3RDW9BEAJ&no_recurring=0&item_name=Thankyou from the bottom of our hearts for supporting ASOT. Every cents goes towards ASOT costs or other features.&currency_code=AUD'
+
+/* Verbatim from the page this replaces. The five answers are the whole of what
+   a donor needs before pressing the button, which is why they are the body of
+   the page rather than a sidebar on it. */
+const NOTES = [
 	{
-		icon: <FavoriteBorder />,
-		title: 'How Donations Help',
-		body: 'There are expenses for running a community such as ASOT which can add up quite a bit over the year. In no way do we expect members to donate — it is not a joining requirement.'
+		q: 'How donations help',
+		a: 'There are expenses for running a community such as ASOT which can add up quite a bit over the year. In no way do we expect members to donate — it is not a joining requirement.',
 	},
 	{
-		icon: <InfoOutlined />,
-		title: 'What is a Donation?',
-		body: 'A donation is a gift given without return consideration. As the donator, you should expect no item or service to be given in return, now or in the future.'
+		q: 'What is a donation?',
+		a: 'A donation is a gift given without return consideration. As the donator, you should expect no item or service to be given in return, now or in the future.',
 	},
 	{
-		icon: <AccountBalance />,
-		title: 'How ASOT Uses Donations',
-		body: 'All donations enter an account used to pay for server-related bills such as the virtual server, ArmA clans, TeamSpeak licenses, and website domains.'
+		q: 'How ASOT uses donations',
+		a: 'All donations enter an account used to pay for server-related bills such as the virtual server, ArmA clans, TeamSpeak licenses, and website domains.',
 	},
 	{
-		icon: <HelpOutline />,
-		title: 'Where Do I Donate?',
-		body: 'Donate via the secure PayPal button above. This will take you off our site to PayPal, where your donation is securely processed.'
+		q: 'Where do I donate?',
+		a: 'Donate via the secure PayPal button above. This will take you off our site to PayPal, where your donation is securely processed.',
 	},
 	{
-		icon: <CardGiftcard />,
-		title: 'What Will You Receive?',
-		body: 'At this stage, due to the nature of our community and Bohemia\'s EULA regarding in-game rewards, nothing will be given to you as a donator on our servers.'
+		q: 'What will you receive?',
+		a: 'At this stage, due to the nature of our community and Bohemia\'s EULA regarding in-game rewards, nothing will be given to you as a donator on our servers.',
 	},
 ]
 
-const conditions = [
+const CONDITIONS = [
 	'Under no circumstance will your donation be disputed or refunded.',
 	'Any incentive for donation can be removed, edited or added without notice.',
 	'Your donation does not in any way exempt you from following the SOPs and rules expected of other members.',
@@ -52,100 +62,72 @@ const conditions = [
 	'Your donation is a contribution to ASOT, held on behalf of thomasdean92@hotmail.com, used solely for server costs and operating expenses.',
 ]
 
-
-
 export default function Page() {
 	return (
-		<Container title="DONATE TO ASOT" kicker="Support the unit" subtitle="Any donations are appreciated and will entirely go towards covering the costs of the community." background={Banner} sx={{ bannerHeight: 'md', maxWidth: 'max-w-6xl' }}>
+		<div className={s.page}>
 
-			{/* PayPal CTA */}
-			<div style={{
-				border: '1px solid rgba(34,112,221,0.25)',
-				borderTop: '2px solid #2270dd',
-				background: 'rgba(34,112,221,0.04)',
-				padding: '2rem',
-				display: 'flex',
-				flexDirection: 'column',
-				alignItems: 'center',
-				gap: '1rem',
-				textAlign: 'center',
-			}}>
-				<VolunteerActivism style={{ fontSize: 40, color: '#2270dd', opacity: 0.85 }} />
-				<div>
-					<Typography variant='h5' fontWeight={700} letterSpacing={2} align="center" style={{ textTransform: 'uppercase' }}>Support ASOT</Typography>
-					<Typography style={{ color: 'rgba(237,237,237,0.55)', marginTop: 4, fontSize: '0.9rem' }}>
-						Every cent goes directly to keeping ASOT running.
-					</Typography>
+			<header className={s.band}>
+				<div className={s.bandImg}>
+					<Image src={Banner} alt='' fill priority placeholder='blur' style={{ objectFit: 'cover' }} />
 				</div>
-				<Link href="https://www.paypal.com/donate?business=JLAN3RDW9BEAJ&no_recurring=0&item_name=Thankyou from the bottom of our hearts for supporting ASOT. Every cents goes towards ASOT costs or other features.&currency_code=AUD" target='_blank'>
-					<Button
-						variant='contained'
-						size='large'
-						startIcon={<VolunteerActivism />}
-						style={{ background: '#2270dd', paddingLeft: 32, paddingRight: 32, letterSpacing: 1 }}
-					>
-						Donate with PayPal
+
+				{/* The mask shares its stops with the veil's ellipse. */}
+				<Topo opacity={0.075} driftSeconds={900} mask='edges' />
+				<div className={s.veil} />
+
+				<div className={s.bandIn}>
+					<Kicker centred>Support the unit</Kicker>
+					<h1 className={s.title}>Keep it<br />running</h1>
+					<p className={s.lede}>
+						Every cent goes to the servers, the licences and the domains. Nothing on
+						this site is behind a donation.
+					</p>
+
+					<Button variant='amber' href={PAYPAL} external className={s.cta}>
+						<CrateIcon /> Donate with PayPal
 					</Button>
-				</Link>
-			</div>
 
-			{/* Info Cards */}
-			<div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4'>
-				{infoCards.map((card, i) => {
-					const lgCol = ['lg:[grid-column:1/3]', 'lg:[grid-column:3/5]', 'lg:[grid-column:5/7]', 'lg:[grid-column:2/4]', 'lg:[grid-column:4/6]']
-					return (
-					<div key={card.title} className={lgCol[i]} style={{
-						border: '1px solid rgba(219,0,29,0.15)',
-						borderTop: '2px solid var(--red)',
-						background: 'rgba(219,0,29,0.03)',
-						padding: '1.25rem',
-						display: 'flex',
-						flexDirection: 'column',
-						gap: '0.75rem',
-					}}>
-						<div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-							<span style={{ color: 'var(--red)', display: 'flex', opacity: 0.85 }}>{card.icon}</span>
-							<Typography fontWeight={600} fontSize='0.8rem' letterSpacing={2} style={{ textTransform: 'uppercase' }}>
-								{card.title}
-							</Typography>
-						</div>
-						<Divider style={{ borderColor: 'rgba(219,0,29,0.15)' }} />
-						<Typography style={{ color: 'rgba(237,237,237,0.6)', fontSize: '0.875rem', lineHeight: 1.6 }}>
-							{card.body}
-						</Typography>
+					<div className={s.assure}>
+						<span>Secure</span>
+						<i />
+						<span>AUD</span>
+						<i />
+						<span>Processed off-site by PayPal</span>
 					</div>
-				)})}
-			</div>
-
-			{/* Conditions */}
-			<div style={{
-				border: '1px solid rgba(255,255,255,0.08)',
-				borderLeft: '3px solid rgba(219,0,29,0.5)',
-				background: 'rgba(255,255,255,0.02)',
-				padding: '1.5rem',
-				display: 'flex',
-				flexDirection: 'column',
-				gap: '1rem',
-			}}>
-				<div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-					<Gavel style={{ color: 'var(--red)', fontSize: 20, opacity: 0.8 }} />
-					<Typography fontWeight={600} fontSize='0.8rem' letterSpacing={2} style={{ textTransform: 'uppercase' }}>
-						Conditions of Donating
-					</Typography>
 				</div>
-				<Divider style={{ borderColor: 'rgba(255,255,255,0.08)' }} />
-				<div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-					{conditions.map((condition, i) => (
-						<div key={i} style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
-							<span style={{ color: 'var(--red)', fontSize: '0.75rem', marginTop: 3, flexShrink: 0 }}>▸</span>
-							<Typography style={{ color: 'rgba(237,237,237,0.5)', fontSize: '0.825rem', lineHeight: 1.6 }}>
-								{condition}
-							</Typography>
-						</div>
-					))}
-				</div>
-			</div>
 
-		</Container>
+				<div className={s.cue} aria-hidden='true'>
+					<span>What this means</span>
+					<i />
+				</div>
+			</header>
+
+			<div className={s.doc}>
+
+				<section>
+					<SectionHead kicker='Before you give' title='Five things, plainly' />
+					<QaStack>
+						{NOTES.map((note, i) => (
+							<QaRow key={note.q} index={String(i + 1).padStart(2, '0')} question={note.q}>
+								<p>{note.a}</p>
+							</QaRow>
+						))}
+					</QaStack>
+				</section>
+
+				<section>
+					<SectionHead kicker='Annex A' title='Conditions of donating' />
+					<List items={CONDITIONS} />
+				</section>
+
+				<div className={s.close}>
+					<p className={s.closeLine}>Now you know where it goes.</p>
+					<Button variant='amber' href={PAYPAL} external>
+						<CrateIcon /> Donate with PayPal
+					</Button>
+				</div>
+
+			</div>
+		</div>
 	)
 }

--- a/apps/web/components/ui/Topo.tsx
+++ b/apps/web/components/ui/Topo.tsx
@@ -48,12 +48,27 @@ import s from '@/styles/ui.module.css'
    relative to the high ones, which is what gives it relief.
 */
 const LEVELS = 30         // contour lines across the field
-const WEIGHT = 1.25          // px, before the index multiplier
+const WEIGHT = 1.3        // px, before the index multiplier
 const WARP = 0.55         // domain-warp strength — the twisting
 const INDEX_EVERY = 4     // heavier line every Nth contour
 const INDEX_BOOST = 2.15  // its opacity multiplier
 const INDEX_WEIGHT = 1.85 // its line-weight multiplier
 const DEPTH = 0.6         // how much brighter high ground reads
+
+/*
+   A floor under the depth ramp, as a fraction of an unfaded line.
+
+   DEPTH alone ran the lowest contours down to 0.61 of full strength, and with
+   no index boost on them either, the plain low lines came out at roughly a
+   quarter of an index line and simply vanished. Relief is worth having;
+   contours you cannot see are not relief, they are absence.
+
+   Clamping rather than reducing DEPTH keeps the ramp intact everywhere it is
+   doing visible work — only the bottom third, where it had gone too far, is
+   held up. Raise this if the faint lines still disappear; lower it toward 0.61
+   for the original, more dramatic falloff.
+*/
+const FAINTEST = 0.8
 
 /*
    The one global lever on how present the field is anywhere.
@@ -68,7 +83,7 @@ const DEPTH = 0.6         // how much brighter high ground reads
    and index contours take another INDEX_BOOST on top. So `opacity={0.05}`
    draws ordinary lines at 0.031-0.06 and its index lines at up to 0.128.
 */
-const GAIN = 1
+const GAIN = 0.9
 const RATE = 0.0055       // clock units per second at driftSeconds = 720
 const FREQ = 0.0022       // per-pixel, so the field keeps its scale on any width
 const STROKE = '#dfe6ee'
@@ -251,7 +266,7 @@ export default function Topo({
 
                 const level = L / (LEVELS + 1)
                 const isIndex = L % INDEX_EVERY === 0
-                const ramp = 1 - DEPTH + DEPTH * (0.35 + level)
+                const ramp = Math.max(FAINTEST, 1 - DEPTH + DEPTH * (0.35 + level))
 
                 ctx!.globalAlpha = Math.min(1, alpha * GAIN * ramp * (isIndex ? INDEX_BOOST : 1))
                 ctx!.lineWidth = WEIGHT * (isIndex ? INDEX_WEIGHT : 1)

--- a/apps/web/components/ui/Topo.tsx
+++ b/apps/web/components/ui/Topo.tsx
@@ -47,13 +47,13 @@ import s from '@/styles/ui.module.css'
    contours relative to the high ones, which is what gives it relief.
 */
 const CELL = 7            // px between field samples
-const LEVELS = 22         // contour lines across the field
+const LEVELS = 30         // contour lines across the field
 const WEIGHT = 0.9        // px, before the index multiplier
 const WARP = 0.55         // domain-warp strength — the twisting
-const INDEX_EVERY = 5     // heavier line every Nth contour
+const INDEX_EVERY = 4     // heavier line every Nth contour
 const INDEX_BOOST = 2.15  // its opacity multiplier
 const INDEX_WEIGHT = 1.85 // its line-weight multiplier
-const DEPTH = 0.52        // how much brighter high ground reads
+const DEPTH = 0.6        // how much brighter high ground reads
 const RATE = 0.0055       // clock units per second at driftSeconds = 720
 const FREQ = 0.0022       // per-pixel, so the field keeps its scale on any width
 const STROKE = '#dfe6ee'
@@ -139,8 +139,8 @@ export default function Topo({
             ctx!.lineCap = 'round'
 
             // One path per contour level: weight and alpha differ between them,
-            // and a canvas path carries a single set of stroke settings. Twenty
-            // -two strokes a frame is nothing beside the tracing above.
+            // and a canvas path carries a single set of stroke settings. That is
+            // LEVELS strokes a frame, which is nothing beside the tracing above.
             for (let L = 1; L <= LEVELS; L++) {
                 const level = L / (LEVELS + 1)
                 const isIndex = L % INDEX_EVERY === 0

--- a/apps/web/components/ui/Topo.tsx
+++ b/apps/web/components/ui/Topo.tsx
@@ -48,12 +48,27 @@ import s from '@/styles/ui.module.css'
    relative to the high ones, which is what gives it relief.
 */
 const LEVELS = 30         // contour lines across the field
-const WEIGHT = 1.5          // px, before the index multiplier
+const WEIGHT = 1.25          // px, before the index multiplier
 const WARP = 0.55         // domain-warp strength — the twisting
 const INDEX_EVERY = 4     // heavier line every Nth contour
 const INDEX_BOOST = 2.15  // its opacity multiplier
 const INDEX_WEIGHT = 1.85 // its line-weight multiplier
 const DEPTH = 0.6         // how much brighter high ground reads
+
+/*
+   The one global lever on how present the field is anywhere.
+
+   `opacity` is per-surface and stays that way — a stat band and the Next Op
+   card want genuinely different intensities. GAIN scales all of them at once,
+   so the whole site can be lifted or dropped without relitigating seven
+   individually tuned numbers, and their relative order is preserved.
+
+   Worth knowing what a call site's number actually resolves to before tuning
+   either: DEPTH ramps each contour between 0.63x and 1.19x the value passed,
+   and index contours take another INDEX_BOOST on top. So `opacity={0.05}`
+   draws ordinary lines at 0.031-0.06 and its index lines at up to 0.128.
+*/
+const GAIN = 1
 const RATE = 0.0055       // clock units per second at driftSeconds = 720
 const FREQ = 0.0022       // per-pixel, so the field keeps its scale on any width
 const STROKE = '#dfe6ee'
@@ -97,7 +112,10 @@ const QUALITY_MAX = 2.4
 const QUALITY_STEP = 1.18
 
 export default function Topo({
-    opacity = 0.102,
+    // Every current call site passes its own, so this governs new ones only —
+    // it is not a global control, and 0.102 (the prototype's tuning value) read
+    // like one. GAIN above is the global control. 0.06 is where the bands sit.
+    opacity = 0.06,
     driftSeconds = 720,
     mask = 'fade',
     className = '',
@@ -235,7 +253,7 @@ export default function Topo({
                 const isIndex = L % INDEX_EVERY === 0
                 const ramp = 1 - DEPTH + DEPTH * (0.35 + level)
 
-                ctx!.globalAlpha = Math.min(1, alpha * ramp * (isIndex ? INDEX_BOOST : 1))
+                ctx!.globalAlpha = Math.min(1, alpha * GAIN * ramp * (isIndex ? INDEX_BOOST : 1))
                 ctx!.lineWidth = WEIGHT * (isIndex ? INDEX_WEIGHT : 1)
                 ctx!.beginPath()
                 for (let k = 0; k < out.length; k += 4) {

--- a/apps/web/components/ui/Topo.tsx
+++ b/apps/web/components/ui/Topo.tsx
@@ -1,26 +1,65 @@
-import React from 'react'
+'use client'
+
+import React, { useEffect, useRef } from 'react'
+import { cellSegments, fbm3, noise3 } from '@/lib/topo/field'
 import s from '@/styles/ui.module.css'
 
 /**
  * The drifting contour-line backdrop.
  *
- * The art (`public/designs/topo.svg`) is a single 2400x800 tile that repeats
- * seamlessly, painted as a repeating background rather than inlined — see the
- * note above `.topo` in ui.module.css for why, and how the loop stays seam-free
- * at any speed.
+ * It used to be `public/designs/topo.svg` — a single 2400x800 tile of contour
+ * paths painted as a repeating background and translated sideways. Cheap: one
+ * composited transform, no JavaScript, no repaint. But a picture of contours
+ * cannot warp, because the lines are baked into the file, so all it could ever
+ * do was slide.
  *
- * `driftSeconds = 0` pins it static. The default of 720s is roughly 4px of
- * movement per second at 1600px wide: slow enough that you never catch it
- * moving, fast enough that the surface is never quite the same twice. It stops
- * entirely under `prefers-reduced-motion`.
+ * The field is generated now (see `lib/topo/field.ts`): a noise field whose
+ * third axis is time, traced into isolines every frame. Individual contours
+ * stretch, pinch, split and close into rings the way real ones do as terrain
+ * moves under them — which is the whole reason for the change.
  *
- * `mask` decides how it meets its edges — `fade` for a full-width band,
- * `edges` for the inverse (present at the sides, gone through the middle),
- * `left` for a hero whose right half carries a photograph, `none` inside a
- * small card that clips it anyway.
+ * The props are unchanged, so every existing call site kept working untouched:
+ *
+ * `opacity` is still the per-surface intensity, and still the thing each caller
+ * tunes — the seven call sites run from 0.045 in a stat band to 0.32 where the
+ * field stands in for a missing cover image.
+ *
+ * `driftSeconds` is still "bigger is slower", and 0 still pins it static. It no
+ * longer means what it used to literally mean (there is no tile to advance one
+ * width) so it is now a rate: 720 gives the tuned speed, 1440 half of it.
+ *
+ * `mask` and `className` are untouched — the masks were always CSS and still
+ * are.
+ *
+ * Two things it does that the old one could not afford to care about: it stops
+ * entirely when scrolled out of view, and under `prefers-reduced-motion` it
+ * draws one frame and never starts the loop, so the field is still there and
+ * still generated — just still.
  */
+
+/*
+   Tuned on a live prototype rather than guessed. Everything here is the field's
+   character and is deliberately global — only `opacity` varies per surface.
+
+   `INDEX_EVERY` is the cartographic convention the old asset already followed:
+   every fifth contour drawn heavier, so elevation bands read at a glance
+   instead of the field being an undifferentiated mat. `DEPTH` fades the low
+   contours relative to the high ones, which is what gives it relief.
+*/
+const CELL = 7            // px between field samples
+const LEVELS = 22         // contour lines across the field
+const WEIGHT = 0.9        // px, before the index multiplier
+const WARP = 0.55         // domain-warp strength — the twisting
+const INDEX_EVERY = 5     // heavier line every Nth contour
+const INDEX_BOOST = 2.15  // its opacity multiplier
+const INDEX_WEIGHT = 1.85 // its line-weight multiplier
+const DEPTH = 0.52        // how much brighter high ground reads
+const RATE = 0.0055       // clock units per second at driftSeconds = 720
+const FREQ = 0.0022       // per-pixel, so the field keeps its scale on any width
+const STROKE = '#dfe6ee'
+
 export default function Topo({
-    opacity = 0.065,
+    opacity = 0.102,
     driftSeconds = 720,
     mask = 'fade',
     className = '',
@@ -32,22 +71,172 @@ export default function Topo({
     className?: string
     style?: React.CSSProperties
 }) {
+    const hostRef = useRef<HTMLDivElement>(null)
+    const canvasRef = useRef<HTMLCanvasElement>(null)
+
+    // Read through refs inside the loop rather than restarting it on every prop
+    // change — a parent re-render must not cost a teardown and a cold canvas.
+    const opts = useRef({ opacity, driftSeconds })
+    opts.current = { opacity, driftSeconds }
+
+    useEffect(() => {
+        const host = hostRef.current
+        const canvas = canvasRef.current
+        if (!host || !canvas) return
+        const ctx = canvas.getContext('2d')
+        if (!ctx) return
+
+        const still = matchMedia('(prefers-reduced-motion: reduce)').matches
+
+        let cols = 0, rows = 0, w = 0, h = 0
+        let field = new Float32Array(0)
+        let clock = 0
+        let raf = 0
+        let visible = true
+        let last = 0
+
+        function measure() {
+            const r = host!.getBoundingClientRect()
+            w = Math.max(1, Math.round(r.width))
+            h = Math.max(1, Math.round(r.height))
+            // Capped at 2: past that the extra pixels cost real time and buy
+            // nothing on a 0.1-opacity hairline.
+            const dpr = Math.min(window.devicePixelRatio || 1, 2)
+            canvas!.width = Math.round(w * dpr)
+            canvas!.height = Math.round(h * dpr)
+            ctx!.setTransform(dpr, 0, 0, dpr, 0, 0)
+            cols = Math.ceil(w / CELL) + 1
+            rows = Math.ceil(h / CELL) + 1
+            field = new Float32Array((cols + 1) * (rows + 1))
+        }
+
+        function draw(t: number) {
+            const alpha = opts.current.opacity
+            ctx!.clearRect(0, 0, w, h)
+
+            const stride = cols + 1
+            const warp = WARP * 90
+
+            for (let j = 0; j <= rows; j++) {
+                const py = j * CELL
+                for (let i = 0; i <= cols; i++) {
+                    const px = i * CELL
+                    // Domain warp: displace the sample point by a second,
+                    // slower field. One octave is enough — it only has to be
+                    // smooth — and its third-speed drift is what makes the
+                    // motion read as shearing rather than sliding.
+                    const wx = noise3(px * FREQ * 0.6 + 11.3, py * FREQ * 0.6 + 4.7, t * 0.33) - 0.5
+                    const wy = noise3(px * FREQ * 0.6 + 47.9, py * FREQ * 0.6 + 23.1, t * 0.33) - 0.5
+                    field[j * stride + i] = fbm3(
+                        (px + wx * warp) * FREQ,
+                        (py + wy * warp) * FREQ,
+                        t,
+                    )
+                }
+            }
+
+            ctx!.strokeStyle = STROKE
+            ctx!.lineCap = 'round'
+
+            // One path per contour level: weight and alpha differ between them,
+            // and a canvas path carries a single set of stroke settings. Twenty
+            // -two strokes a frame is nothing beside the tracing above.
+            for (let L = 1; L <= LEVELS; L++) {
+                const level = L / (LEVELS + 1)
+                const isIndex = L % INDEX_EVERY === 0
+                const ramp = 1 - DEPTH + DEPTH * (0.35 + level)
+
+                ctx!.globalAlpha = Math.min(1, alpha * ramp * (isIndex ? INDEX_BOOST : 1))
+                ctx!.lineWidth = WEIGHT * (isIndex ? INDEX_WEIGHT : 1)
+                ctx!.beginPath()
+
+                for (let j = 0; j < rows; j++) {
+                    for (let i = 0; i < cols; i++) {
+                        const o = j * stride + i
+                        const segs = cellSegments(
+                            field[o], field[o + 1],
+                            field[o + stride + 1], field[o + stride],
+                            level,
+                        )
+                        if (segs.length === 0) continue
+
+                        const x0 = i * CELL, y0 = j * CELL
+                        for (let k = 0; k < segs.length; k += 4) {
+                            ctx!.moveTo(x0 + segs[k] * CELL, y0 + segs[k + 1] * CELL)
+                            ctx!.lineTo(x0 + segs[k + 2] * CELL, y0 + segs[k + 3] * CELL)
+                        }
+                    }
+                }
+
+                ctx!.stroke()
+            }
+
+            ctx!.globalAlpha = 1
+        }
+
+        function frame(now: number) {
+            const dt = Math.min(0.05, (now - last) / 1000)
+            last = now
+            const secs = opts.current.driftSeconds
+            if (secs > 0) clock += dt * RATE * (720 / secs)
+            draw(clock)
+            raf = requestAnimationFrame(frame)
+        }
+
+        function start() {
+            if (raf || still) return
+            last = performance.now()
+            raf = requestAnimationFrame(frame)
+        }
+
+        function stop() {
+            if (!raf) return
+            cancelAnimationFrame(raf)
+            raf = 0
+        }
+
+        measure()
+        draw(clock)
+
+        const ro = new ResizeObserver(() => { measure(); draw(clock) })
+        ro.observe(host)
+
+        // Topo is on nearly every page and the landing page mounts several at
+        // once. Without this they would all trace a field nobody is looking at.
+        const io = new IntersectionObserver(entries => {
+            visible = entries[0].isIntersecting
+            if (visible) start()
+            else stop()
+        }, { rootMargin: '120px' })
+        io.observe(host)
+
+        const onVisibility = () => {
+            if (document.hidden) stop()
+            else if (visible) start()
+        }
+        document.addEventListener('visibilitychange', onVisibility)
+
+        return () => {
+            stop()
+            ro.disconnect()
+            io.disconnect()
+            document.removeEventListener('visibilitychange', onVisibility)
+        }
+    }, [])
+
     const maskClass = mask === 'fade' ? s.topoFade
         : mask === 'edges' ? s.topoEdges
             : mask === 'left' ? s.topoLeft
                 : ''
-    const classes = [s.topo, maskClass, driftSeconds > 0 ? s.topoDrift : '', className]
-        .filter(Boolean).join(' ')
 
     return (
-        <div className={classes} style={style} aria-hidden='true'>
-            <div
-                className={s.topoTile}
-                style={{
-                    '--topo-op': opacity,
-                    '--topo-drift': `${driftSeconds}s`,
-                } as React.CSSProperties}
-            />
+        <div
+            ref={hostRef}
+            className={[s.topo, maskClass, className].filter(Boolean).join(' ')}
+            style={style}
+            aria-hidden='true'
+        >
+            <canvas ref={canvasRef} className={s.topoCanvas} />
         </div>
     )
 }

--- a/apps/web/components/ui/Topo.tsx
+++ b/apps/web/components/ui/Topo.tsx
@@ -48,7 +48,7 @@ import s from '@/styles/ui.module.css'
    relative to the high ones, which is what gives it relief.
 */
 const LEVELS = 30         // contour lines across the field
-const WEIGHT = 0.9        // px, before the index multiplier
+const WEIGHT = 1.5          // px, before the index multiplier
 const WARP = 0.55         // domain-warp strength — the twisting
 const INDEX_EVERY = 4     // heavier line every Nth contour
 const INDEX_BOOST = 2.15  // its opacity multiplier

--- a/apps/web/components/ui/Topo.tsx
+++ b/apps/web/components/ui/Topo.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useEffect, useRef } from 'react'
-import { cellSegments, fbm3, noise3 } from '@/lib/topo/field'
+import { cellSegments, fbm3, highestLevel, lowestLevel, noise3 } from '@/lib/topo/field'
 import s from '@/styles/ui.module.css'
 
 /**
@@ -31,32 +31,70 @@ import s from '@/styles/ui.module.css'
  * `mask` and `className` are untouched — the masks were always CSS and still
  * are.
  *
- * Two things it does that the old one could not afford to care about: it stops
- * entirely when scrolled out of view, and under `prefers-reduced-motion` it
- * draws one frame and never starts the loop, so the field is still there and
- * still generated — just still.
+ * Three things it does that the old one could not afford to care about: it
+ * stops entirely when scrolled out of view, it holds a single frame under
+ * `prefers-reduced-motion`, and it coarsens its own grid on a machine that
+ * cannot keep up — see "Cost" below.
  */
 
 /*
-   Tuned on a live prototype rather than guessed. Everything here is the field's
-   character and is deliberately global — only `opacity` varies per surface.
+   ── Character ─────────────────────────────────────────────────────────────
+   Tuned on a live prototype rather than guessed. This is the field's look and
+   is deliberately global; only `opacity` varies per surface.
 
    `INDEX_EVERY` is the cartographic convention the old asset already followed:
-   every fifth contour drawn heavier, so elevation bands read at a glance
-   instead of the field being an undifferentiated mat. `DEPTH` fades the low
-   contours relative to the high ones, which is what gives it relief.
+   every Nth contour drawn heavier, so elevation bands read at a glance instead
+   of the field being an undifferentiated mat. `DEPTH` fades the low contours
+   relative to the high ones, which is what gives it relief.
 */
-const CELL = 7            // px between field samples
 const LEVELS = 30         // contour lines across the field
 const WEIGHT = 0.9        // px, before the index multiplier
 const WARP = 0.55         // domain-warp strength — the twisting
 const INDEX_EVERY = 4     // heavier line every Nth contour
 const INDEX_BOOST = 2.15  // its opacity multiplier
 const INDEX_WEIGHT = 1.85 // its line-weight multiplier
-const DEPTH = 0.6        // how much brighter high ground reads
+const DEPTH = 0.6         // how much brighter high ground reads
 const RATE = 0.0055       // clock units per second at driftSeconds = 720
 const FREQ = 0.0022       // per-pixel, so the field keeps its scale on any width
 const STROKE = '#dfe6ee'
+
+/*
+   ── Cost ──────────────────────────────────────────────────────────────────
+   Work scales with the number of grid cells, which is area / cell². Band height
+   was therefore the thing that hurt: the 66px navbar strip comes to ~3,000
+   cells and drew in 2.3ms, while a 620px band came to ~24,000 and took 18.8ms —
+   past a whole frame, so it visibly stuttered. (Figures are the fastest of 25
+   runs; means are worthless here, background load swamps them.)
+
+   Three things hold it down now.
+
+   1. `lowestLevel`/`highestLevel` skip cells no contour can cross. Testing every
+      level against every cell was 726,000 calls a frame on that band to produce
+      7,900 segments — 99% of the work establishing that a contour was nowhere
+      near. A cell's corner range says directly which levels can appear in it.
+      That alone took the band from 18.8ms to 10.5ms and the navbar to 1.3ms.
+
+   2. Thirty frames a second, not sixty. The field crosses one noise cell every
+      three minutes — nothing in it is resolved by 60fps that is not resolved by
+      30 — and it halves the work outright.
+
+   3. The grid coarsens when frames run long and refines again when they do not,
+      which is what carries a machine slower than the one those figures came
+      from. Each step is 18% on the cell size, so a step is ~30% of the work;
+      `QUALITY_MAX` is about a 6x reduction in cells overall. Contours get
+      slightly less smooth and nothing else changes, which at 6% opacity is not
+      a visible trade. On the machine above the band settles around 5.5ms.
+
+   `MAX_CELLS` is a floor under all of that for the pathological case — a
+   full-bleed band on a very large display — so the first frame is never the
+   slow one.
+*/
+const BASE_CELL = 7
+const MAX_CELLS = 30_000
+const FRAME_MS = 1000 / 30
+const BUDGET_MS = 5.5
+const QUALITY_MAX = 2.4
+const QUALITY_STEP = 1.18
 
 export default function Topo({
     opacity = 0.102,
@@ -88,26 +126,41 @@ export default function Topo({
 
         const still = matchMedia('(prefers-reduced-motion: reduce)').matches
 
-        let cols = 0, rows = 0, w = 0, h = 0
+        let cols = 0, rows = 0, w = 0, h = 0, cell = BASE_CELL
         let field = new Float32Array(0)
+        // Segments per contour level, so the cell pass can run once and each
+        // level can still be stroked with its own weight and alpha.
+        let lines: number[][] = []
         let clock = 0
         let raf = 0
         let visible = true
         let last = 0
 
+        // Grid coarseness. 1 is full detail; higher is cheaper.
+        let quality = 1
+        let costAvg = 0
+        let costSamples = 0
+        let sinceChange = 0
+
         function measure() {
             const r = host!.getBoundingClientRect()
             w = Math.max(1, Math.round(r.width))
             h = Math.max(1, Math.round(r.height))
+
+            const floor = Math.sqrt((w * h) / MAX_CELLS)
+            cell = Math.max(BASE_CELL, floor) * quality
+
             // Capped at 2: past that the extra pixels cost real time and buy
             // nothing on a 0.1-opacity hairline.
             const dpr = Math.min(window.devicePixelRatio || 1, 2)
             canvas!.width = Math.round(w * dpr)
             canvas!.height = Math.round(h * dpr)
             ctx!.setTransform(dpr, 0, 0, dpr, 0, 0)
-            cols = Math.ceil(w / CELL) + 1
-            rows = Math.ceil(h / CELL) + 1
+
+            cols = Math.ceil(w / cell) + 1
+            rows = Math.ceil(h / cell) + 1
             field = new Float32Array((cols + 1) * (rows + 1))
+            lines = Array.from({ length: LEVELS + 1 }, () => [] as number[])
         }
 
         function draw(t: number) {
@@ -118,9 +171,9 @@ export default function Topo({
             const warp = WARP * 90
 
             for (let j = 0; j <= rows; j++) {
-                const py = j * CELL
+                const py = j * cell
                 for (let i = 0; i <= cols; i++) {
-                    const px = i * CELL
+                    const px = i * cell
                     // Domain warp: displace the sample point by a second,
                     // slower field. One octave is enough — it only has to be
                     // smooth — and its third-speed drift is what makes the
@@ -135,13 +188,49 @@ export default function Topo({
                 }
             }
 
+            for (let L = 1; L <= LEVELS; L++) lines[L].length = 0
+
+            // Cell-major, so each cell's corner range is computed once and used
+            // to skip every level that cannot cross it.
+            for (let j = 0; j < rows; j++) {
+                for (let i = 0; i < cols; i++) {
+                    const o = j * stride + i
+                    const a = field[o], b = field[o + 1]
+                    const c = field[o + stride + 1], d = field[o + stride]
+
+                    let mn = a, mx = a
+                    if (b < mn) mn = b
+                    if (b > mx) mx = b
+                    if (c < mn) mn = c
+                    if (c > mx) mx = c
+                    if (d < mn) mn = d
+                    if (d > mx) mx = d
+
+                    const lo = lowestLevel(mn, LEVELS)
+                    const hi = highestLevel(mx, LEVELS)
+                    if (hi < lo) continue
+
+                    const x0 = i * cell, y0 = j * cell
+                    for (let L = lo; L <= hi; L++) {
+                        const segs = cellSegments(a, b, c, d, L / (LEVELS + 1))
+                        const out = lines[L]
+                        for (let k = 0; k < segs.length; k += 4) {
+                            out.push(
+                                x0 + segs[k] * cell, y0 + segs[k + 1] * cell,
+                                x0 + segs[k + 2] * cell, y0 + segs[k + 3] * cell,
+                            )
+                        }
+                    }
+                }
+            }
+
             ctx!.strokeStyle = STROKE
             ctx!.lineCap = 'round'
 
-            // One path per contour level: weight and alpha differ between them,
-            // and a canvas path carries a single set of stroke settings. That is
-            // LEVELS strokes a frame, which is nothing beside the tracing above.
             for (let L = 1; L <= LEVELS; L++) {
+                const out = lines[L]
+                if (out.length === 0) continue
+
                 const level = L / (LEVELS + 1)
                 const isIndex = L % INDEX_EVERY === 0
                 const ramp = 1 - DEPTH + DEPTH * (0.35 + level)
@@ -149,43 +238,68 @@ export default function Topo({
                 ctx!.globalAlpha = Math.min(1, alpha * ramp * (isIndex ? INDEX_BOOST : 1))
                 ctx!.lineWidth = WEIGHT * (isIndex ? INDEX_WEIGHT : 1)
                 ctx!.beginPath()
-
-                for (let j = 0; j < rows; j++) {
-                    for (let i = 0; i < cols; i++) {
-                        const o = j * stride + i
-                        const segs = cellSegments(
-                            field[o], field[o + 1],
-                            field[o + stride + 1], field[o + stride],
-                            level,
-                        )
-                        if (segs.length === 0) continue
-
-                        const x0 = i * CELL, y0 = j * CELL
-                        for (let k = 0; k < segs.length; k += 4) {
-                            ctx!.moveTo(x0 + segs[k] * CELL, y0 + segs[k + 1] * CELL)
-                            ctx!.lineTo(x0 + segs[k + 2] * CELL, y0 + segs[k + 3] * CELL)
-                        }
-                    }
+                for (let k = 0; k < out.length; k += 4) {
+                    ctx!.moveTo(out[k], out[k + 1])
+                    ctx!.lineTo(out[k + 2], out[k + 3])
                 }
-
                 ctx!.stroke()
             }
 
             ctx!.globalAlpha = 1
         }
 
+        /**
+         * Coarsen when frames run long, refine when they do not.
+         *
+         * The gap between the two thresholds is what stops it oscillating: a
+         * grid that has just been coarsened lands well under the refine
+         * threshold, so nothing changes again until the machine's load actually
+         * does. Every adjustment resets the average, because the old figure
+         * describes a grid that no longer exists.
+         */
+        function adapt() {
+            // The first look comes early, so a slow machine settles in well
+            // under a second rather than stuttering while a long average fills.
+            const gate = costSamples < 40 ? 12 : 45
+            if (sinceChange < gate) return
+            sinceChange = 0
+
+            if (costAvg > BUDGET_MS * 1.35 && quality < QUALITY_MAX) {
+                quality = Math.min(QUALITY_MAX, quality * QUALITY_STEP)
+            } else if (costAvg < BUDGET_MS * 0.55 && quality > 1) {
+                quality = Math.max(1, quality / QUALITY_STEP)
+            } else {
+                return
+            }
+
+            measure()
+            costAvg = 0
+            costSamples = 0
+        }
+
         function frame(now: number) {
+            raf = requestAnimationFrame(frame)
+            if (now - last < FRAME_MS) return
+
             const dt = Math.min(0.05, (now - last) / 1000)
             last = now
             const secs = opts.current.driftSeconds
             if (secs > 0) clock += dt * RATE * (720 / secs)
+
+            const t0 = performance.now()
             draw(clock)
-            raf = requestAnimationFrame(frame)
+            const cost = performance.now() - t0
+
+            costAvg = costSamples ? costAvg * 0.85 + cost * 0.15 : cost
+            costSamples++
+            sinceChange++
+            adapt()
         }
 
         function start() {
             if (raf || still) return
-            last = performance.now()
+            // Back-dated so the first callback draws rather than being paced out.
+            last = performance.now() - FRAME_MS
             raf = requestAnimationFrame(frame)
         }
 

--- a/apps/web/docs/map/g-public-pages.md
+++ b/apps/web/docs/map/g-public-pages.md
@@ -106,8 +106,16 @@ Callsign registry (India 0A, 1-0, Gamemasters, 1-1/1-2/1-3 platoons, Reservists)
 `List`. Public, purely static content.
 
 #### app/(landing)/about/contact/page.tsx
-Contact cards (TeamSpeak, Facebook, Email, own `Channel` helper) + embedded Discord widget iframe.
-Public.
+Opens on the live presence panel (`.presence*` in shell.module.css) — TeamSpeak online, active
+roster, next-op countdown — then four `.channel` cards (Discord, TeamSpeak, Email, Facebook).
+`force-dynamic`; reads `getFeaturedOp`/`getRosterCount` (lib/landing) and `getOnlineCache`
+(lib/teamspeak/cache) directly rather than through /api/nav/status, which serves the navbar rail the
+same three figures. Replaced the embedded Discord widget iframe, which published members' display
+names to anyone loading the page. Public.
+
+#### app/(landing)/about/contact/next-op-figure.tsx
+Client component: the countdown tile's figure. Takes the server-rendered string as `initial` so the
+first client render matches the server HTML, then re-derives via `formatUntil` every 30s.
 
 #### app/(landing)/about/faq/page.tsx
 FAQ grouped into three `Card`s (`Joining ASOT` / `Game & setup` / `Playing with us`) of `QaRow`/

--- a/apps/web/docs/map/h-lib-types-components.md
+++ b/apps/web/docs/map/h-lib-types-components.md
@@ -643,6 +643,17 @@ not the whole page.
 
 ---
 
+### lib/topo/field.ts
+Pure field maths behind `components/ui/Topo`.
+- `noise3(x, y, z)` / `fbm3(x, y, z)` → integer-hash value noise and a four-octave sum in 0..1. The
+  third axis is time, and the finer octaves advance faster so detail churns while landforms drift.
+- `cellSegments(a, b, c, d, level)` → marching squares for one cell, flat `x0,y0,x1,y1` per segment
+  in unit coordinates (flat because it runs tens of thousands of times a frame). Corners are a
+  top-left, b top-right, c bottom-right, d bottom-left. The two saddle cases resolve on the cell
+  centre — picking arbitrarily produces crossed contours. Tested: `lib/topo/field.test.ts`.
+
+---
+
 ### lib/contact/countdown.ts
 - `formatUntil(iso, now)` → the contact page's next-op display figure: `2d 14h` · `14h 30m` · `30m`
   · `Running`, null on an unreadable date. Units drop as the target nears and everything floors.
@@ -805,10 +816,15 @@ choreography stays in that surface's own module.
 - **Rule:** only one button in a cluster is ever solid-filled — whichever is primary for that state.
 
 #### components/ui/Topo.tsx
-- Default export `Topo({opacity, driftSeconds, mask, className, style})` — the drifting contour
-  backdrop. Paints `public/designs/topo.svg` (a seamless 2400x800 tile) as a repeating background
-  rather than inlining ~160KB of paths. `mask`: `fade` (full-width band) · `left` (hero with a photo
-  on the right) · `none`. `driftSeconds = 0` pins it; motion stops under `prefers-reduced-motion`.
+- Default export `Topo({opacity, driftSeconds, mask, className, style})` — the contour backdrop, on a
+  canvas. **Client component.** Generates the lines every frame via `lib/topo/field.ts` rather than
+  translating `public/designs/topo.svg`, so individual contours stretch, split and close into rings;
+  the SVG is no longer referenced by anything. Field character (spacing, warp, index contours, depth)
+  is fixed in the module — only `opacity` is per-surface, and the seven call sites run 0.045→0.32.
+  `mask` unchanged: `fade` · `edges` · `left` · `none`, still pure CSS. `driftSeconds` is now a rate
+  (720 = tuned speed, 1440 = half) and `0` still pins it. Stops via `IntersectionObserver` when
+  off-screen and on `visibilitychange`; under `prefers-reduced-motion` it draws one frame and never
+  starts the loop.
 
 #### components/ui/Pulse.tsx
 - Default export `Pulse({tone})` — the live dot. `live` / `amber` / `idle` (dim, animation off, for
@@ -897,9 +913,6 @@ the mobile sheet share one source of truth. Layout and interaction live in
 - `NAV_ITEMS: NavItem[]` — the public navigation tree (six top-level items, MUI icons, each child carrying a `description` for the mega panel). Consumed by both `app/navbar.tsx` and `MobileSheet`. `Support` lives under `Community` (the menu formerly labelled `Our Orbat`; its `href` is still `/community`) rather than at the top level.
 - `isItemActive(item, pathname)` — active check that also matches any child href.
 - Types `NavItem` / `NavChild`.
-
-#### components/nav/Topo.tsx
-- Default export `Topo({opacity?, driftSeconds?, fade?})` — the drifting contour backdrop. Paints `public/designs/topo.svg` (a seamless 2400x800 tile) as a repeating background rather than inlining ~160KB of paths into every page. `driftSeconds = 0` pins it static; motion stops under `prefers-reduced-motion`.
 
 #### components/nav/useNavStatus.ts
 - `useNavStatus()` — fetches `/api/nav/status` on mount and every 5 minutes. Never throws or exposes an error state; a failed request just leaves rail segments unrendered. Shared by `StatusRail` and the mega panel's "Next Op" card so both quote the same operation.

--- a/apps/web/docs/map/h-lib-types-components.md
+++ b/apps/web/docs/map/h-lib-types-components.md
@@ -643,6 +643,15 @@ not the whole page.
 
 ---
 
+### lib/contact/countdown.ts
+- `formatUntil(iso, now)` → the contact page's next-op display figure: `2d 14h` · `14h 30m` · `30m`
+  · `Running`, null on an unreadable date. Units drop as the target nears and everything floors.
+  `now` is a parameter so the server renders one value and the client ticks from it. Deliberately
+  not `formatCountdown` (components/nav/useNavStatus) — that is 9.5px page chrome reading
+  `T−2D 04H 11M`; this is a 62px display figure. Tested: `lib/contact/countdown.test.ts`.
+
+---
+
 ### lib/shell/masthead.ts
 Pure helpers for the public page masthead (`components/container.tsx` / `components/ui/Masthead.tsx`).
 - `bannerHeightValue(size?: BannerHeight)` → the band's height as a clamped CSS value (`xsm|sm|md|lg`,

--- a/apps/web/docs/map/h-lib-types-components.md
+++ b/apps/web/docs/map/h-lib-types-components.md
@@ -650,7 +650,14 @@ Pure field maths behind `components/ui/Topo`.
 - `cellSegments(a, b, c, d, level)` → marching squares for one cell, flat `x0,y0,x1,y1` per segment
   in unit coordinates (flat because it runs tens of thousands of times a frame). Corners are a
   top-left, b top-right, c bottom-right, d bottom-left. The two saddle cases resolve on the cell
-  centre — picking arbitrarily produces crossed contours. Tested: `lib/topo/field.test.ts`.
+  centre — picking arbitrarily produces crossed contours.
+- `lowestLevel(min, levels)` / `highestLevel(max, levels)` → the inclusive range of contour levels a
+  cell's corner range can carry; `highestLevel < lowestLevel` means skip the cell. This is the
+  page-performance lever: testing every level against every cell was 726k calls a frame on a large
+  band to yield 7.9k segments. Two scalars rather than a tuple because returning a pair allocated
+  24k short-lived arrays a frame, which measured as two thirds of the tracing cost.
+- Tested throughout: `lib/topo/field.test.ts`, including that the range never excludes a level
+  `cellSegments` would have drawn, and that the field's rate of change stays steady over time.
 
 ---
 
@@ -824,7 +831,10 @@ choreography stays in that surface's own module.
   `mask` unchanged: `fade` · `edges` · `left` · `none`, still pure CSS. `driftSeconds` is now a rate
   (720 = tuned speed, 1440 = half) and `0` still pins it. Stops via `IntersectionObserver` when
   off-screen and on `visibilitychange`; under `prefers-reduced-motion` it draws one frame and never
-  starts the loop.
+  starts the loop. Paces to 30fps and **adapts its own grid**: a rolling frame-cost average coarsens
+  the cell size when draws exceed ~5.5ms and refines it again when they do not, up to a ~6x cell
+  reduction. Cost scales with area/cell², so tall bands were what stuttered — see the `Cost` block
+  in the file for measured figures.
 
 #### components/ui/Pulse.tsx
 - Default export `Pulse({tone})` — the live dot. `live` / `amber` / `idle` (dim, animation off, for

--- a/apps/web/docs/map/h-lib-types-components.md
+++ b/apps/web/docs/map/h-lib-types-components.md
@@ -828,6 +828,10 @@ choreography stays in that surface's own module.
   translating `public/designs/topo.svg`, so individual contours stretch, split and close into rings;
   the SVG is no longer referenced by anything. Field character (spacing, warp, index contours, depth)
   is fixed in the module — only `opacity` is per-surface, and the seven call sites run 0.045→0.32.
+  `GAIN` in the module scales every call site at once; the `opacity` default governs new call sites
+  only (all seven pass their own) and is deliberately not a global control. A call site's number is
+  not the alpha drawn: `DEPTH` ramps each contour to 0.63–1.19x it, and index contours take
+  `INDEX_BOOST` on top.
   `mask` unchanged: `fade` · `edges` · `left` · `none`, still pure CSS. `driftSeconds` is now a rate
   (720 = tuned speed, 1440 = half) and `0` still pins it. Stops via `IntersectionObserver` when
   off-screen and on `visibilitychange`; under `prefers-reduced-motion` it draws one frame and never

--- a/apps/web/lib/contact/countdown.test.ts
+++ b/apps/web/lib/contact/countdown.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { formatUntil } from './countdown'
+
+const AT = Date.UTC(2026, 7, 27, 10, 0, 0)
+const after = (ms: number) => new Date(AT + ms).toISOString()
+
+const MIN = 60_000
+const HOUR = 60 * MIN
+const DAY = 24 * HOUR
+
+describe('formatUntil', () => {
+    it('drops minutes past a day — the figure is read at a glance, not planned against', () => {
+        expect(formatUntil(after(2 * DAY + 14 * HOUR + 37 * MIN), AT)).toBe('2d 14h')
+    })
+
+    it('keeps minutes inside a day, where they start to matter', () => {
+        expect(formatUntil(after(14 * HOUR + 30 * MIN), AT)).toBe('14h 30m')
+    })
+
+    it('drops to minutes alone in the last hour', () => {
+        expect(formatUntil(after(30 * MIN), AT)).toBe('30m')
+    })
+
+    /*
+       A 25-hour gap is "1d 1h", not "25h". The unit boundary is what makes the
+       figure scannable — the whole point of it being large.
+    */
+    it('crosses into days at 24 hours', () => {
+        expect(formatUntil(after(25 * HOUR), AT)).toBe('1d 1h')
+        expect(formatUntil(after(23 * HOUR + 59 * MIN), AT)).toBe('23h 59m')
+    })
+
+    it('reads as running once the start time has passed', () => {
+        expect(formatUntil(after(-1 * MIN), AT)).toBe('Running')
+        expect(formatUntil(after(0), AT)).toBe('Running')
+    })
+
+    /*
+       Rounding down, always. An op 59 seconds away is not "1m" — saying so
+       would let the figure claim time the reader does not have.
+    */
+    it('floors rather than rounds', () => {
+        expect(formatUntil(after(59_000), AT)).toBe('0m')
+        expect(formatUntil(after(2 * DAY - 1), AT)).toBe('1d 23h')
+    })
+
+    it('returns null for a date it cannot read, so the tile can fall back', () => {
+        expect(formatUntil('not a date', AT)).toBeNull()
+        expect(formatUntil('', AT)).toBeNull()
+    })
+})

--- a/apps/web/lib/contact/countdown.ts
+++ b/apps/web/lib/contact/countdown.ts
@@ -1,0 +1,45 @@
+/**
+ * The contact page's "next operation" figure.
+ *
+ * Deliberately not `formatCountdown` from the navbar rail. That one is page
+ * chrome at 9.5px and reads `T−2D 04H 11M`; this is a 62px display figure and
+ * the two want different things — the rail is a precise clock you glance at,
+ * this is a headline number that has to be legible in one beat. Sharing an
+ * arithmetic helper between them would save four lines and couple two formats
+ * that should be free to diverge.
+ *
+ * Pure and here in lib/ rather than beside the component because vitest picks
+ * up `lib/**\/*.test.ts` and nothing else.
+ */
+
+const MIN = 60_000
+const HOUR = 60 * MIN
+const DAY = 24 * HOUR
+
+/**
+ * `2d 14h` · `14h 30m` · `30m` · `Running`, or null when `iso` is unreadable.
+ *
+ * Units drop as the target nears: minutes are noise two days out and the whole
+ * point in the last hour. Everything floors — an operation 59 seconds away is
+ * not a minute away, and a figure this size should never claim time the reader
+ * does not have.
+ *
+ * `now` is a parameter rather than a `Date.now()` call so the caller controls
+ * the clock: the server renders one value, the client ticks from it, and the
+ * test does not need a fake timer.
+ */
+export function formatUntil(iso: string, now: number): string | null {
+    const target = new Date(iso).getTime()
+    if (Number.isNaN(target)) return null
+
+    const ms = target - now
+    if (ms <= 0) return 'Running'
+
+    if (ms >= DAY) {
+        return `${Math.floor(ms / DAY)}d ${Math.floor(ms / HOUR) % 24}h`
+    }
+    if (ms >= HOUR) {
+        return `${Math.floor(ms / HOUR)}h ${Math.floor(ms / MIN) % 60}m`
+    }
+    return `${Math.floor(ms / MIN)}m`
+}

--- a/apps/web/lib/topo/field.test.ts
+++ b/apps/web/lib/topo/field.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { cellSegments, fbm3 } from './field'
+import { cellSegments, fbm3, highestLevel, lowestLevel } from './field'
 
 /**
  * Corners are named for their position in the cell: a top-left, b top-right,
@@ -124,5 +124,58 @@ describe('fbm3', () => {
         const atLoad = changeRate(0)
         const settled = changeRate(0.5)
         expect(atLoad / settled).toBeGreaterThan(0.25)
+    })
+})
+
+describe('lowestLevel / highestLevel', () => {
+    /*
+       Levels sit at L / (levels + 1), so with 30 levels they run 1/31 … 30/31.
+       A cell carries level v when min <= v < max — the same convention
+       cellSegments uses when it treats a corner exactly on the level as below
+       it. The two have to agree or contours are dropped or drawn twice.
+    */
+    it('returns only the levels that fall inside the corner range', () => {
+        expect(lowestLevel(0.2, 30)).toBe(7)
+        expect(highestLevel(0.5, 30)).toBe(15)
+        // 7/31 = 0.2258 is the first at or above 0.2; 16/31 = 0.516 is past 0.5.
+        expect(7 / 31).toBeGreaterThanOrEqual(0.2)
+        expect(15 / 31).toBeLessThan(0.5)
+        expect(16 / 31).toBeGreaterThan(0.5)
+    })
+
+    it('reports an empty range for a cell lying between two contours', () => {
+        expect(highestLevel(0.221, 30)).toBeLessThan(lowestLevel(0.201, 30))
+    })
+
+    it('clamps to the levels that actually exist', () => {
+        expect(lowestLevel(0, 30)).toBe(1)
+        expect(highestLevel(1, 30)).toBe(30)
+        expect(lowestLevel(-0.4, 30)).toBe(1)
+        expect(highestLevel(1.6, 30)).toBe(30)
+    })
+
+    /*
+       The contract that matters: whatever the range excludes must genuinely
+       produce nothing. Checked against cellSegments itself rather than against
+       my arithmetic.
+    */
+    it('never excludes a level that cellSegments would have drawn', () => {
+        const levels = 30
+        let checked = 0
+        for (let s = 0; s < 500; s++) {
+            const a = ((s * 37) % 100) / 100, b = ((s * 61) % 100) / 100
+            const c = ((s * 83) % 100) / 100, d = ((s * 29) % 100) / 100
+            const lo = lowestLevel(Math.min(a, b, c, d), levels)
+            const hi = highestLevel(Math.max(a, b, c, d), levels)
+            for (let L = 1; L <= levels; L++) {
+                const drew = cellSegments(a, b, c, d, L / (levels + 1)).length > 0
+                if (drew) {
+                    expect(L).toBeGreaterThanOrEqual(lo)
+                    expect(L).toBeLessThanOrEqual(hi)
+                    checked++
+                }
+            }
+        }
+        expect(checked).toBeGreaterThan(200)
     })
 })

--- a/apps/web/lib/topo/field.test.ts
+++ b/apps/web/lib/topo/field.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { cellSegments, fbm3 } from './field'
+
+/**
+ * Corners are named for their position in the cell: a top-left, b top-right,
+ * c bottom-right, d bottom-left. Segments come back flat — x0, y0, x1, y1 per
+ * segment — in unit coordinates, so a crossing halfway along the top edge is
+ * (0.5, 0).
+ */
+const seg = (v: number[]) => v.map(n => Math.round(n * 1000) / 1000)
+
+describe('cellSegments', () => {
+    it('emits nothing for a cell wholly above or wholly below the level', () => {
+        expect(cellSegments(0.1, 0.2, 0.15, 0.05, 0.5)).toEqual([])
+        expect(cellSegments(0.9, 0.8, 0.85, 0.95, 0.5)).toEqual([])
+    })
+
+    it('cuts a corner off when one corner crosses', () => {
+        // Only a (top-left) is above: the contour runs from the left edge to
+        // the top edge, both crossed at their midpoints.
+        expect(seg(cellSegments(1, 0, 0, 0, 0.5))).toEqual([0, 0.5, 0.5, 0])
+    })
+
+    it('interpolates the crossing rather than snapping to the midpoint', () => {
+        // a=1, b=0 puts the top crossing at 0.75 for level 0.25; a=1, d=0 puts
+        // the left crossing at the same place.
+        expect(seg(cellSegments(1, 0, 0, 0, 0.25))).toEqual([0, 0.75, 0.75, 0])
+    })
+
+    it('runs edge to edge when one side is above', () => {
+        // a and b above, c and d below — a single contour crossing left to right.
+        expect(seg(cellSegments(1, 1, 0, 0, 0.5))).toEqual([0, 0.5, 1, 0.5])
+    })
+
+    /*
+       The saddle is the only case where the corners do not determine the
+       answer. Two opposite corners are above and two below, and the contours
+       can join either way; the cell centre breaks the tie. Guessing produces
+       lines that cross, which never happens on a real contour map.
+    */
+    it('resolves a saddle by the cell centre — high centre joins the high corners', () => {
+        // b and d above, centre above: the two high corners connect through the
+        // middle, so the contours wrap a and c separately.
+        expect(seg(cellSegments(0.4, 1, 0.4, 1, 0.5))).toEqual([0, 0.167, 0.167, 0, 0.833, 1, 1, 0.833])
+    })
+
+    it('resolves a saddle the other way when the centre is low', () => {
+        // b and d above, centre below: the low corners connect instead, so the
+        // contours wrap b and c the other way about.
+        const out = cellSegments(0.1, 0.6, 0.1, 0.6, 0.5)
+        expect(out).toHaveLength(8)
+        // The two segments must not be the high-centre pairing.
+        expect(seg(out)).not.toEqual(seg(cellSegments(0.4, 1, 0.4, 1, 0.5)))
+    })
+
+    it('gives the same geometry for a cell and its inverse', () => {
+        // Flipping which side of the level every corner sits on traces the same
+        // line — a contour has no preferred side.
+        const up = seg(cellSegments(0.8, 0.2, 0.2, 0.2, 0.5))
+        const down = seg(cellSegments(0.2, 0.8, 0.8, 0.8, 0.5))
+        expect(up).toEqual(down)
+    })
+})
+
+describe('fbm3', () => {
+    it('stays inside 0..1 so contour levels can be spaced across it', () => {
+        for (let i = 0; i < 400; i++) {
+            const v = fbm3(i * 0.37, i * 0.11, i * 0.05)
+            expect(v).toBeGreaterThanOrEqual(0)
+            expect(v).toBeLessThanOrEqual(1)
+        }
+    })
+
+    it('is deterministic — the same point always returns the same height', () => {
+        expect(fbm3(3.2, 1.7, 0.4)).toBe(fbm3(3.2, 1.7, 0.4))
+    })
+
+    it('is continuous, so contours never tear between adjacent samples', () => {
+        const a = fbm3(2, 2, 1)
+        const b = fbm3(2.001, 2, 1)
+        expect(Math.abs(a - b)).toBeLessThan(0.01)
+    })
+
+    it('actually varies over time — the third axis is what makes the field live', () => {
+        expect(fbm3(2, 2, 0)).not.toBe(fbm3(2, 2, 4))
+    })
+})

--- a/apps/web/lib/topo/field.test.ts
+++ b/apps/web/lib/topo/field.test.ts
@@ -84,4 +84,45 @@ describe('fbm3', () => {
     it('actually varies over time — the third axis is what makes the field live', () => {
         expect(fbm3(2, 2, 0)).not.toBe(fbm3(2, 2, 4))
     })
+
+    /*
+       Regression: the field used to stall and surge.
+
+       The quintic fade has a derivative of zero at every lattice boundary, and
+       applying it to the time axis made that a change in *speed*. At z = 0 all
+       four octaves sit on a boundary at once, so a freshly loaded page opened
+       frozen and took about a minute to reach full speed — measured at 0.1% of
+       the steady rate on the first frame.
+
+       Spatial axes still use the quintic: there it hides the lattice in the
+       image, which is a real job. On the time axis there is no lattice to hide,
+       only a speed to keep constant.
+    */
+    const STEP = 0.0055 // one second of clock at the shipped drift rate
+
+    function changeRate(z: number): number {
+        let sum = 0
+        for (let i = 0; i < 240; i++) {
+            const x = (i % 20) * 0.13, y = Math.floor(i / 20) * 0.17
+            sum += Math.abs(fbm3(x, y, z + STEP) - fbm3(x, y, z))
+        }
+        return sum / 240
+    }
+
+    it('morphs at a steady rate, including from a standing start at z = 0', () => {
+        const rates = [0, 0.03, 0.1, 0.25, 0.5, 0.75, 0.97, 1, 1.4, 2.2].map(changeRate)
+        const min = Math.min(...rates)
+        const max = Math.max(...rates)
+
+        expect(min).toBeGreaterThan(0)
+        // A lattice crossing still changes the gradient the field is moving
+        // along, so some spread is inherent. A stall is not.
+        expect(max / min).toBeLessThan(4)
+    })
+
+    it('does not open frozen — the first second moves like any other', () => {
+        const atLoad = changeRate(0)
+        const settled = changeRate(0.5)
+        expect(atLoad / settled).toBeGreaterThan(0.25)
+    })
 })

--- a/apps/web/lib/topo/field.ts
+++ b/apps/web/lib/topo/field.ts
@@ -29,9 +29,24 @@ function hash(x: number, y: number, z: number): number {
 const fade = (t: number) => t * t * t * (t * (t * 6 - 15) + 10)
 const lerp = (a: number, b: number, t: number) => a + (b - a) * t
 
+/*
+   The spatial axes are eased, the time axis is not — and that asymmetry is
+   deliberate.
+
+   The quintic exists to hide the sample lattice in the *image*: without it the
+   grid shows up as visible structure in the contours. The time axis has no
+   image to protect; what a viewer perceives along it is speed. And the quintic's
+   derivative is exactly zero at every lattice boundary, so easing time turned
+   each crossing into a stall followed by a surge — at z = 0, where all four
+   octaves sit on a boundary at once, a freshly loaded page opened frozen and
+   took about a minute to reach full speed.
+
+   Linear on z trades an imperceptible kink in acceleration at each crossing for
+   a constant speed everywhere, which is the property that actually matters here.
+*/
 export function noise3(x: number, y: number, z: number): number {
     const xi = Math.floor(x), yi = Math.floor(y), zi = Math.floor(z)
-    const xf = fade(x - xi), yf = fade(y - yi), zf = fade(z - zi)
+    const xf = fade(x - xi), yf = fade(y - yi), zf = z - zi
 
     const c000 = hash(xi, yi, zi), c100 = hash(xi + 1, yi, zi)
     const c010 = hash(xi, yi + 1, zi), c110 = hash(xi + 1, yi + 1, zi)

--- a/apps/web/lib/topo/field.ts
+++ b/apps/web/lib/topo/field.ts
@@ -1,0 +1,106 @@
+/**
+ * The contour field behind `components/ui/Topo`.
+ *
+ * The backdrop used to be a static SVG of contour lines translated sideways —
+ * cheap, but nothing about a picture of contours can warp, because the lines
+ * are baked into the file. These two functions generate them instead: sample a
+ * noise field whose third axis is time, then trace the isolines. Contours can
+ * then do what real ones do as terrain moves — stretch, pinch, split in two,
+ * and close into a ring as a peak rises past a threshold.
+ *
+ * Pure and here in lib/ rather than beside the component because vitest picks
+ * up `lib/**\/*.test.ts` and nothing else, and the marching-squares saddle
+ * cases are exactly the sort of thing that fails silently and looks like a
+ * rendering glitch.
+ */
+
+/**
+ * Integer-hash value noise. Cheaper than simplex and indistinguishable from it
+ * once it has been through four octaves and a contour tracer — the tracer only
+ * ever sees level crossings, not the field itself.
+ */
+function hash(x: number, y: number, z: number): number {
+    let n = (x * 374761393 + y * 668265263 + z * 1274126177) | 0
+    n = ((n ^ (n >>> 13)) * 1274126177) | 0
+    return ((n ^ (n >>> 16)) >>> 0) / 4294967295
+}
+
+/** Quintic fade. Smoother than cubic at the cell edges, which contours show up. */
+const fade = (t: number) => t * t * t * (t * (t * 6 - 15) + 10)
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t
+
+export function noise3(x: number, y: number, z: number): number {
+    const xi = Math.floor(x), yi = Math.floor(y), zi = Math.floor(z)
+    const xf = fade(x - xi), yf = fade(y - yi), zf = fade(z - zi)
+
+    const c000 = hash(xi, yi, zi), c100 = hash(xi + 1, yi, zi)
+    const c010 = hash(xi, yi + 1, zi), c110 = hash(xi + 1, yi + 1, zi)
+    const c001 = hash(xi, yi, zi + 1), c101 = hash(xi + 1, yi, zi + 1)
+    const c011 = hash(xi, yi + 1, zi + 1), c111 = hash(xi + 1, yi + 1, zi + 1)
+
+    return lerp(
+        lerp(lerp(c000, c100, xf), lerp(c010, c110, xf), yf),
+        lerp(lerp(c001, c101, xf), lerp(c011, c111, xf), yf),
+        zf,
+    )
+}
+
+/**
+ * Four octaves, weights summing to 1 so the result stays in 0..1 and contour
+ * levels can be spaced evenly across it. Time advances faster on the finer
+ * octaves: the broad landforms drift while the detail on them churns, which is
+ * what stops the whole field reading as one sliding sheet.
+ */
+export function fbm3(x: number, y: number, z: number): number {
+    return noise3(x, y, z) * 0.5333
+        + noise3(x * 2.03, y * 2.03, z * 1.7) * 0.2667
+        + noise3(x * 4.01, y * 4.01, z * 2.6) * 0.1333
+        + noise3(x * 8.07, y * 8.07, z * 3.9) * 0.0667
+}
+
+/**
+ * Marching squares for one cell, in unit coordinates.
+ *
+ * Corners are `a` top-left, `b` top-right, `c` bottom-right, `d` bottom-left.
+ * Returns a flat `x0, y0, x1, y1` per segment — flat rather than tupled because
+ * this runs tens of thousands of times a frame and every array allocation shows
+ * up.
+ *
+ * The saddle cases (two opposite corners above the level) are the only ones the
+ * corners do not settle on their own: the contours can join either way, and the
+ * cell centre breaks the tie. Picking arbitrarily produces crossed lines, which
+ * never occur on a real contour map and read immediately as a bug.
+ */
+export function cellSegments(a: number, b: number, c: number, d: number, level: number): number[] {
+    let idx = 0
+    if (a > level) idx |= 8
+    if (b > level) idx |= 4
+    if (c > level) idx |= 2
+    if (d > level) idx |= 1
+    if (idx === 0 || idx === 15) return []
+
+    // Crossing points along each edge, computed only where they are used.
+    const top = () => (level - a) / (b - a)
+    const right = () => (level - b) / (c - b)
+    const bottom = () => (level - d) / (c - d)
+    const left = () => (level - a) / (d - a)
+
+    switch (idx) {
+        case 1: case 14: return [0, left(), bottom(), 1]
+        case 2: case 13: return [bottom(), 1, 1, right()]
+        case 3: case 12: return [0, left(), 1, right()]
+        case 4: case 11: return [top(), 0, 1, right()]
+        case 6: case 9: return [top(), 0, bottom(), 1]
+        case 7: case 8: return [0, left(), top(), 0]
+
+        case 5: return (a + b + c + d) / 4 > level
+            ? [0, left(), top(), 0, bottom(), 1, 1, right()]
+            : [0, left(), bottom(), 1, top(), 0, 1, right()]
+
+        case 10: return (a + b + c + d) / 4 > level
+            ? [0, left(), bottom(), 1, top(), 0, 1, right()]
+            : [0, left(), top(), 0, bottom(), 1, 1, right()]
+
+        default: return []
+    }
+}

--- a/apps/web/lib/topo/field.ts
+++ b/apps/web/lib/topo/field.ts
@@ -74,6 +74,36 @@ export function fbm3(x: number, y: number, z: number): number {
 }
 
 /**
+ * Which contour levels can possibly cross a cell, given its corner range.
+ *
+ * This is the whole performance story. Testing every level against every cell
+ * meant 726,000 calls a frame on a large band to produce 7,900 segments — 99%
+ * of the work established that a contour was nowhere near. A cell only carries
+ * level `v` when `min <= v < max` across its corners, and levels are evenly
+ * spaced, so the handful that qualify can be computed directly.
+ *
+ * Two scalars rather than one `[lo, hi]` tuple, deliberately: this runs once
+ * per cell, and returning a pair allocated 24,000 short-lived arrays a frame on
+ * a large band — which measured as two thirds of the tracing cost, more than
+ * the contour maths it was there to avoid.
+ *
+ * The range is inclusive and clamped into 1..levels. `highestLevel < lowestLevel`
+ * means the cell lies entirely between two contours and can be skipped.
+ *
+ * The top bound is exclusive for the same reason `cellSegments` uses `> level`:
+ * a corner sitting exactly on a level counts as below it. Getting this off by
+ * one drops or duplicates whole contours, and at 6% opacity nobody would notice
+ * until the field looked subtly wrong.
+ */
+export function lowestLevel(min: number, levels: number): number {
+    return Math.max(1, Math.ceil(min * (levels + 1)))
+}
+
+export function highestLevel(max: number, levels: number): number {
+    return Math.min(levels, Math.ceil(max * (levels + 1)) - 1)
+}
+
+/**
  * Marching squares for one cell, in unit coordinates.
  *
  * Corners are `a` top-left, `b` top-right, `c` bottom-right, `d` bottom-left.

--- a/apps/web/styles/donate.module.css
+++ b/apps/web/styles/donate.module.css
@@ -113,6 +113,9 @@
 
 .lede {
     color: #eceff2;
+    /* globals.css sets text-align: left directly on p in @layer base, so the
+       centring inherited from .bandIn never reaches it. */
+    text-align: center;
     font-size: clamp(15.5px, 1.3vw, 18px);
     line-height: 1.6;
     max-width: 46ch;

--- a/apps/web/styles/donate.module.css
+++ b/apps/web/styles/donate.module.css
@@ -1,0 +1,274 @@
+/* ============================================================================
+   ASOT — donate
+   ----------------------------------------------------------------------------
+   The one public page that is pitched at rather than read, which is why it is
+   the one public page that does not use the shared masthead.
+
+   Container/Masthead cap the band at 440px (lib/shell/masthead.ts) on the
+   principle that a page you came to read should not open with a photograph and
+   one word. That principle is right for /about and wrong here. This page asks
+   for money, and asking well means one photograph, one sentence and one button
+   with nothing else competing — so the band deliberately fills the viewport
+   under the navbar, and the column underneath is deliberately the quietest on
+   the site. The contrast between the monument and the document is the design;
+   neither half works without the other.
+
+   The vocabulary — notched button, topo, kickers, Q&A rows, lists — comes from
+   ui.module.css and shell.module.css. Only the monument and its column live
+   here.
+   ========================================================================== */
+
+.page {
+    background: var(--ink-0);
+    font-family: var(--font-ui);
+}
+
+/* ---------- the monument ------------------------------------------------- */
+
+/*
+   Fills what the navbar leaves (28px status strip + 66px bar), capped at 900px
+   so it stops being a monument and starts being a wall on a tall display. The
+   floor matters more than the ceiling: below ~560px the headline, the sentence
+   and the button stop fitting together and the composition collapses.
+*/
+.band {
+    position: relative;
+    height: clamp(560px, calc(100vh - 94px), 900px);
+    overflow: hidden;
+    background: #0b0e10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.bandImg {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+}
+
+.bandImg img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center 40%;
+}
+
+/*
+   Not shell.module.css's veil. That one ramps hard from the left because the
+   copy sits in a left column and the photograph is only allowed through on the
+   right. Here the copy is in the middle, so the darkness has to be too — a
+   centred ellipse, with the vertical pass seating the band under the navbar and
+   landing its bottom edge on --ink-0 rather than on a seam.
+
+   The topo's `edges` mask clears at 34%, inside the ellipse's own ramp, for the
+   same reason it does in the shell: contours that outlive the darkening read as
+   a separate layer floating over the photograph.
+*/
+.veil {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    background:
+        radial-gradient(ellipse 74% 62% at 50% 52%,
+            rgba(6, 7, 9, .86) 0%,
+            rgba(6, 7, 9, .72) 38%,
+            rgba(6, 7, 9, .34) 68%,
+            rgba(6, 7, 9, .2) 100%),
+        linear-gradient(180deg,
+            rgba(6, 7, 9, .62) 0%,
+            transparent 26%,
+            transparent 54%,
+            rgba(6, 7, 9, .96) 100%);
+}
+
+.bandIn {
+    position: relative;
+    z-index: 4;
+    width: 100%;
+    max-width: 980px;
+    padding: 0 clamp(22px, 3.4vw, 49px);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+/*
+   Larger than anything else on the site, deliberately: this is the whole first
+   screen, and at the shell's 72px ceiling it reads as a page heading rather
+   than a statement. The shadow is broader and softer than the shell title's for
+   the same reason — at 118px a tight halo fattens the letterforms.
+*/
+.title {
+    font-family: var(--font-disp);
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: clamp(52px, 8.2vw, 118px);
+    line-height: .9;
+    letter-spacing: .005em;
+    margin: clamp(20px, 2vw, 26px) 0 0;
+    text-shadow: 0 6px 44px rgba(0, 0, 0, .85);
+}
+
+.lede {
+    color: #eceff2;
+    font-size: clamp(15.5px, 1.3vw, 18px);
+    line-height: 1.6;
+    max-width: 46ch;
+    margin: clamp(24px, 2.6vw, 34px) 0 0;
+    padding-top: clamp(20px, 2vw, 26px);
+    border-top: 1px solid rgba(255, 255, 255, .18);
+    text-shadow: 0 2px 12px rgba(0, 0, 0, .9), 0 0 3px rgba(0, 0, 0, .75);
+}
+
+/*
+   The shared Button has md and sm; this needs neither. Rather than adding a
+   third size to a component five other surfaces render — a size only this page
+   would ever ask for — the page scales its own copy here.
+
+   `a.cta` rather than `.cta`: .btn sets the height and .cta overrides it, and
+   two single-class selectors are decided by the order the two CSS modules land
+   in the bundle, which is not something this file gets to know. Adding the
+   element narrows the specificity contest to one this always wins.
+*/
+a.cta {
+    height: 58px;
+    padding: 0 40px;
+    gap: 11px;
+    font-size: 18px;
+    margin-top: clamp(30px, 3vw, 40px);
+    background: color-mix(in srgb, var(--amber) 40%, transparent);
+}
+
+a.cta svg {
+    width: 19px;
+    height: 19px;
+}
+
+/* The plate behind the notch is the button's own; on a photograph it needs to
+   stay dark enough to hold 18px type without swallowing the picture whole. */
+a.cta::before {
+    background: rgba(11, 12, 14, .86);
+}
+
+a.cta:focus-visible {
+    outline: 2px solid var(--amber);
+    outline-offset: 3px;
+}
+
+/* What a donor wants to know before pressing it: that it is safe, what it will
+   charge them in, and that the money is handled somewhere else. */
+.assure {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 20px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: .18em;
+    text-transform: uppercase;
+    color: var(--txt-2);
+    text-shadow: 0 2px 10px rgba(0, 0, 0, .9);
+}
+
+.assure i {
+    width: 3px;
+    height: 3px;
+    background: var(--txt-3);
+    flex: none;
+}
+
+.cue {
+    position: absolute;
+    z-index: 4;
+    bottom: 30px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 9px;
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: .22em;
+    text-transform: uppercase;
+    color: var(--txt-3);
+}
+
+.cue i {
+    width: 1px;
+    height: 26px;
+    background: linear-gradient(180deg, var(--line-2), transparent);
+}
+
+/* ---------- the document ------------------------------------------------- */
+
+/*
+   760px, against the shell body's 1400. Everything above this point is scale;
+   everything below it is the opposite, and the column is narrow because a
+   reader who has just been shouted at should be able to tell they are being
+   spoken to plainly.
+*/
+.doc {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: clamp(56px, 6vw, 96px) 22px 0;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(48px, 5vw, 66px);
+}
+
+.close {
+    margin-top: clamp(20px, 2vw, 28px);
+    padding: 26px 0 clamp(60px, 7vw, 96px);
+    border-top: 1px solid var(--line-1);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+}
+
+.closeLine {
+    font-family: var(--font-disp);
+    font-size: clamp(17px, 1.6vw, 19px);
+    font-weight: 500;
+    letter-spacing: .03em;
+    text-transform: uppercase;
+    color: var(--txt-1);
+    margin: 0;
+}
+
+/* ---------- narrow ------------------------------------------------------- */
+
+@media (max-width: 860px) {
+    /* A monument that fills a phone is just a wall — and the button has to land
+       above the fold or the whole composition is decorative. */
+    .band {
+        height: clamp(480px, calc(100vh - 94px), 640px);
+    }
+
+    a.cta {
+        height: 56px;
+        width: 100%;
+        font-size: 17px;
+    }
+
+    /* Two lines at this width, so the dot separators would orphan mid-wrap. */
+    .assure {
+        flex-direction: column;
+        gap: 5px;
+    }
+
+    .assure i {
+        display: none;
+    }
+
+    /* Side by side these get ~170px each and the button label wraps. */
+    .close {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/apps/web/styles/shell.module.css
+++ b/apps/web/styles/shell.module.css
@@ -882,34 +882,200 @@
 
 .channels {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 16px;
 }
 
-.widget {
-    border: 1px solid var(--line-1);
-    border-top: 2px solid var(--discord);
+/* A badge on the right of a channel head — "Start here" on the primary one,
+   the live TeamSpeak count on another. Pushed over rather than given a margin
+   so the head stays a plain gap-spaced row. */
+.channelH em {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 8.5px;
+    font-style: normal;
+    letter-spacing: .18em;
+    text-transform: uppercase;
+    color: var(--amber);
+    white-space: nowrap;
+}
+
+.channelH em.channelLive {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--live);
+}
+
+/* ---------- presence panel ----------------------------------------------- */
+
+/*
+   What replaced the embedded Discord widget.
+
+   The widget's one real virtue was showing the place is alive; its cost was
+   saying so in Discord's design language, and publishing our members' display
+   names to anyone who opened the page. This makes the same claim in our own
+   numbers and our own type, and says nothing about who is here beyond how
+   many.
+
+   The three figures are the navbar rail's, at six times the size. The rail is
+   a clock you glance at; this is the page's opening statement.
+*/
+.presence {
+    position: relative;
+    border: 1px solid var(--line-2);
     background: var(--ink-1);
-    padding: 20px;
+    overflow: hidden;
+}
+
+.presenceH {
+    position: relative;
+    z-index: 2;
     display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-/* The widget's description sits under .widget, which has no `p` rule of its
-   own — without this it inherits browser-default 16px full-strength body text
-   beside three .channel p siblings. */
-.widget p {
+    align-items: center;
+    gap: 12px;
+    padding: 16px 26px;
+    border-bottom: 1px solid var(--line-1);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: .22em;
+    text-transform: uppercase;
     color: var(--txt-2);
-    font-size: 13.2px;
-    line-height: 1.58;
-    margin: 0;
 }
 
-.widget iframe {
-    width: 100%;
-    height: 500px;
-    border: none;
+.presenceH b {
+    margin-left: auto;
+    font-weight: 400;
+    font-size: 9.5px;
+    letter-spacing: .18em;
+    color: var(--txt-3);
+}
+
+.presenceGrid {
+    position: relative;
+    z-index: 2;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.presenceCell {
+    padding: 34px 26px;
+    border-left: 1px solid var(--line-1);
+}
+
+.presenceCell:first-child {
+    border-left: 0;
+}
+
+.presenceK {
+    font-family: var(--font-mono);
+    font-size: 9.5px;
+    letter-spacing: .2em;
+    text-transform: uppercase;
+    color: var(--txt-3);
+}
+
+/*
+   Tabular figures: the countdown repaints every thirty seconds, and without
+   them the panel twitches sideways each time a 1 becomes a 4.
+*/
+.presenceN {
+    font-family: var(--font-disp);
+    font-size: clamp(42px, 4.4vw, 62px);
+    font-weight: 700;
+    line-height: 1;
+    color: var(--txt-1);
+    margin-top: 12px;
+    font-variant-numeric: tabular-nums;
+}
+
+.presenceNLive {
+    color: var(--live);
+}
+
+.presenceNAmber {
+    color: var(--amber);
+}
+
+/* Grey, not green. A zero painted in the live colour claims the opposite of
+   what the number is saying — and an em dash means "we don't know", which is a
+   third state again. */
+.presenceNIdle {
+    color: var(--txt-3);
+}
+
+.presenceCell p {
+    color: var(--txt-2);
+    font-size: 13.4px;
+    line-height: 1.6;
+    margin: 12px 0 0;
+}
+
+.presenceCell a,
+.presenceLede a {
+    color: var(--amber);
+    border-bottom: 1px solid rgba(216, 172, 69, .4);
+}
+
+.presenceLede {
+    color: var(--txt-2);
+    font-size: 15px;
+    line-height: 1.65;
+    max-width: 68ch;
+    margin: 26px 0 0;
+}
+
+@media (max-width: 1180px) {
+    .channels {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 860px) {
+    .channels {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    /*
+       Three cells across a phone give each about 115px, and a 62px numeral ends
+       up alone on a line above its own label. Stacked, the figure keeps its
+       weight beside the label and the rules between cells turn horizontal.
+    */
+    .presenceGrid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .presenceCell {
+        border-left: 0;
+        border-top: 1px solid var(--line-1);
+        display: grid;
+        grid-template-columns: 84px minmax(0, 1fr);
+        column-gap: 16px;
+        align-items: start;
+        padding: 22px 18px;
+    }
+
+    .presenceCell:first-child {
+        border-top: 0;
+    }
+
+    .presenceK {
+        grid-column: 2;
+        grid-row: 1;
+    }
+
+    .presenceN {
+        grid-column: 1;
+        grid-row: 1 / 3;
+        font-size: 40px;
+        margin-top: 0;
+    }
+
+    .presenceCell p {
+        grid-column: 2;
+        grid-row: 2;
+        margin-top: 7px;
+    }
 }
 
 /* ---------- callsign card ------------------------------------------------ */

--- a/apps/web/styles/ui.module.css
+++ b/apps/web/styles/ui.module.css
@@ -16,16 +16,14 @@
 /* ---------- topo backdrop ------------------------------------------------ */
 
 /*
-   The drifting contour field. The mockups inlined ~160KB of contour paths and
-   repeated them with two <use> copies; here the same art is an external file
-   (public/designs/topo.svg, viewBox 0 0 2400 800) painted as a repeating
-   background, so it is cached once by the browser and never lands in the HTML
-   of every page.
+   The contour field. Drawn to a canvas by components/ui/Topo, which generates
+   the lines rather than translating a picture of them — see the notes there and
+   in lib/topo/field.ts.
 
-   The seam-free loop is the same trick by other means: the tile div is 340% of
-   its container wide with tiles at 50% of that (= 170% of the container), so
-   translating it by exactly -50% of itself advances precisely one tile. There
-   is no jump to hide, which is what makes an arbitrarily slow drift safe.
+   Only the frame and the edge masks live here now. The tile, its seam-free
+   translate loop and the reduced-motion override all went with the SVG: there
+   is no tile to advance, and the component holds a single frame rather than
+   pausing an animation.
 */
 .topo {
     position: absolute;
@@ -35,19 +33,10 @@
     z-index: 0;
 }
 
-.topoTile {
-    position: absolute;
-    top: 0;
-    left: 0;
+.topoCanvas {
+    display: block;
+    width: 100%;
     height: 100%;
-    width: 340%;
-    background-image: url('/designs/topo.svg');
-    background-repeat: repeat-x;
-    background-size: 50% auto;
-    /* The art is far taller than most bands it sits in; centring shows a
-       horizontal slice rather than the whole field. */
-    background-position: left center;
-    opacity: var(--topo-op, 0.065);
 }
 
 /* Fades in from both edges — for full-width bands that shouldn't have the
@@ -73,22 +62,6 @@
 .topoLeft {
     -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 38%, transparent 74%);
     mask-image: linear-gradient(90deg, #000 0%, #000 38%, transparent 74%);
-}
-
-.topoDrift .topoTile {
-    animation: topodrift var(--topo-drift, 720s) linear infinite;
-}
-
-@keyframes topodrift {
-    to {
-        transform: translateX(-50%);
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .topoDrift .topoTile {
-        animation: none;
-    }
 }
 
 /* ---------- notched button ----------------------------------------------- */


### PR DESCRIPTION
Three pieces of work, in the order they happened. The first two are the "second wave" the [public page shell spec](apps/web/docs/superpowers/specs/2026-08-21-public-page-shell-design.md) deferred; the third started as a question about the topo backdrop and turned into a rewrite.

Both page designs were settled on mockups before any code, and the chosen directions are still browsable — [donate](https://claude.ai/code/artifact/b60fcdd6-f5b5-4a14-8fe6-0e755ef4d3ab), [contact](https://claude.ai/code/artifact/062628ec-f1b6-4159-ba13-1b01308477ea), each with the unchosen alternatives on a second page.

---

### Donate — a monument and a document

The last public surface still on raw MUI: `Typography`, `Divider`, MUI icons, a PayPal-blue CTA and five identical red-topped boxes. None of the site's own vocabulary was on it.

It is now the **one page that deliberately does not render `Container`**. The shared masthead caps its band at 440px on the principle that a page you came to read should not open with a photograph and one word. That is right for `/about` and wrong here: this page asks for money, and asking well means one photograph, one sentence and one button with nothing else competing. The band fills the viewport under the navbar, capped at 900px; the column underneath is the narrowest and quietest on the site. The contrast between the two *is* the design, and the reasoning is in a header comment on the CSS module so nobody later "fixes" it back.

Everything else is standard vocabulary rather than new invention — the notched amber button, the topo, the FAQ's Q&A rows, the real list from Rules. The CTA is amber because `globals.css` already assigns amber the "information / support" meaning and names the donate button as a consumer; the old blue was the outlier.

Copy is verbatim from the page it replaces, with one exception worth flagging: **the headline is new.** "Keep it running" replaces "Donate to ASOT", because the monument needs a statement rather than a page title. Easy to revert if you would rather not put words in the unit's mouth.

### Contact — proof of life instead of a list of pipes

The page opened on an embedded Discord widget: a third-party iframe carrying Discord's blurple, Discord's type, Discord's button, and **a scrolling list of our members' display names published to anyone who loaded the page**. It was also the only element doing visual work, which is why the three cards beside it read as thin.

What the widget genuinely provided was proof the place is alive, so that is what replaces it — the same claim in our own numbers and our own type, saying nothing about who is here beyond how many. TeamSpeak online, active roster, next-op countdown; all three already fetched for the navbar rail, read straight from the loaders since the page is a server component.

Each figure degrades on its own and says so honestly. **A cold TeamSpeak cache is an em dash, not a zero** — "we don't know" and "nobody is here" are different claims, and only one of them is grey rather than green. With nobody in voice the tile keeps the zero and the line underneath does the work; that quiet state is the whole risk of leading with live data, so it was designed rather than left to chance.

### Topo — generated, not scrolled

`public/designs/topo.svg` was one tile of contour paths translated sideways. Cheap, and it could never do anything but slide: the lines are baked into the file, so there is nothing there to warp.

The field is computed now — a noise field whose third axis is time, traced into isolines every frame by marching squares, so individual contours stretch, pinch, split in two and close into rings as terrain moves under them. Domain warping is what makes it shear rather than slide. Line weight varies the way the old asset's did but computed rather than drawn: every Nth contour is an index line at 1.85x weight and 2.15x opacity — the cartographic convention that lets elevation bands read at a glance — with a depth ramp fading the low contours for relief. Parameters were tuned on a [live prototype](https://claude.ai/code/artifact/3fbac371-a36b-4fa7-92dd-82e017d8e1f2), not guessed.

Two bugs found and fixed after it landed, both with regression tests:

**It opened frozen and surged.** Measured at 0.1% of the steady rate on the first frame, peaking at 109% around 60s. Not the animation loop — `noise3` applied the quintic fade to all three axes, and that curve's derivative is exactly zero at every lattice boundary. On the spatial axes that is the point; on the time axis the derivative *is* the perceived speed. At `clock = 0` all four octaves sit on a boundary at once, so every page load started from the one point where the field is completely still. Time now interpolates linearly: load-time rate 0.001 → 0.957 of steady state.

**It stuttered on tall bands.** Cost scales with area/cell², so the 66px navbar strip was fine at 2.3ms while a 620px band hit 18.8ms. Almost all of it was waste — tracing tested every level against every cell, 726,000 calls a frame to produce 7,900 segments. A cell's corners bound which levels can cross it, so the loop is now cell-major with a per-level segment buffer. Navbar 2.3 → 1.3ms, enlist band 18.8 → 10.5ms, donate monument 26.8 → 14.7ms. Then 30fps instead of 60 (the field crosses one noise cell every three minutes), and **an adaptive grid** that coarsens when frames run long and refines when they do not.

Props are unchanged, so all seven call sites work untouched, and this can be reverted by swapping one file.

---

### Testing

`tsc --noEmit`, lint, and 24 vitest tests clean. New coverage in `lib/`, where the repo's vitest picks it up:

- `lib/topo/field.test.ts` — marching-squares saddle resolution (two opposite corners above the level can join either way; the cell centre breaks the tie, and guessing yields crossed contours), the level-range optimisation never excluding a level `cellSegments` would have drawn, and the field's rate of change staying steady over time.
- `lib/contact/countdown.test.ts` — the next-op display figure, which floors rather than rounds so it never claims time the reader does not have.

Site map entries updated per `apps/web/CLAUDE.md`, including removal of a stale `components/nav/Topo.tsx` entry for a file that no longer exists.

**Not verified:** none of this has been looked at rendered. The perf figures are Node-side — the same engine, but without canvas stroke cost — so treat them as the shape of the improvement rather than absolutes. The landing page, which mounts several bands at once, is the real test.

### Known, deliberate, and left for a decision

- **Call-site opacities are unchanged** (0.045–0.32). The field was tuned at 0.102, so bands read fainter than the prototype. Each was tuned per surface against the old raster, and rescaling six of them quietly was not mine to do. `navbar.tsx:327` at 0.32 is the one most likely wrong now — with the index boost its heavy lines land near 0.8 alpha, and it was tuned for uniform-weight lines.
- **`topo.svg` is still on disk**, referenced by nothing. It is the way back.
- **Every Topo instance starts at `clock = 0`**, so all bands on a page render the identical field and every reload starts from the same pattern. Harmless; a per-instance phase offset would fix it.
- **The join page** still carries the same `Applications` / `Open` status this branch removed elsewhere, and its `Location: AU / NZ` row contradicts `WhySection.tsx`'s "Australia, New Zealand **and Asia**". Worth deciding which is the real policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
