### PR TITLE
feat(operations): a Sci-Fi theme — the orders on a bridge console

### DIFF
--- a/apps/web/app/operations/[id]/OperationTabs.tsx
+++ b/apps/web/app/operations/[id]/OperationTabs.tsx
@@ -139,7 +139,11 @@ export default function OperationTabs({ operationId, active, canEdit, signedIn =
                      * that browsers unnest on you — and because clicking the label
                      * itself should still just open the orders.
                      */
-                    <span key={t} className={s.tabSlot} ref={hasMenu ? slotRef : undefined}>
+                    <span
+                        key={t}
+                        className={`${s.tabSlot} ${t === active ? s.tabSlotOn : ''}`}
+                        ref={hasMenu ? slotRef : undefined}
+                    >
                         <Link
                             href={t === 'orders' ? ordersHref : tabHref(operationId, t)}
                             aria-current={t === active ? 'page' : undefined}

--- a/apps/web/app/operations/[id]/page.tsx
+++ b/apps/web/app/operations/[id]/page.tsx
@@ -7,6 +7,7 @@ import { hasPermission } from '@/lib/orbat/hasPermission'
 import ClassicPage from './themes/ClassicPage'
 import ModernPage from './themes/ModernPage'
 import ColdWarPage from './themes/ColdWarPage'
+import SciFiPage from './themes/SciFiPage'
 import type { OrdersAttendance, OrdersLineage, ThemePageProps } from './themes/theme-props'
 
 /**
@@ -72,17 +73,24 @@ export default async function Page({ params, searchParams }: { params: Promise<{
      * Themes that have their own page get one; everything else falls back to
      * the page as it always looked. `coldwar` was already a selectable era with
      * no rendering of its own, which is why choosing it used to give you Modern.
+     *
+     * `scifi` is the other direction: it *did* render, as ClassicPage's `isSF`
+     * variant, and now has a page of its own instead. ClassicPage keeps that
+     * branch — it is the fallback for anything unrecognised, and deleting a
+     * working code path to tidy up is how a fallback stops being one — but
+     * nothing routes to it any more.
      */
     const pageTheme = operation.pageTheme || 'modern'
-    if (pageTheme !== 'modern' && pageTheme !== 'coldwar') return <ClassicPage {...shared} />
+    const OWN_PAGE = { modern: ModernPage, coldwar: ColdWarPage, scifi: SciFiPage } as const
+    const Themed = OWN_PAGE[pageTheme as keyof typeof OWN_PAGE]
+    if (!Themed) return <ClassicPage {...shared} />
 
     const [attendance, lineage] = await Promise.all([
         readAttendance(id, me?.id ?? null),
         readLineage(operation),
     ])
 
-    const themed = { ...shared, attendance, lineage }
-    return pageTheme === 'coldwar' ? <ColdWarPage {...themed} /> : <ModernPage {...themed} />
+    return <Themed {...shared} attendance={attendance} lineage={lineage} />
 }
 
 /**

--- a/apps/web/app/operations/[id]/tabs.module.css
+++ b/apps/web/app/operations/[id]/tabs.module.css
@@ -68,8 +68,18 @@
     flex-shrink: 0;
 }
 .tab:hover { color: var(--ink-2); }
-.tabOn { color: var(--ink); border-bottom-color: var(--acc); }
+.tabOn { color: var(--ink); border-bottom-color: var(--acc); box-shadow: var(--tab-glow, none); }
 .tab:focus-visible { outline: 2px solid var(--acc); outline-offset: -2px; }
+
+/*
+ * `--tab-glow` is the strip's one themeable seam beyond `--acc`, and it
+ * defaults to `none` so every theme that does not set it renders exactly as
+ * before. It exists for the Sci-Fi console, where the underline is a phosphor
+ * rule and has to emit rather than just be coloured — see `themes/SciFiPage`.
+ * A theme passes it through `OperationBar`'s `palette`, which lands inline on
+ * the bar; custom properties inherit, so it reaches here without this file
+ * knowing anything about the theme.
+ */
 
 /* The label half of the split: the caret takes over its right padding, so the
    two read as one control rather than a tab with something stuck beside it. */
@@ -88,6 +98,7 @@
     background: none;
     border: none;
     border-bottom: 2px solid var(--acc);
+    box-shadow: var(--tab-glow, none);
     color: var(--ink-3);
     font-size: 8px;
     line-height: 1;

--- a/apps/web/app/operations/[id]/tabs.module.css
+++ b/apps/web/app/operations/[id]/tabs.module.css
@@ -89,11 +89,18 @@
  * escape its own box. So the glow pools *upward* from the rule into the tab,
  * which is also what a lit rule physically does to the surface above it.
  */
-.tabOn,
-.caret { position: relative; }
-
-.tabOn::after,
-.caret::after {
+/*
+ * Drawn once, by the slot, rather than once per half.
+ *
+ * Orders is a split control — a label and a caret, two boxes sharing one
+ * underline — and giving each half its own glow meant the two had to meet
+ * exactly. Butted, sub-pixel rounding left a dark hairline; overlapped, two
+ * translucent gradients stacked to a *bright* one, which is the vertical rule
+ * that appeared between ORDERS and its caret. There is no third option at that
+ * seam, so the seam has to go: `.tabSlot` already wraps both halves, so one
+ * gradient across it has nothing to line up with.
+ */
+.tabSlotOn::after {
     content: '';
     position: absolute;
     left: 0;
@@ -103,11 +110,6 @@
     pointer-events: none;
     background: var(--tab-glow, transparent);
 }
-
-/* The label and caret halves of the Orders control are two boxes sharing one
-   underline, so their glows have to meet without a seam down the join. */
-.tabSplit::after { right: -3px; }
-.caret::after { left: -1px; }
 
 /* The label half of the split: the caret takes over its right padding, so the
    two read as one control rather than a tab with something stuck beside it. */

--- a/apps/web/app/operations/[id]/tabs.module.css
+++ b/apps/web/app/operations/[id]/tabs.module.css
@@ -68,18 +68,46 @@
     flex-shrink: 0;
 }
 .tab:hover { color: var(--ink-2); }
-.tabOn { color: var(--ink); border-bottom-color: var(--acc); box-shadow: var(--tab-glow, none); }
+.tabOn { color: var(--ink); border-bottom-color: var(--acc); }
 .tab:focus-visible { outline: 2px solid var(--acc); outline-offset: -2px; }
 
 /*
- * `--tab-glow` is the strip's one themeable seam beyond `--acc`, and it
- * defaults to `none` so every theme that does not set it renders exactly as
- * before. It exists for the Sci-Fi console, where the underline is a phosphor
- * rule and has to emit rather than just be coloured — see `themes/SciFiPage`.
- * A theme passes it through `OperationBar`'s `palette`, which lands inline on
- * the bar; custom properties inherit, so it reaches here without this file
- * knowing anything about the theme.
+ * `--tab-glow` is the strip's one themeable seam beyond `--acc`: the light the
+ * active underline throws. It defaults to `transparent`, so every theme that
+ * does not set it renders exactly as before. It exists for the Sci-Fi console,
+ * where the underline is a phosphor rule and has to emit rather than just be
+ * coloured — see `themes/SciFiPage`. A theme passes it through
+ * `OperationBar`'s `palette`, which lands inline on the bar; custom properties
+ * inherit, so it reaches here without this file knowing anything about the
+ * theme.
+ *
+ * It is a *background* on a pseudo-element rather than a `box-shadow`, and that
+ * is the whole point of the shape. A box-shadow haloes all four sides — even
+ * with a negative spread and a downward offset, enough light escapes left and
+ * right to draw a hairline down each edge of the tab, which read as a stray
+ * vertical rule between Orders and the tab beside it. A background cannot
+ * escape its own box. So the glow pools *upward* from the rule into the tab,
+ * which is also what a lit rule physically does to the surface above it.
  */
+.tabOn,
+.caret { position: relative; }
+
+.tabOn::after,
+.caret::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 14px;
+    pointer-events: none;
+    background: var(--tab-glow, transparent);
+}
+
+/* The label and caret halves of the Orders control are two boxes sharing one
+   underline, so their glows have to meet without a seam down the join. */
+.tabSplit::after { right: -3px; }
+.caret::after { left: -1px; }
 
 /* The label half of the split: the caret takes over its right padding, so the
    two read as one control rather than a tab with something stuck beside it. */
@@ -98,7 +126,6 @@
     background: none;
     border: none;
     border-bottom: 2px solid var(--acc);
-    box-shadow: var(--tab-glow, none);
     color: var(--ink-3);
     font-size: 8px;
     line-height: 1;

--- a/apps/web/app/operations/[id]/themes/ConsoleRail.tsx
+++ b/apps/web/app/operations/[id]/themes/ConsoleRail.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import type { Route } from 'next'
+import type { SpineDocument, SpineSection } from './OrdersSpine'
+import s from './scifi.module.css'
+
+interface Props {
+    operationId: string
+    documents: SpineDocument[]
+    activeDocument: string
+    /** Sections of the *active* document only — the others aren't rendered. */
+    sections: SpineSection[]
+    fromJ2: boolean
+}
+
+/**
+ * The console's index: documents, with the open one's sections nested beneath.
+ *
+ * Same model as `OrdersSpine` and `FileTabs`, and deliberately — three themes
+ * drawing one navigation three ways is fine, three themes *disagreeing* about
+ * what is in the file is not. Documents are `?page=` links, so each has a URL
+ * somebody can paste; sections are buttons that scroll, because a hash left in
+ * the address bar would fight the scroll-spy over which one is current.
+ *
+ * The observer band sits across the upper third of the viewport, which is what
+ * makes "current" mean the section you are reading rather than whichever one
+ * last touched the bottom edge.
+ */
+export default function ConsoleRail({ operationId, documents, activeDocument, sections, fromJ2 }: Props) {
+    const [activeSection, setActiveSection] = useState<string | null>(null)
+
+    useEffect(() => {
+        if (!sections.length) return
+
+        const observers = sections.map(sec => {
+            const el = document.getElementById(`section-${sec.id}`)
+            if (!el) return null
+            const observer = new IntersectionObserver(
+                ([entry]) => { if (entry.isIntersecting) setActiveSection(sec.id) },
+                { rootMargin: '-20% 0px -70% 0px', threshold: 0 },
+            )
+            observer.observe(el)
+            return observer
+        })
+
+        return () => observers.forEach(o => o?.disconnect())
+    }, [sections])
+
+    const docHref = (pageId: string): Route => {
+        const params = new URLSearchParams()
+        if (pageId !== 'main') params.set('page', pageId)
+        if (fromJ2) params.set('from', 'j2')
+        const query = params.toString()
+        return (query ? `/operations/${operationId}?${query}` : `/operations/${operationId}`) as Route
+    }
+
+    const scrollTo = (sectionId: string) => {
+        const el = document.getElementById(`section-${sectionId}`)
+        if (!el) return
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        setActiveSection(sectionId)
+    }
+
+    const orders = documents.filter(d => d.group === 'orders')
+    const aside = documents.filter(d => d.group === 'aside')
+
+    const renderDoc = (doc: SpineDocument, i: number) => {
+        const on = doc.id === activeDocument
+        return (
+            <div key={doc.id}>
+                <Link
+                    href={docHref(doc.id)}
+                    className={on ? `${s.doc} ${s.docOn}` : s.doc}
+                    aria-current={on ? 'page' : undefined}
+                >
+                    <span className={s.docNum}>{String(i + 1).padStart(2, '0')}</span>
+                    {doc.title}
+                </Link>
+
+                {on && sections.length > 1 && (
+                    <ul className={s.secs}>
+                        {sections.map((sec, n) => (
+                            <li key={sec.id}>
+                                <button
+                                    type='button'
+                                    className={sec.id === activeSection ? `${s.sec} ${s.secOn}` : s.sec}
+                                    onClick={() => scrollTo(sec.id)}
+                                >
+                                    <span className={s.secN}>{n + 1}.</span>
+                                    <span>{sec.title}</span>
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        )
+    }
+
+    return (
+        <nav className={s.rail} aria-label='Orders contents'>
+            <span className={s.railHead}>Operation file</span>
+            {orders.map(renderDoc)}
+
+            {aside.length > 0 && (
+                <>
+                    <span className={`${s.railHead} ${s.railHeadLater}`}>Attached</span>
+                    {aside.map((doc, i) => renderDoc(doc, orders.length + i))}
+                </>
+            )}
+        </nav>
+    )
+}

--- a/apps/web/app/operations/[id]/themes/ConsoleRsvp.tsx
+++ b/apps/web/app/operations/[id]/themes/ConsoleRsvp.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useRsvpCountdown } from './useRsvpCountdown'
+import s from './scifi.module.css'
+
+interface Props {
+    operationId: string
+    /** SSR value, so the gauge has a shape before the live read lands. */
+    rsvpOpen: boolean
+}
+
+/**
+ * The one live gauge on the console: how long is left to answer.
+ *
+ * The rules come from `useRsvpCountdown`, shared with Modern and Cold War so
+ * the three cannot end up disagreeing about the same operation. Only the
+ * drawing differs — amber on a green screen, the single warm cell in the row,
+ * which is what makes the deadline the first thing read.
+ */
+export default function ConsoleRsvp({ operationId, rsvpOpen }: Props) {
+    const { key, value, urgent, ready } = useRsvpCountdown(operationId, rsvpOpen)
+
+    // A gauge reading "—" is worse than one that isn't there.
+    if (!ready) return null
+
+    return (
+        <div className={urgent ? `${s.gauge} ${s.gaugeHot}` : s.gauge}>
+            <dt className={s.gaugeKey}>{key}</dt>
+            <dd className={s.gaugeVal}>{value}</dd>
+        </div>
+    )
+}

--- a/apps/web/app/operations/[id]/themes/SciFiPage.tsx
+++ b/apps/web/app/operations/[id]/themes/SciFiPage.tsx
@@ -1,0 +1,403 @@
+import dayjs from 'dayjs'
+import Link from 'next/link'
+import type { Route } from 'next'
+import DocBody from '../doc-body'
+import LocalDate from '../local-date'
+import OcapLinkPanel from '../OcapLinkPanel'
+import OcapStatsPanel from '../OcapStatsPanel'
+import DocAcknowledgeCard from '../DocAcknowledgeCard'
+import OperationBar from '../OperationBar'
+import EditOrdersButton from '../EditOrdersButton'
+import HideSiteNav from '@/components/HideSiteNav'
+import ConsoleRail from './ConsoleRail'
+import ConsoleRsvp from './ConsoleRsvp'
+import type { SpineDocument } from './OrdersSpine'
+import type { ModernPageProps } from './theme-props'
+import s from './scifi.module.css'
+
+const OCAP = '__ocap__'
+
+/** Ten segments, because a console reads in segments. */
+const SEATS_SEGMENTS = 10
+
+/**
+ * The operation bar, repainted as the console's own strip.
+ *
+ * Same contract Cold War established: the bar and its tab strip draw entirely
+ * from `.command` tokens, and that class sits on the bar itself — so these have
+ * to arrive as inline styles to outrank it. They are `var()` references rather
+ * than literals wherever the theme already has a token for it, so
+ * `scifi.module.css` stays the one place this palette is written down.
+ *
+ * The bar is the one lit thing outside the glass, and it is lit the way a
+ * backlit panel is rather than the way the tube is: a dark strip with a
+ * phosphor hairline under it. Measured on that strip, the title reads 15.4:1,
+ * tab labels 6.1:1 and the accent 12.6:1.
+ */
+const CONSOLE_CHROME: Record<string, string> = {
+    '--s1': '#101519',
+    '--s2': '#161d21',
+    '--s3': '#1d2529',
+    '--line': 'var(--grid)',
+    '--line-2': 'rgba(98, 232, 176, 0.28)',
+    '--ink': 'var(--ink)',
+    '--ink-2': 'var(--ink-2)',
+    '--ink-3': 'var(--ink-3)',
+    '--acc': 'var(--phos)',
+    '--acc-rgb': '98, 232, 176',
+    /* The status dot. Amber for Upcoming is the same warm-second-voice rule the
+       RSVP gauge follows, and the stock green would be indistinguishable from
+       the phosphor everything else on the bar is drawn in. */
+    '--good': 'var(--phos-2)',
+    '--warn': 'var(--amber)',
+    '--crit': 'var(--alarm)',
+
+    /* Backlit glass rather than painted metal: a faint phosphor cast rising
+       through a dark strip, with the tube's own fibre showing in it. */
+    '--bar-bg': [
+        'repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.18) 0 1px, transparent 1px 3px)',
+        'linear-gradient(180deg, rgba(23, 33, 32, 0.96) 0%, rgba(10, 15, 15, 0.98) 100%)',
+    ].join(', '),
+
+    /* The hairline the strip sits on, then its shadow on the hull below. */
+    '--bar-shadow': [
+        'inset 0 1px 0 rgba(98, 232, 176, 0.10)',
+        '0 1px 0 rgba(98, 232, 176, 0.18)',
+        '0 10px 30px rgba(0, 0, 0, 0.6)',
+    ].join(', '),
+
+    '--bar-edge': '1px solid rgba(98, 232, 176, 0.22)',
+
+    /*
+     * The one thing this theme adds to the tab strip: the active tab's
+     * underline emits. Offset downward with a negative spread so the light
+     * pools under the rule rather than haloing the whole tab.
+     */
+    '--tab-glow': '0 3px 14px -4px var(--phos)',
+}
+
+/**
+ * The Sci-Fi orders page — "Bridge Console".
+ *
+ * The orders as a piece of hardware: a brushed hull, a bezel with screws, and
+ * behind it a slab of dead-black glass with phosphor burning inside. The whole
+ * theme rests on one rule — **the light never leaves the screen** — which is
+ * what separates a CRT from a filter laid over a page.
+ *
+ * It shares Modern's data exactly (`page.tsx` does all the fetching and every
+ * permission check) and disagrees with it about what the page *is*. That is
+ * what a theme is for here, and why each one is its own file.
+ *
+ * Two things it does that Modern does not:
+ *
+ * - **The console outlives the document.** Title, gauges and the two calls sit
+ *   on the screen rather than on the open document, so they stay put when you
+ *   switch pages in the rail. A console's readout does not change because you
+ *   changed channel.
+ * - **Encryption instead of a locked banner.** A logged-out reader gets the
+ *   document with the paragraphs they cannot see rendered as signal that
+ *   arrives and fails to resolve, in place. Same call Cold War made with its
+ *   strikeouts, and for the same reason: you can see how much is withheld and
+ *   where it sits.
+ */
+export default function SciFiPage({
+    id, operation, isLoggedIn, isHQ, canZeus, showAcknowledgeCard,
+    activePageParam, fromJ2, attendance, lineage,
+}: ModernPageProps) {
+    /*
+     * Zeus Notes pages are ordinary documents — same sections, same schema,
+     * same editor — and the only thing that sets them apart is who may open
+     * one. A viewer without `operations.zeus` never sees the page listed, so
+     * there is nothing to click and nothing to 404 on.
+     *
+     * OCAP is still excluded here: it is a panel of match statistics, not a
+     * document with sections.
+     *
+     * The id de-dupe guards against stale Yjs race-condition data in Mongo,
+     * which has produced duplicate pages before.
+     */
+    const seen = new Set<string>()
+    const contentPages = (operation.pages ?? []).filter(pg => {
+        if (pg.pageType === 'ocap') return false
+        if (pg.pageType === 'zeus' && !canZeus) return false
+        if (seen.has(pg.id)) return false
+        seen.add(pg.id)
+        return true
+    })
+
+    const documents: SpineDocument[] = contentPages.length > 1
+        ? contentPages.map(pg => ({ id: pg.id, title: pg.title, group: 'orders' as const }))
+        : [{ id: contentPages[0]?.id ?? 'main', title: contentPages[0]?.title || 'Operation Orders', group: 'orders' as const }]
+
+    const hasOcap = isHQ || (isLoggedIn && !!operation.ocap)
+    if (hasOcap) documents.push({ id: OCAP, title: 'OCAP Replay', group: 'aside' })
+
+    const validIds = documents.map(d => d.id)
+    const activeDocument = activePageParam && validIds.includes(activePageParam)
+        ? activePageParam
+        : documents[0].id
+    const onContent = activeDocument !== OCAP
+
+    const rawSections = activeDocument === 'main'
+        ? operation.sections ?? []
+        : operation.extraPageSections?.[activeDocument] ?? operation.sections ?? []
+    const readable = rawSections.filter(sec => isLoggedIn || sec.isPublic)
+
+    const documentTitle = documents.find(doc => doc.id === activeDocument)?.title ?? 'Operation Orders'
+    const loreDate = operation.loreDate ? dayjs(operation.loreDate) : null
+    const attendanceHref = `/operations/${id}/attendance` as Route
+
+    const refLine = [
+        operation.department,
+        lineage?.campaign,
+        lineage?.sequence ? `Mission ${String(lineage.sequence).padStart(2, '0')}` : null,
+        operation.daySlot ? `${operation.daySlot} serial` : null,
+    ].filter(Boolean).join(' // ')
+
+    return (
+        <div className={s.page}>
+            <HideSiteNav />
+            <OperationBar
+                operationId={id}
+                title={operation.title}
+                status={operation.status}
+                themeColor={operation.themeColor}
+                active='orders'
+                canEdit={isHQ}
+                signedIn={isLoggedIn}
+                fromJ2={fromJ2}
+                palette={CONSOLE_CHROME}
+            />
+
+            <div className={s.hull}>
+                <div className={s.bezel}>
+                    <span className={`${s.screw} ${s.screwTL}`} aria-hidden />
+                    <span className={`${s.screw} ${s.screwTR}`} aria-hidden />
+                    <span className={`${s.screw} ${s.screwBL}`} aria-hidden />
+                    <span className={`${s.screw} ${s.screwBR}`} aria-hidden />
+
+                    <div className={s.glass}>
+                        <div className={s.sweep} aria-hidden />
+
+                        <div className={s.screen}>
+                            <header className={operation.coverImage ? s.head : `${s.head} ${s.headSolo}`}>
+                                <div>
+                                    <p className={s.ref}>
+                                        {refLine ? <span className={s.refLit}>{refLine}</span> : null}
+                                        {refLine && operation.status ? ' // ' : ''}
+                                        {operation.status}
+                                    </p>
+                                    <h1 className={s.title}>{operation.title || 'Untitled Operation'}</h1>
+                                </div>
+
+                                {operation.coverImage && (
+                                    <figure className={s.feed}>
+                                        <img className={s.feedImg} src={operation.coverImage} alt='' />
+                                        <figcaption className={s.feedCap}>
+                                            <span>{'Feed 01 // '}{operation.mapWorld || 'AO'}</span>
+                                            <span className={s.feedRec}>● REC</span>
+                                        </figcaption>
+                                    </figure>
+                                )}
+                            </header>
+
+                            <dl className={s.gauges}>
+                                {operation.date && (
+                                    <div className={s.gauge}>
+                                        <dt className={s.gaugeKey}>Step off</dt>
+                                        <dd className={s.gaugeVal}><LocalDate iso={new Date(operation.date).toISOString()} /></dd>
+                                    </div>
+                                )}
+                                {loreDate?.isValid() && (
+                                    <div className={s.gauge}>
+                                        <dt className={s.gaugeKey}>In-game</dt>
+                                        <dd className={s.gaugeVal}>{loreDate.format('DD MMM YYYY').toUpperCase()}</dd>
+                                    </div>
+                                )}
+                                {operation.mapWorld && (
+                                    <div className={s.gauge}>
+                                        <dt className={s.gaugeKey}>Map</dt>
+                                        <dd className={s.gaugeVal}>{operation.mapWorld.toUpperCase()}</dd>
+                                    </div>
+                                )}
+                                {attendance.seats > 0 && (
+                                    <div className={s.gauge}>
+                                        <dt className={s.gaugeKey}>Positions</dt>
+                                        <dd className={s.gaugeVal}>{attendance.filled} / {attendance.seats}</dd>
+                                        <SeatBar filled={attendance.filled} seats={attendance.seats} />
+                                    </div>
+                                )}
+                                <ConsoleRsvp operationId={id} rsvpOpen={attendance.rsvpOpen} />
+                            </dl>
+
+                            {(showAcknowledgeCard || isLoggedIn) && (
+                                <div className={s.calls}>
+                                    {showAcknowledgeCard && (
+                                        <a className={s.alert} href='#acknowledge'>
+                                            <span>
+                                                <span className={s.alertKey}>Acknowledgement outstanding</span>
+                                                <span className={s.alertSub}>These orders are not yet signed</span>
+                                            </span>
+                                            <span className={s.btnRed}>Sign</span>
+                                        </a>
+                                    )}
+                                    {isLoggedIn && (
+                                        <Link className={s.muster} href={attendanceHref}>
+                                            <span>
+                                                <span className={s.musterKey}>{postingLine(attendance)}</span>
+                                                <span className={s.musterSub}>{seatLine(attendance)}</span>
+                                            </span>
+                                            <span className={s.btnGo}>Muster board →</span>
+                                        </Link>
+                                    )}
+                                </div>
+                            )}
+
+                            <div className={s.body}>
+                                <ConsoleRail
+                                    operationId={id}
+                                    documents={documents}
+                                    activeDocument={activeDocument}
+                                    sections={onContent ? readable.map(sec => ({ id: sec.id, title: sec.title })) : []}
+                                    fromJ2={fromJ2}
+                                />
+
+                                {!onContent ? (
+                                    /* Staff instruments, not orders. They keep the dark chrome they
+                                       wear everywhere else — the glass behind them is dark, so they
+                                       need nothing from this theme but room. */
+                                    <div className={s.panel}>
+                                        {activeDocument === OCAP && hasOcap && (
+                                            <>
+                                                {isHQ && <OcapLinkPanel operationId={id} initialOcap={operation.ocap ?? null} />}
+                                                {isLoggedIn && !!operation.ocap?.playerStats?.length && (
+                                                    <OcapStatsPanel
+                                                        ocap={operation.ocap}
+                                                        themeColor={operation.themeColor || '#db001d'}
+                                                        r={219} g={0} b={29}
+                                                        pageTheme='modern'
+                                                        operationId={id}
+                                                    />
+                                                )}
+                                            </>
+                                        )}
+                                    </div>
+                                ) : (
+                                    <article className={s.sheet}>
+                                        <div className={s.sheetTop}>
+                                            <span>{documentTitle}</span>
+                                            <span><span className={s.sheetTopLit}>Secret</span>{' // ASOT eyes only'}</span>
+                                        </div>
+
+                                        <div className={s.sheetBody}>
+                                            {rawSections.length > 0 ? (
+                                                rawSections.map((sec, i) => {
+                                                    const visible = isLoggedIn || sec.isPublic
+                                                    return (
+                                                        <section
+                                                            key={sec.id}
+                                                            id={visible ? `section-${sec.id}` : undefined}
+                                                            data-print-section={visible ? true : undefined}
+                                                            className={s.para}
+                                                        >
+                                                            <div className={s.paraHead}>
+                                                                <span className={s.paraNum}>{String(i + 1).padStart(2, '0')}</span>
+                                                                <h2 className={s.paraTitle}>{visible ? sec.title : 'Withheld'}</h2>
+                                                                {isLoggedIn && !sec.isPublic && (
+                                                                    <span className={s.paraTag}>Classified</span>
+                                                                )}
+                                                            </div>
+
+                                                            {visible
+                                                                ? <DocBody content={sec.content ?? null} themeColor={operation.themeColor || '#db001d'} />
+                                                                : <Encrypted />}
+                                                        </section>
+                                                    )
+                                                })
+                                            ) : operation.content ? (
+                                                <section className={s.para} data-print-section>
+                                                    <div className={s.paraHead}>
+                                                        <span className={s.paraNum}>01</span>
+                                                        <h2 className={s.paraTitle}>Operation Orders</h2>
+                                                    </div>
+                                                    <DocBody content={operation.content} themeColor={operation.themeColor || '#db001d'} />
+                                                </section>
+                                            ) : (
+                                                <p className={s.empty}>No orders have been written yet.</p>
+                                            )}
+
+                                            {showAcknowledgeCard && (
+                                                <div id='acknowledge'>
+                                                    <DocAcknowledgeCard operationId={id} pageId='main' />
+                                                </div>
+                                            )}
+                                        </div>
+                                    </article>
+                                )}
+                            </div>
+
+                            <div className={s.foot}>
+                                <span>{operation.department || 'ASOT'}{' // '}{documentTitle}</span>
+                                <span>
+                                    {isLoggedIn
+                                        ? `${attendance.attending} attending`
+                                        : <Link className={s.footLink} href={`/login?returnTo=/operations/${id}` as Route}>Log in to decrypt the withheld paragraphs</Link>}
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* Same repaint as the bar — otherwise it is one red chip on a green screen. */}
+            {isHQ && <EditOrdersButton operationId={id} themeColor={operation.themeColor} palette={CONSOLE_CHROME} />}
+        </div>
+    )
+}
+
+/**
+ * Seats as a segmented bar.
+ *
+ * Answers "nearly full?" at a glance, which "28 / 34" beside it does not — the
+ * number is the precise answer and this is the fast one. Rounds up, so one
+ * filled seat always lights one segment rather than none.
+ */
+function SeatBar({ filled, seats }: { filled: number; seats: number }) {
+    const lit = seats > 0 ? Math.min(SEATS_SEGMENTS, Math.ceil((filled / seats) * SEATS_SEGMENTS)) : 0
+
+    return (
+        <div className={s.bars} aria-hidden>
+            {Array.from({ length: SEATS_SEGMENTS }, (_, i) => (
+                <span key={i} className={i < lit ? `${s.barSeg} ${s.barOn}` : s.barSeg} />
+            ))}
+        </div>
+    )
+}
+
+/** Signal that arrives and fails to resolve — a paragraph this reader is not
+ *  cleared for. Uneven bars, so it reads as content withheld rather than as a
+ *  loading skeleton. */
+function Encrypted() {
+    const widths = ['97%', '84%', '91%', '69%', '88%']
+
+    return (
+        <div className={s.encrypted} aria-label='Withheld — log in to read this paragraph'>
+            {widths.map((w, i) => <div key={i} className={s.encBar} style={{ width: w }} />)}
+            <p className={s.encNote}>Signal withheld from this terminal.</p>
+        </div>
+    )
+}
+
+/** What the muster call says you are down for. */
+function postingLine(attendance: ModernPageProps['attendance']): string {
+    if (attendance.myRsvp === 'not_attending') return 'Excused — not attending'
+    if (attendance.myPosition) return `Detailed: ${attendance.myPosition}`
+    if (attendance.myRsvp === 'attending') return 'Attending — no position allotted'
+    return attendance.rsvpOpen ? 'No return made' : 'Not detailed'
+}
+
+/** The state of the roster underneath it. */
+function seatLine(attendance: ModernPageProps['attendance']): string {
+    if (attendance.seats > 0) return `${attendance.filled} of ${attendance.seats} seats filled`
+    return attendance.rsvpOpen ? 'RSVP open — no roster cut yet' : 'Roster not cut'
+}

--- a/apps/web/app/operations/[id]/themes/SciFiPage.tsx
+++ b/apps/web/app/operations/[id]/themes/SciFiPage.tsx
@@ -70,10 +70,19 @@ const CONSOLE_CHROME: Record<string, string> = {
 
     /*
      * The one thing this theme adds to the tab strip: the active tab's
-     * underline emits. Offset downward with a negative spread so the light
-     * pools under the rule rather than haloing the whole tab.
+     * underline emits. It is the light the rule throws *up* onto the strip
+     * above it, painted as a background so it cannot escape the tab's own box
+     * — see the note in `tabs.module.css` for why that shape and not a
+     * box-shadow. Steep falloff, because phosphor is bright at the source and
+     * gone within a few millimetres of it.
      */
-    '--tab-glow': '0 3px 14px -4px var(--phos)',
+    '--tab-glow': [
+        'linear-gradient(0deg,',
+        'rgba(98, 232, 176, 0.40) 0%,',
+        'rgba(98, 232, 176, 0.16) 30%,',
+        'rgba(98, 232, 176, 0.04) 62%,',
+        'transparent 100%)',
+    ].join(' '),
 }
 
 /**

--- a/apps/web/app/operations/[id]/themes/SciFiPage.tsx
+++ b/apps/web/app/operations/[id]/themes/SciFiPage.tsx
@@ -59,7 +59,7 @@ const CONSOLE_CHROME: Record<string, string> = {
         'linear-gradient(180deg, rgba(23, 33, 32, 0.96) 0%, rgba(10, 15, 15, 0.98) 100%)',
     ].join(', '),
 
-    /* The hairline the strip sits on, then its shadow on the hull below. */
+    /* The hairline the strip sits on, then its shadow on the glass below. */
     '--bar-shadow': [
         'inset 0 1px 0 rgba(98, 232, 176, 0.10)',
         '0 1px 0 rgba(98, 232, 176, 0.18)',
@@ -79,10 +79,12 @@ const CONSOLE_CHROME: Record<string, string> = {
 /**
  * The Sci-Fi orders page — "Bridge Console".
  *
- * The orders as a piece of hardware: a brushed hull, a bezel with screws, and
- * behind it a slab of dead-black glass with phosphor burning inside. The whole
- * theme rests on one rule — **the light never leaves the screen** — which is
- * what separates a CRT from a filter laid over a page.
+ * The orders as a slab of dead-black glass with phosphor burning inside, run
+ * to all four edges of the window. The whole theme rests on one rule — **the
+ * light never leaves the screen** — which is what separates a CRT from a
+ * filter laid over a page. It wore a bezel until that was seen at size: a
+ * bezel is a thing you look *at*, and edge to edge the reader is looking
+ * *through*.
  *
  * It shares Modern's data exactly (`page.tsx` does all the fetching and every
  * permission check) and disagrees with it about what the page *is*. That is
@@ -169,182 +171,173 @@ export default function SciFiPage({
                 palette={CONSOLE_CHROME}
             />
 
-            <div className={s.hull}>
-                <div className={s.bezel}>
-                    <span className={`${s.screw} ${s.screwTL}`} aria-hidden />
-                    <span className={`${s.screw} ${s.screwTR}`} aria-hidden />
-                    <span className={`${s.screw} ${s.screwBL}`} aria-hidden />
-                    <span className={`${s.screw} ${s.screwBR}`} aria-hidden />
+            <div className={s.glass}>
+                <div className={s.sweep} aria-hidden />
 
-                    <div className={s.glass}>
-                        <div className={s.sweep} aria-hidden />
-
-                        <div className={s.screen}>
-                            <header className={operation.coverImage ? s.head : `${s.head} ${s.headSolo}`}>
-                                <div>
-                                    <p className={s.ref}>
-                                        {refLine ? <span className={s.refLit}>{refLine}</span> : null}
-                                        {refLine && operation.status ? ' // ' : ''}
-                                        {operation.status}
-                                    </p>
-                                    <h1 className={s.title}>{operation.title || 'Untitled Operation'}</h1>
-                                </div>
-
-                                {operation.coverImage && (
-                                    <figure className={s.feed}>
-                                        <img className={s.feedImg} src={operation.coverImage} alt='' />
-                                        <figcaption className={s.feedCap}>
-                                            <span>{'Feed 01 // '}{operation.mapWorld || 'AO'}</span>
-                                            <span className={s.feedRec}>● REC</span>
-                                        </figcaption>
-                                    </figure>
-                                )}
-                            </header>
-
-                            <dl className={s.gauges}>
-                                {operation.date && (
-                                    <div className={s.gauge}>
-                                        <dt className={s.gaugeKey}>Step off</dt>
-                                        <dd className={s.gaugeVal}><LocalDate iso={new Date(operation.date).toISOString()} /></dd>
-                                    </div>
-                                )}
-                                {loreDate?.isValid() && (
-                                    <div className={s.gauge}>
-                                        <dt className={s.gaugeKey}>In-game</dt>
-                                        <dd className={s.gaugeVal}>{loreDate.format('DD MMM YYYY').toUpperCase()}</dd>
-                                    </div>
-                                )}
-                                {operation.mapWorld && (
-                                    <div className={s.gauge}>
-                                        <dt className={s.gaugeKey}>Map</dt>
-                                        <dd className={s.gaugeVal}>{operation.mapWorld.toUpperCase()}</dd>
-                                    </div>
-                                )}
-                                {attendance.seats > 0 && (
-                                    <div className={s.gauge}>
-                                        <dt className={s.gaugeKey}>Positions</dt>
-                                        <dd className={s.gaugeVal}>{attendance.filled} / {attendance.seats}</dd>
-                                        <SeatBar filled={attendance.filled} seats={attendance.seats} />
-                                    </div>
-                                )}
-                                <ConsoleRsvp operationId={id} rsvpOpen={attendance.rsvpOpen} />
-                            </dl>
-
-                            {(showAcknowledgeCard || isLoggedIn) && (
-                                <div className={s.calls}>
-                                    {showAcknowledgeCard && (
-                                        <a className={s.alert} href='#acknowledge'>
-                                            <span>
-                                                <span className={s.alertKey}>Acknowledgement outstanding</span>
-                                                <span className={s.alertSub}>These orders are not yet signed</span>
-                                            </span>
-                                            <span className={s.btnRed}>Sign</span>
-                                        </a>
-                                    )}
-                                    {isLoggedIn && (
-                                        <Link className={s.muster} href={attendanceHref}>
-                                            <span>
-                                                <span className={s.musterKey}>{postingLine(attendance)}</span>
-                                                <span className={s.musterSub}>{seatLine(attendance)}</span>
-                                            </span>
-                                            <span className={s.btnGo}>Muster board →</span>
-                                        </Link>
-                                    )}
-                                </div>
-                            )}
-
-                            <div className={s.body}>
-                                <ConsoleRail
-                                    operationId={id}
-                                    documents={documents}
-                                    activeDocument={activeDocument}
-                                    sections={onContent ? readable.map(sec => ({ id: sec.id, title: sec.title })) : []}
-                                    fromJ2={fromJ2}
-                                />
-
-                                {!onContent ? (
-                                    /* Staff instruments, not orders. They keep the dark chrome they
-                                       wear everywhere else — the glass behind them is dark, so they
-                                       need nothing from this theme but room. */
-                                    <div className={s.panel}>
-                                        {activeDocument === OCAP && hasOcap && (
-                                            <>
-                                                {isHQ && <OcapLinkPanel operationId={id} initialOcap={operation.ocap ?? null} />}
-                                                {isLoggedIn && !!operation.ocap?.playerStats?.length && (
-                                                    <OcapStatsPanel
-                                                        ocap={operation.ocap}
-                                                        themeColor={operation.themeColor || '#db001d'}
-                                                        r={219} g={0} b={29}
-                                                        pageTheme='modern'
-                                                        operationId={id}
-                                                    />
-                                                )}
-                                            </>
-                                        )}
-                                    </div>
-                                ) : (
-                                    <article className={s.sheet}>
-                                        <div className={s.sheetTop}>
-                                            <span>{documentTitle}</span>
-                                            <span><span className={s.sheetTopLit}>Secret</span>{' // ASOT eyes only'}</span>
-                                        </div>
-
-                                        <div className={s.sheetBody}>
-                                            {rawSections.length > 0 ? (
-                                                rawSections.map((sec, i) => {
-                                                    const visible = isLoggedIn || sec.isPublic
-                                                    return (
-                                                        <section
-                                                            key={sec.id}
-                                                            id={visible ? `section-${sec.id}` : undefined}
-                                                            data-print-section={visible ? true : undefined}
-                                                            className={s.para}
-                                                        >
-                                                            <div className={s.paraHead}>
-                                                                <span className={s.paraNum}>{String(i + 1).padStart(2, '0')}</span>
-                                                                <h2 className={s.paraTitle}>{visible ? sec.title : 'Withheld'}</h2>
-                                                                {isLoggedIn && !sec.isPublic && (
-                                                                    <span className={s.paraTag}>Classified</span>
-                                                                )}
-                                                            </div>
-
-                                                            {visible
-                                                                ? <DocBody content={sec.content ?? null} themeColor={operation.themeColor || '#db001d'} />
-                                                                : <Encrypted />}
-                                                        </section>
-                                                    )
-                                                })
-                                            ) : operation.content ? (
-                                                <section className={s.para} data-print-section>
-                                                    <div className={s.paraHead}>
-                                                        <span className={s.paraNum}>01</span>
-                                                        <h2 className={s.paraTitle}>Operation Orders</h2>
-                                                    </div>
-                                                    <DocBody content={operation.content} themeColor={operation.themeColor || '#db001d'} />
-                                                </section>
-                                            ) : (
-                                                <p className={s.empty}>No orders have been written yet.</p>
-                                            )}
-
-                                            {showAcknowledgeCard && (
-                                                <div id='acknowledge'>
-                                                    <DocAcknowledgeCard operationId={id} pageId='main' />
-                                                </div>
-                                            )}
-                                        </div>
-                                    </article>
-                                )}
-                            </div>
-
-                            <div className={s.foot}>
-                                <span>{operation.department || 'ASOT'}{' // '}{documentTitle}</span>
-                                <span>
-                                    {isLoggedIn
-                                        ? `${attendance.attending} attending`
-                                        : <Link className={s.footLink} href={`/login?returnTo=/operations/${id}` as Route}>Log in to decrypt the withheld paragraphs</Link>}
-                                </span>
-                            </div>
+                <div className={s.screen}>
+                    <header className={operation.coverImage ? s.head : `${s.head} ${s.headSolo}`}>
+                        <div>
+                            <p className={s.ref}>
+                                {refLine ? <span className={s.refLit}>{refLine}</span> : null}
+                                {refLine && operation.status ? ' // ' : ''}
+                                {operation.status}
+                            </p>
+                            <h1 className={s.title}>{operation.title || 'Untitled Operation'}</h1>
                         </div>
+
+                        {operation.coverImage && (
+                            <figure className={s.feed}>
+                                <img className={s.feedImg} src={operation.coverImage} alt='' />
+                                <figcaption className={s.feedCap}>
+                                    <span>{'Feed 01 // '}{operation.mapWorld || 'AO'}</span>
+                                    <span className={s.feedRec}>● REC</span>
+                                </figcaption>
+                            </figure>
+                        )}
+                    </header>
+
+                    <dl className={s.gauges}>
+                        {operation.date && (
+                            <div className={s.gauge}>
+                                <dt className={s.gaugeKey}>Step off</dt>
+                                <dd className={s.gaugeVal}><LocalDate iso={new Date(operation.date).toISOString()} /></dd>
+                            </div>
+                        )}
+                        {loreDate?.isValid() && (
+                            <div className={s.gauge}>
+                                <dt className={s.gaugeKey}>In-game</dt>
+                                <dd className={s.gaugeVal}>{loreDate.format('DD MMM YYYY').toUpperCase()}</dd>
+                            </div>
+                        )}
+                        {operation.mapWorld && (
+                            <div className={s.gauge}>
+                                <dt className={s.gaugeKey}>Map</dt>
+                                <dd className={s.gaugeVal}>{operation.mapWorld.toUpperCase()}</dd>
+                            </div>
+                        )}
+                        {attendance.seats > 0 && (
+                            <div className={s.gauge}>
+                                <dt className={s.gaugeKey}>Positions</dt>
+                                <dd className={s.gaugeVal}>{attendance.filled} / {attendance.seats}</dd>
+                                <SeatBar filled={attendance.filled} seats={attendance.seats} />
+                            </div>
+                        )}
+                        <ConsoleRsvp operationId={id} rsvpOpen={attendance.rsvpOpen} />
+                    </dl>
+
+                    {(showAcknowledgeCard || isLoggedIn) && (
+                        <div className={s.calls}>
+                            {showAcknowledgeCard && (
+                                <a className={s.alert} href='#acknowledge'>
+                                    <span>
+                                        <span className={s.alertKey}>Acknowledgement outstanding</span>
+                                        <span className={s.alertSub}>These orders are not yet signed</span>
+                                    </span>
+                                    <span className={s.btnRed}>Sign</span>
+                                </a>
+                            )}
+                            {isLoggedIn && (
+                                <Link className={s.muster} href={attendanceHref}>
+                                    <span>
+                                        <span className={s.musterKey}>{postingLine(attendance)}</span>
+                                        <span className={s.musterSub}>{seatLine(attendance)}</span>
+                                    </span>
+                                    <span className={s.btnGo}>Muster board →</span>
+                                </Link>
+                            )}
+                        </div>
+                    )}
+
+                    <div className={s.body}>
+                        <ConsoleRail
+                            operationId={id}
+                            documents={documents}
+                            activeDocument={activeDocument}
+                            sections={onContent ? readable.map(sec => ({ id: sec.id, title: sec.title })) : []}
+                            fromJ2={fromJ2}
+                        />
+
+                        {!onContent ? (
+                            /* Staff instruments, not orders. They keep the dark chrome they
+                               wear everywhere else — the glass behind them is dark, so they
+                               need nothing from this theme but room. */
+                            <div className={s.panel}>
+                                {activeDocument === OCAP && hasOcap && (
+                                    <>
+                                        {isHQ && <OcapLinkPanel operationId={id} initialOcap={operation.ocap ?? null} />}
+                                        {isLoggedIn && !!operation.ocap?.playerStats?.length && (
+                                            <OcapStatsPanel
+                                                ocap={operation.ocap}
+                                                themeColor={operation.themeColor || '#db001d'}
+                                                r={219} g={0} b={29}
+                                                pageTheme='modern'
+                                                operationId={id}
+                                            />
+                                        )}
+                                    </>
+                                )}
+                            </div>
+                        ) : (
+                            <article className={s.sheet}>
+                                <div className={s.sheetTop}>
+                                    <span>{documentTitle}</span>
+                                    <span><span className={s.sheetTopLit}>Secret</span>{' // ASOT eyes only'}</span>
+                                </div>
+
+                                <div className={s.sheetBody}>
+                                    {rawSections.length > 0 ? (
+                                        rawSections.map((sec, i) => {
+                                            const visible = isLoggedIn || sec.isPublic
+                                            return (
+                                                <section
+                                                    key={sec.id}
+                                                    id={visible ? `section-${sec.id}` : undefined}
+                                                    data-print-section={visible ? true : undefined}
+                                                    className={s.para}
+                                                >
+                                                    <div className={s.paraHead}>
+                                                        <span className={s.paraNum}>{String(i + 1).padStart(2, '0')}</span>
+                                                        <h2 className={s.paraTitle}>{visible ? sec.title : 'Withheld'}</h2>
+                                                        {isLoggedIn && !sec.isPublic && (
+                                                            <span className={s.paraTag}>Classified</span>
+                                                        )}
+                                                    </div>
+
+                                                    {visible
+                                                        ? <DocBody content={sec.content ?? null} themeColor={operation.themeColor || '#db001d'} />
+                                                        : <Encrypted />}
+                                                </section>
+                                            )
+                                        })
+                                    ) : operation.content ? (
+                                        <section className={s.para} data-print-section>
+                                            <div className={s.paraHead}>
+                                                <span className={s.paraNum}>01</span>
+                                                <h2 className={s.paraTitle}>Operation Orders</h2>
+                                            </div>
+                                            <DocBody content={operation.content} themeColor={operation.themeColor || '#db001d'} />
+                                        </section>
+                                    ) : (
+                                        <p className={s.empty}>No orders have been written yet.</p>
+                                    )}
+
+                                    {showAcknowledgeCard && (
+                                        <div id='acknowledge'>
+                                            <DocAcknowledgeCard operationId={id} pageId='main' />
+                                        </div>
+                                    )}
+                                </div>
+                            </article>
+                        )}
+                    </div>
+
+                    <div className={s.foot}>
+                        <span>{operation.department || 'ASOT'}{' // '}{documentTitle}</span>
+                        <span>
+                            {isLoggedIn
+                                ? `${attendance.attending} attending`
+                                : <Link className={s.footLink} href={`/login?returnTo=/operations/${id}` as Route}>Log in to decrypt the withheld paragraphs</Link>}
+                        </span>
                     </div>
                 </div>
             </div>

--- a/apps/web/app/operations/[id]/themes/scifi.module.css
+++ b/apps/web/app/operations/[id]/themes/scifi.module.css
@@ -1,0 +1,715 @@
+/*
+ * The Sci-Fi orders page — "Bridge Console".
+ *
+ * The orders as a piece of hardware: a brushed hull, a bezel with screws in
+ * it, and behind the bezel a slab of dead-black glass with phosphor burning
+ * inside. The one rule the whole theme is built on is that **the light never
+ * leaves the screen**. Glow lives on text and on hairlines *inside* the glass;
+ * the hull around it is unlit metal. That is the difference between a CRT and
+ * a filter laid over a page, and every decision below defers to it.
+ *
+ * Like Cold War, the palette is fixed rather than taking the operation's
+ * `--acc`. A console does not change colour because the operation does — a
+ * phosphor tube emits one colour, that is what makes it a phosphor tube — and
+ * an operation themed deep red would leave this page glowing in a hue no
+ * hardware ever produced. Phosphor green is the tube, amber is the second
+ * voice for times and headings, and red appears exactly once, on an order you
+ * have not signed.
+ */
+
+.page {
+    /*
+     * The hull: unlit metal, three steps. The bezel is the lit face, the deck
+     * behind it is the shadowed one, and `--hull-3` is what the bezel's own
+     * gradient falls to at its bottom edge.
+     */
+    --hull:    #14161a;
+    --hull-2:  #1c1f25;
+    --hull-3:  #0b0d10;
+    --seam:    #2a2f38;
+    --seam-2:  #3a414d;
+
+    /* The glass. Not pure black — a tube at rest still has a faint cast. */
+    --glass:   #05070a;
+    --glass-2: #080c11;
+
+    /*
+     * Phosphor, amber, alarm. Measured against `--glass`, not eyeballed:
+     * 13.1:1, 11.0:1 and 6.4:1. Generous, and deliberately so — the raster
+     * below lays a 1-in-3 line of black over everything on the screen, which
+     * costs a few percent of luminance that a ratio sitting on the 4.5:1 floor
+     * could not afford to give up.
+     */
+    --phos:    #62e8b0;
+    --phos-2:  #38b98a;
+    --amber:   #ffb020;
+    --alarm:   #ff5252;
+
+    /*
+     * Three inks, same measurement: 17.8:1, 11.1:1 and 6.1:1. `--ink-3` is the
+     * one that matters — it is every gauge label and rail header on the page,
+     * all of it small uppercase mono at wide tracking, which needs more
+     * contrast than its ratio implies. It started at #4d6b60 (3.4:1) and
+     * failed AA outright.
+     */
+    --ink:     #d9f7e8;
+    --ink-2:   #9fc9b6;
+    --ink-3:   #6f9788;
+
+    /* Hairlines inside the glass. Phosphor at low alpha, so the screen's own
+       divisions look emitted rather than drawn on top of it. */
+    --grid:    rgba(98, 232, 176, 0.18);
+    --grid-2:  rgba(98, 232, 176, 0.09);
+
+    --type:    var(--font-mono);
+    --display: var(--font-disp);
+
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    background: var(--hull);
+    color: var(--ink-2);
+    font-family: var(--type);
+}
+
+/*
+ * Give the screen back its inheritance.
+ *
+ * `styles/globals.css` carries a base reset:
+ *
+ *     :where(h1, h2, h3, h4, h5, h6, p, b, span, label) { color: var(--foreground) }
+ *
+ * `:where()` contributes no specificity, but specificity is not what decides
+ * this: a declaration that *matches* an element always beats a value the
+ * element would have *inherited*, however weak the selector. So every bare
+ * `<span>` on this page takes the site's near-white foreground directly and
+ * never sees the phosphor set on its parent.
+ *
+ * On a dark theme that does not go white-on-white the way it did on Cold War's
+ * paper — it does something quieter and just as wrong. The ink hierarchy
+ * collapses: `--ink-3` labels meant to sit back come forward to full
+ * brightness, the amber and phosphor accents turn plain white, and the screen
+ * stops looking like a tube emitting one colour, which is the entire theme.
+ *
+ * Scoped to the glass and placed before everything else here, so it only
+ * restores normal inheritance and every rule below still wins.
+ */
+.screen :where(h1, h2, h3, h4, h5, h6, p, b, span, label, a, li, td, th) {
+    color: inherit;
+}
+
+/* ── Hull ─────────────────────────────────────────────────────────────── */
+
+.hull {
+    flex: 1;
+    padding: 16px;
+    /* A fine vertical brush over a top-lit body. Unlit, both of them: nothing
+       out here emits, it only catches the room. */
+    background:
+        repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.014) 0 1px, transparent 1px 3px),
+        linear-gradient(180deg, var(--hull-2) 0%, #101317 100%);
+}
+
+.bezel {
+    position: relative;
+    height: 100%;
+    padding: 11px;
+    border: 1px solid var(--seam-2);
+    border-radius: 7px;
+    background: linear-gradient(180deg, var(--hull-2), var(--hull-3));
+    /* The lit top edge, then the weight of the thing on the deck. */
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.06),
+        0 18px 44px rgba(0, 0, 0, 0.6);
+}
+
+/*
+ * Four screws, one per corner. Small enough to be noticed rather than seen —
+ * they are the cheapest thing on the page that says "this is an object", and
+ * without them the bezel reads as a rounded div.
+ */
+.screw {
+    position: absolute;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 30%, #4a515c, #191c21);
+    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.9);
+}
+.screwTL { top: 7px; left: 7px; }
+.screwTR { top: 7px; right: 7px; }
+.screwBL { bottom: 7px; left: 7px; }
+.screwBR { bottom: 7px; right: 7px; }
+
+/* ── Glass ────────────────────────────────────────────────────────────── */
+
+.glass {
+    position: relative;
+    height: 100%;
+    border: 1px solid var(--seam);
+    border-radius: 3px;
+    overflow: hidden;
+    background: radial-gradient(120% 100% at 50% 0%, var(--glass-2), var(--glass) 70%, #020304 100%);
+    /* Depth behind the glass, and the faintest phosphor bloom filling it. */
+    box-shadow:
+        inset 0 0 90px rgba(0, 0, 0, 0.9),
+        inset 0 0 160px rgba(56, 185, 138, 0.05);
+}
+
+/*
+ * The raster, and the tube's curvature.
+ *
+ * One line of black in every three, at low alpha — enough to break the surface
+ * into scanlines, not enough to cost the text its contrast (the inks above are
+ * measured with this on). The vignette is what actually sells the curve: a
+ * flat screen with scanlines still looks flat.
+ */
+.glass::before,
+.glass::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    pointer-events: none;
+}
+.glass::before {
+    background: repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.26) 0 1px, transparent 1px 3px);
+    opacity: 0.5;
+}
+.glass::after {
+    z-index: 4;
+    background: radial-gradient(112% 106% at 50% 50%, transparent 58%, rgba(0, 0, 0, 0.62) 100%);
+}
+
+/* The refresh, crossing once every nine seconds. Slow on purpose: this is a
+   page somebody reads for ten minutes, and anything quicker competes with the
+   text instead of sitting behind it. */
+.sweep {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 3px;
+    z-index: 3;
+    pointer-events: none;
+    background: linear-gradient(180deg, transparent, rgba(98, 232, 176, 0.14), transparent);
+    animation: sweep 9s linear infinite;
+}
+@keyframes sweep {
+    0%   { top: -3px; }
+    100% { top: 100%; }
+}
+
+.screen {
+    position: relative;
+    z-index: 2;
+    padding: 32px 36px 36px;
+}
+
+/* ── Header ───────────────────────────────────────────────────────────── */
+
+.head {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 340px;
+    gap: 36px;
+    /* The title sits on the feed's bottom edge rather than floating above it.
+       An operation has no summary line in the data model, so there is nothing
+       to fill the column beside a 176px print and `start` left a hole. */
+    align-items: end;
+    padding-bottom: 28px;
+    border-bottom: 1px solid var(--grid);
+}
+/* No print, no column to reserve for one. */
+.headSolo { grid-template-columns: minmax(0, 1fr); }
+
+.ref {
+    margin: 0 0 15px;
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+.refLit { color: var(--phos-2); }
+
+.title {
+    margin: 0;
+    font-family: var(--display);
+    font-size: clamp(2.1rem, 4.4vw, 3.3rem);
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    text-wrap: balance;
+    color: var(--phos);
+    /* Two radii: the tight one is the phosphor itself, the wide one is the
+       bloom in the glass in front of it. */
+    text-shadow: 0 0 10px rgba(98, 232, 176, 0.55), 0 0 34px rgba(56, 185, 138, 0.35);
+}
+
+/*
+ * The cover image, as the AO feed.
+ *
+ * In the header rather than in the document, the same call Cold War made with
+ * its taped print and for the same reason: set into the body it reads as part
+ * of the orders, and a screen that appears to contain a photograph stops
+ * looking like a screen. Pushed hard towards the tube's own green so it looks
+ * received rather than pasted in.
+ */
+.feed {
+    margin: 0;
+    border: 1px solid var(--grid);
+    background: rgba(0, 0, 0, 0.5);
+}
+.feedImg {
+    display: block;
+    width: 100%;
+    height: 176px;
+    object-fit: cover;
+    opacity: 0.7;
+    filter: grayscale(1) contrast(1.3) brightness(0.6) sepia(0.4) hue-rotate(90deg);
+}
+.feedCap {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 7px 11px;
+    border-top: 1px solid var(--grid-2);
+    font-size: 9px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+.feedRec { color: var(--alarm); }
+
+/* ── Gauges ───────────────────────────────────────────────────────────── */
+
+.gauges {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 10px;
+    margin: 22px 0 0;
+}
+.gauge {
+    padding: 12px 14px 13px;
+    border: 1px solid var(--grid-2);
+    background: rgba(98, 232, 176, 0.03);
+}
+.gaugeKey {
+    margin: 0 0 6px;
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+.gaugeVal {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    color: var(--ink);
+}
+
+/* The one live gauge. The single amber cell on a green screen is what makes
+   the deadline read first — the same job Modern's accent cell does. */
+.gaugeHot { border-color: rgba(255, 176, 32, 0.4); background: rgba(255, 176, 32, 0.05); }
+.gaugeHot .gaugeVal { color: var(--amber); text-shadow: 0 0 12px rgba(255, 176, 32, 0.55); }
+
+/* Seats, as a segmented bar. Ten segments because a console reads in segments,
+   and because it answers "nearly full?" at a glance in a way "28 / 34" does not. */
+.bars { display: flex; gap: 2px; margin-top: 7px; }
+.barSeg { flex: 1; height: 5px; background: rgba(98, 232, 176, 0.14); }
+.barOn { background: var(--phos-2); box-shadow: 0 0 7px rgba(56, 185, 138, 0.7); }
+
+/* ── The two things you might owe ─────────────────────────────────────── */
+
+.calls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.alert, .muster {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px 18px;
+    text-decoration: none;
+}
+
+/*
+ * The only red on the page, and the only thing that pulses. Both are the
+ * point: an unsigned order is the one state the page is actually asking you to
+ * change, and if anything else were alarming this would stop being.
+ */
+.alert {
+    border: 1px solid rgba(255, 82, 82, 0.4);
+    background: rgba(255, 82, 82, 0.07);
+    animation: alert 3.2s ease-in-out infinite;
+}
+@keyframes alert {
+    0%, 100% { box-shadow: inset 0 0 0 rgba(255, 82, 82, 0); }
+    50%      { box-shadow: inset 0 0 30px rgba(255, 82, 82, 0.16); }
+}
+.alertKey { display: block; font-size: 0.95rem; font-weight: 600; letter-spacing: 0.03em; color: #ffc2c2; }
+.alertSub { display: block; margin-top: 3px; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(255, 150, 150, 0.75); }
+.btnRed {
+    flex: none;
+    padding: 9px 18px;
+    border: 1px solid var(--alarm);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: #fff;
+    background: rgba(255, 82, 82, 0.18);
+}
+
+.muster { border: 1px solid rgba(98, 232, 176, 0.35); background: rgba(98, 232, 176, 0.06); }
+.musterKey { display: block; font-size: 1.02rem; font-weight: 600; letter-spacing: 0.03em; color: var(--ink); }
+.musterSub { display: block; margin-top: 3px; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-2); }
+.btnGo {
+    flex: none;
+    padding: 12px 24px;
+    border: 1px solid var(--phos);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #04120c;
+    background: var(--phos);
+    box-shadow: 0 0 22px rgba(98, 232, 176, 0.45);
+    transition: box-shadow 140ms ease;
+}
+.muster:hover .btnGo { box-shadow: 0 0 34px rgba(98, 232, 176, 0.7); }
+
+/* ── Body ─────────────────────────────────────────────────────────────── */
+
+.body {
+    display: grid;
+    grid-template-columns: 232px minmax(0, 1fr);
+    gap: 24px;
+    margin-top: 24px;
+    align-items: start;
+}
+@media (max-width: 900px) {
+    .body { grid-template-columns: minmax(0, 1fr); }
+    .head { grid-template-columns: minmax(0, 1fr); }
+}
+
+/* ── The rail ─────────────────────────────────────────────────────────── */
+
+.rail {
+    position: sticky;
+    top: 16px;
+    border: 1px solid var(--grid);
+    background: rgba(0, 0, 0, 0.35);
+}
+.railHead {
+    display: block;
+    padding: 9px 13px;
+    border-bottom: 1px solid var(--grid);
+    background: rgba(98, 232, 176, 0.04);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+.railHeadLater { border-top: 1px solid var(--grid); }
+
+.doc {
+    display: block;
+    padding: 9px 13px;
+    border-bottom: 1px solid var(--grid-2);
+    font-size: 0.78rem;
+    letter-spacing: 0.05em;
+    text-decoration: none;
+    color: var(--ink-2);
+    transition: background 140ms ease, color 140ms ease;
+}
+.doc:hover { background: rgba(98, 232, 176, 0.05); color: var(--ink); }
+
+/*
+ * The open document is filled, not outlined. A console selects by lighting a
+ * whole cell — an outline would read as a focus ring, which is a different
+ * thing and one this page also uses.
+ */
+.docOn {
+    font-weight: 600;
+    color: #04120c;
+    background: var(--phos-2);
+}
+.docOn:hover { background: var(--phos); color: #04120c; }
+.docNum { opacity: 0.6; margin-right: 8px; }
+
+.secs {
+    padding: 4px 0 6px;
+    border-bottom: 1px solid var(--grid-2);
+    background: rgba(98, 232, 176, 0.03);
+}
+.sec {
+    display: block;
+    width: 100%;
+    padding: 5px 13px 5px 30px;
+    border: none;
+    background: none;
+    font-family: var(--type);
+    font-size: 0.72rem;
+    letter-spacing: 0.05em;
+    text-align: left;
+    cursor: pointer;
+    color: var(--ink-3);
+    transition: color 140ms ease;
+}
+.sec:hover { color: var(--ink-2); }
+.secOn { color: var(--phos); }
+.secN { display: inline-block; width: 15px; margin-left: -17px; }
+
+/* ── The document ─────────────────────────────────────────────────────── */
+
+.sheet {
+    border: 1px solid var(--grid);
+    background: rgba(0, 0, 0, 0.32);
+}
+.sheetTop {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 22px;
+    border-bottom: 1px solid var(--grid-2);
+    font-size: 9px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+.sheetTopLit { color: var(--phos-2); }
+
+/*
+ * The typed column stops before the panel does, the same way Cold War's does.
+ * A console can be as wide as the desk; a paragraph cannot be, or it stops
+ * being readable somewhere around 100 characters.
+ */
+.sheetBody { padding: 30px 44px 38px; max-width: 980px; }
+
+.para { margin-bottom: 40px; }
+.para:last-child { margin-bottom: 0; }
+
+.paraHead {
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    margin-bottom: 16px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--grid);
+}
+.paraNum { flex: none; font-size: 0.78rem; color: var(--amber); }
+.paraTitle {
+    margin: 0;
+    font-family: var(--display);
+    font-size: 1.3rem;
+    font-weight: 600;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--phos);
+    text-shadow: 0 0 9px rgba(98, 232, 176, 0.4);
+}
+.paraTag {
+    margin-left: auto;
+    flex: none;
+    padding: 2px 8px;
+    border: 1px solid rgba(255, 82, 82, 0.4);
+    font-size: 9px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--alarm);
+}
+
+.empty {
+    padding: 60px 0;
+    text-align: center;
+    font-size: 0.75rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+
+/*
+ * A paragraph this reader is not cleared for.
+ *
+ * Cold War strikes the text out; a console has no ink to strike, so it shows
+ * the signal arriving and failing to resolve. Same purpose either way, and it
+ * is the reason both themes do this rather than dropping a banner at the
+ * bottom: you can see how much is withheld and where it sits.
+ */
+.encrypted { padding: 4px 0 8px; }
+.encBar {
+    height: 9px;
+    margin-bottom: 7px;
+    background:
+        repeating-linear-gradient(90deg,
+            rgba(98, 232, 176, 0.22) 0 3px,
+            rgba(98, 232, 176, 0.06) 3px 7px,
+            rgba(98, 232, 176, 0.14) 7px 11px,
+            transparent 11px 16px);
+}
+.encNote {
+    margin: 10px 0 0;
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+
+/* ── Foot ─────────────────────────────────────────────────────────────── */
+
+.foot {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    margin-top: 22px;
+    padding-top: 13px;
+    border-top: 1px solid var(--grid);
+    font-size: 9px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+.footLink { color: var(--phos-2); text-decoration: underline; text-underline-offset: 3px; }
+.footLink:hover { color: var(--phos); }
+
+/* Staff instruments — OCAP and the like. They keep the dark chrome they wear
+   everywhere else, and the glass behind them is dark, so they need nothing
+   from this theme but room. */
+.panel { padding: 30px 36px; }
+
+/* ── The stored document ──────────────────────────────────────────────── */
+
+/*
+ * Overridden from here rather than injected by `DocBody`, which is the seam
+ * Cold War discovered the hard way: rules injected from that file land at
+ * `.op-doc`, tie with the base rule in globals.css and lose on source order.
+ * `.sheet :global(.op-doc)` outranks it outright.
+ *
+ * Fixed inks again, not the operation's `--acc` — see the note at the top.
+ */
+.sheet :global(.op-doc) {
+    padding: 0;
+    font-family: var(--type);
+    font-size: 0.9rem;
+    line-height: 1.78;
+    color: var(--ink-2);
+}
+.sheet :global(.op-doc p),
+.sheet :global(.op-doc li),
+.sheet :global(.op-doc td) { color: var(--ink-2); }
+
+.sheet :global(.op-doc h1) {
+    margin: 1.5em 0 0.7em;
+    padding: 8px 14px;
+    border: none;
+    border-left: 2px solid var(--phos);
+    background: rgba(98, 232, 176, 0.07);
+    box-shadow: inset 0 0 26px rgba(98, 232, 176, 0.05);
+    font-family: var(--display);
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--phos);
+    text-shadow: 0 0 10px rgba(98, 232, 176, 0.5);
+}
+.sheet :global(.op-doc h2) {
+    margin: 1.4em 0 0.5em;
+    font-family: var(--display);
+    font-size: 0.86rem;
+    font-weight: 600;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--amber);
+    text-shadow: 0 0 8px rgba(255, 176, 32, 0.35);
+}
+/* Modern's `// ` prefix; this theme uses a prompt instead. */
+.sheet :global(.op-doc h2)::before { content: '> '; color: rgba(255, 176, 32, 0.5); }
+.sheet :global(.op-doc h3) {
+    margin: 1.1em 0 0.35em;
+    font-size: 0.76rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+}
+
+.sheet :global(.op-doc li)::marker { color: var(--phos-2); }
+.sheet :global(.op-doc li) { font-size: inherit; }
+
+.sheet :global(.op-doc blockquote) {
+    margin: 1em 0;
+    padding: 11px 16px;
+    border: 1px solid rgba(255, 176, 32, 0.3);
+    background: rgba(255, 176, 32, 0.05);
+    color: var(--ink);
+    font-style: normal;
+}
+.sheet :global(.op-doc hr) {
+    border: none;
+    border-top: 1px solid var(--grid);
+    box-shadow: 0 0 6px rgba(98, 232, 176, 0.2);
+    margin: 1.6em 0;
+}
+.sheet :global(.op-doc mark) { background: rgba(98, 232, 176, 0.22); color: var(--ink); padding: 1px 4px; }
+.sheet :global(.op-doc strong) { color: var(--ink); font-weight: 700; }
+.sheet :global(.op-doc a) {
+    color: var(--phos);
+    opacity: 1;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-shadow: 0 0 6px rgba(98, 232, 176, 0.4);
+}
+.sheet :global(.op-doc a):hover { color: var(--ink); }
+.sheet :global(.op-doc code) {
+    padding: 1px 5px;
+    border: 1px solid var(--grid);
+    background: rgba(98, 232, 176, 0.08);
+    color: var(--phos);
+    font-family: var(--type);
+}
+.sheet :global(.op-doc pre) {
+    padding: 11px 14px;
+    border: 1px solid var(--grid);
+    background: rgba(0, 0, 0, 0.45);
+    overflow-x: auto;
+}
+.sheet :global(.op-doc th) {
+    color: var(--amber);
+    border-bottom: 1px solid rgba(255, 176, 32, 0.3);
+    font-size: 9px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+}
+.sheet :global(.op-doc td) { border-bottom: 1px solid var(--grid-2); }
+/* Received on the same tube as the feed above, so it belongs to the screen
+   rather than sitting on it. */
+.sheet :global(.op-doc img) {
+    max-width: 100%;
+    border: 1px solid var(--grid);
+    box-shadow: 0 0 14px rgba(98, 232, 176, 0.12);
+}
+
+/* ── Motion ───────────────────────────────────────────────────────────── */
+
+/*
+ * The sweep and the alarm are atmosphere; nothing on the page depends on
+ * either to be understood. The alarm's job is done by its colour and its
+ * words, so taking the pulse away costs a reader nothing.
+ */
+@media (prefers-reduced-motion: reduce) {
+    .sweep { display: none; }
+    .alert { animation: none; }
+    .doc,
+    .sec,
+    .btnGo { transition: none; }
+}

--- a/apps/web/app/operations/[id]/themes/scifi.module.css
+++ b/apps/web/app/operations/[id]/themes/scifi.module.css
@@ -1,12 +1,17 @@
 /*
  * The Sci-Fi orders page — "Bridge Console".
  *
- * The orders as a piece of hardware: a brushed hull, a bezel with screws in
- * it, and behind the bezel a slab of dead-black glass with phosphor burning
- * inside. The one rule the whole theme is built on is that **the light never
- * leaves the screen**. Glow lives on text and on hairlines *inside* the glass;
- * the hull around it is unlit metal. That is the difference between a CRT and
- * a filter laid over a page, and every decision below defers to it.
+ * The orders as a slab of dead-black glass with phosphor burning inside, run
+ * to all four edges of the window. The one rule the whole theme is built on is
+ * that **the light never leaves the screen**: glow lives on text and on
+ * hairlines, never on a frame or a ground. That is the difference between a
+ * CRT and a filter laid over a page, and every decision below defers to it.
+ *
+ * It began inside a bezel — brushed hull, rounded corners, screws in each
+ * corner — and the frame lost its argument the moment it was seen at size. A
+ * bezel is a thing you look *at*; edge to edge, the reader is looking
+ * *through*. The vignette and the raster carry the tube on their own, and the
+ * hardware they were framing only cost the document its width.
  *
  * Like Cold War, the palette is fixed rather than taking the operation's
  * `--acc`. A console does not change colour because the operation does — a
@@ -18,18 +23,9 @@
  */
 
 .page {
-    /*
-     * The hull: unlit metal, three steps. The bezel is the lit face, the deck
-     * behind it is the shadowed one, and `--hull-3` is what the bezel's own
-     * gradient falls to at its bottom edge.
-     */
-    --hull:    #14161a;
-    --hull-2:  #1c1f25;
-    --hull-3:  #0b0d10;
-    --seam:    #2a2f38;
-    --seam-2:  #3a414d;
-
-    /* The glass. Not pure black — a tube at rest still has a faint cast. */
+    /* The glass, and the only ground there is. Not pure black — a tube at rest
+       still has a faint cast, and a true #000 page reads as a hole rather than
+       as a screen that happens to be dark. */
     --glass:   #05070a;
     --glass-2: #080c11;
 
@@ -67,7 +63,7 @@
     display: flex;
     flex-direction: column;
     min-height: 100%;
-    background: var(--hull);
+    background: var(--glass);
     color: var(--ink-2);
     font-family: var(--type);
 }
@@ -98,62 +94,20 @@
     color: inherit;
 }
 
-/* ── Hull ─────────────────────────────────────────────────────────────── */
-
-.hull {
-    flex: 1;
-    padding: 16px;
-    /* A fine vertical brush over a top-lit body. Unlit, both of them: nothing
-       out here emits, it only catches the room. */
-    background:
-        repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.014) 0 1px, transparent 1px 3px),
-        linear-gradient(180deg, var(--hull-2) 0%, #101317 100%);
-}
-
-.bezel {
-    position: relative;
-    height: 100%;
-    padding: 11px;
-    border: 1px solid var(--seam-2);
-    border-radius: 7px;
-    background: linear-gradient(180deg, var(--hull-2), var(--hull-3));
-    /* The lit top edge, then the weight of the thing on the deck. */
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.06),
-        0 18px 44px rgba(0, 0, 0, 0.6);
-}
-
-/*
- * Four screws, one per corner. Small enough to be noticed rather than seen —
- * they are the cheapest thing on the page that says "this is an object", and
- * without them the bezel reads as a rounded div.
- */
-.screw {
-    position: absolute;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: radial-gradient(circle at 35% 30%, #4a515c, #191c21);
-    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.9);
-}
-.screwTL { top: 7px; left: 7px; }
-.screwTR { top: 7px; right: 7px; }
-.screwBL { bottom: 7px; left: 7px; }
-.screwBR { bottom: 7px; right: 7px; }
-
 /* ── Glass ────────────────────────────────────────────────────────────── */
 
 .glass {
     position: relative;
-    height: 100%;
-    border: 1px solid var(--seam);
-    border-radius: 3px;
+    /* Grows to the window even when the document is short, so the vignette has
+       corners to darken and the screen does not stop halfway down the page. */
+    flex: 1;
     overflow: hidden;
     background: radial-gradient(120% 100% at 50% 0%, var(--glass-2), var(--glass) 70%, #020304 100%);
-    /* Depth behind the glass, and the faintest phosphor bloom filling it. */
-    box-shadow:
-        inset 0 0 90px rgba(0, 0, 0, 0.9),
-        inset 0 0 160px rgba(56, 185, 138, 0.05);
+    /* The faintest phosphor bloom filling the tube. The 90px black inset that
+       used to sit under this went with the bezel — at full bleed it only
+       dirtied the edges of the reading area, which the vignette already
+       handles more honestly. */
+    box-shadow: inset 0 0 200px rgba(56, 185, 138, 0.05);
 }
 
 /*
@@ -202,7 +156,10 @@
 .screen {
     position: relative;
     z-index: 2;
-    padding: 32px 36px 36px;
+    /* Grows with the window now the frame is gone. A fixed 36px was right
+       inside a bezel that had already inset the screen; against the glass it
+       leaves the gauges reading as if they had fallen off the left edge. */
+    padding: 34px clamp(24px, 4vw, 72px) 44px;
 }
 
 /* ── Header ───────────────────────────────────────────────────────────── */

--- a/apps/web/app/operations/[id]/themes/scifi.module.css
+++ b/apps/web/app/operations/[id]/themes/scifi.module.css
@@ -431,12 +431,17 @@
     border: 1px solid var(--grid);
     background: rgba(0, 0, 0, 0.32);
 }
+/* Its two labels sit over the reading column rather than at the panel's far
+   edges — the strip is the document's own header, and a header that starts a
+   screen-width away from the text it heads has stopped being one. */
 .sheetTop {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    padding: 10px 22px;
+    max-width: 1300px;
+    margin-inline: auto;
+    padding: 10px 44px;
     border-bottom: 1px solid var(--grid-2);
     font-size: 9px;
     letter-spacing: 0.2em;
@@ -450,7 +455,21 @@
  * A console can be as wide as the desk; a paragraph cannot be, or it stops
  * being readable somewhere around 100 characters.
  */
-.sheetBody { padding: 30px 44px 38px; max-width: 980px; }
+/*
+ * The typed column stops before the panel does, and sits in the middle of what
+ * is left — the same split Cold War makes between its sheet and its measure.
+ * The panel is the screen and takes the whole width; the reading column is
+ * capped, because a paragraph that runs the width of a monitor stops being
+ * readable somewhere around 100 characters however much room there is.
+ *
+ * 1300px is the measure including the side padding, the way `--measure` is on
+ * Cold War, so the two themes mean the same thing by the same number.
+ */
+.sheetBody {
+    max-width: 1300px;
+    margin-inline: auto;
+    padding: 30px 44px 38px;
+}
 
 .para { margin-bottom: 40px; }
 .para:last-child { margin-bottom: 0; }

--- a/apps/web/docs/map/g-public-pages.md
+++ b/apps/web/docs/map/g-public-pages.md
@@ -771,6 +771,20 @@ the orders page is still a document you scroll to the end of. Deliberately *not*
 header — no save state, no Publish, no delete menu. Those belong to somebody who has opened the editor, and putting them on a page every member
 can read would be showing controls that either do nothing or should not be there.
 
+**The bar has four themeable seams**, all defaulted to what it has always looked like so a theme
+that passes nothing renders identically. `palette` (a `Record<string, string>` of custom-property
+overrides) arrives as *inline* styles because `.command` sits on the bar element itself — an
+ancestor cannot repaint it, it would only be outranked by the class's own declarations. Three are
+consumed by the bar (`--bar-bg`, `--bar-shadow`, `--bar-edge`; `background` is a shorthand, so an
+inline one would blank out any `background-image` a stylesheet tried to add, which is why it is a
+token and not a prop). The fourth, **`--tab-glow`**, is read by `tabs.module.css` on `.tabOn` and
+`.caret` and defaults to `none` — custom properties inherit, so it reaches the strip without that
+file knowing anything about the theme. Sci-Fi is what it exists for: there the active tab's
+underline is a phosphor rule and has to *emit*, not just be coloured. Themes should pass `var(--...)`
+references rather than literals wherever they already have a token, so the theme's own stylesheet
+stays the one place its palette is written down — see `themes/ColdWarPage.tsx` and
+`themes/SciFiPage.tsx`.
+
 `/operations/[id]/map` serves **both audiences from one path**: the editor's Map tab to anyone
 with `pages.operationsEdit`, and the read-only fullscreen viewer to everyone else. Splitting it
 would mean the link people paste to each other only works for half of them.
@@ -799,13 +813,15 @@ touch. `theme-props.ts` carries the shared `ThemePageProps` (plus `OrdersAttenda
 `ModernPageProps`); themes are pure renderers with no `await`, no `Db`, no `fetchMe`.
 
 - **`ClassicPage.tsx`** — the page as it always looked, lifted out unchanged, now serving
-  `oldfashioned` and `scifi` only. Hero banner, `<SectionNav/>`, `<PageNavClient/>`,
+  `oldfashioned` and anything unrecognised (`wwii`, `vietnam`, `fantasy`) only — `scifi` moved to a
+  page of its own. Hero banner, `<SectionNav/>`, `<PageNavClient/>`,
   `<OperationStatusBar/>`, `<PagedView/>` when `operation.pages.length > 1`, framed sections via
   `<DocBody/>`, `<AttendanceDrawer/>` sidebar, the full-width `<AttendanceBoard/>` beneath, Zeus and
   OCAP tabs. Its `isModern` branches are dead (the dispatch never sends Modern here) and are left in
   place on purpose: pruning them by hand through that many nested ternaries is exactly the edit that
-  silently breaks two themes nobody asked to change. Splitting it into `OldFashionedPage` and
-  `SciFiPage` is the next step, and lets the dead branches fall out on their own.
+  silently breaks two themes nobody asked to change. Its `isSF` branches are now dead the same way —
+  `SciFiPage` took that era over — and stay for the same reason, since this file is also the fallback
+  for any era with no page of its own. `OldFashionedPage` is the last split left to do.
 - **`ModernPage.tsx` + `modern.module.css`** — the rebuild, "**Warning Order**". The reordering *is*
   the design: what a member owes comes above the document rather than beside or below it. A
   `clamp(300px, 38vh, 430px)` cover **band** (not a screen) carrying the operation's lineage —
@@ -845,6 +861,31 @@ touch. `theme-props.ts` carries the shared `ThemePageProps` (plus `OrdersAttenda
   `coldwar` was already a selectable era (`/api/admin/era-options`) with no rendering of its own,
   which is why choosing it used to give you Modern. **`wwii`, `vietnam` and `fantasy` still do** —
   they are offered in the picker and fall through to `ClassicPage`.
+- **`SciFiPage.tsx` + `scifi.module.css` + `ConsoleRail.tsx` + `ConsoleRsvp.tsx`** — the `scifi` era,
+  "**Bridge Console**". The orders as a piece of hardware: a brushed hull, a bezel with screws in it,
+  and behind the bezel a slab of dead-black glass with phosphor burning inside. The whole theme rests
+  on one rule — **the light never leaves the screen**. Glow lives on text and hairlines *inside* the
+  glass; the hull around it is unlit metal, which is the difference between a CRT and a filter laid
+  over a page. Palette **fixed, not the operation's `--acc`**, for Cold War's reason in a different
+  key: a phosphor tube emits one colour, and an operation themed deep red would leave the page
+  glowing in a hue no hardware ever produced. Phosphor green is the tube, amber the second voice for
+  times and headings, red appears exactly once — on an order you have not signed, and it is the only
+  thing that pulses.
+  Two things it does that Modern does not: **the console outlives the document** (title, gauges and
+  the two calls sit on the *screen*, not the open page, so they stay put when you switch documents in
+  the rail — a console's readout does not change because you changed channel), and **encryption
+  instead of a locked banner** (withheld paragraphs render as signal that arrives and fails to
+  resolve, in place — the same call Cold War's strikeouts make, so a reader can see how much is held
+  back and where). `ConsoleRail.tsx` is `OrdersSpine`'s model drawn as an instrument index; the open
+  document is *filled* rather than outlined, because an outline would read as a focus ring and the
+  page already uses one. `ConsoleRsvp.tsx` is the single amber gauge in a green row. Seats also get a
+  ten-segment bar, which answers "nearly full?" at a glance in a way `28 / 34` beside it does not.
+  Motion is one 9s raster sweep and the alarm's pulse, both `display: none` / `animation: none` under
+  `prefers-reduced-motion`, and neither carries meaning the words do not.
+  Inks are **measured against the glass, not eyeballed** — 17.8:1 / 11.1:1 / 6.1:1, with the phosphor
+  at 13.1:1 and amber at 11.0:1. `--ink-3` (every gauge label and rail header, all small uppercase
+  mono at wide tracking) began at #4d6b60, which is 3.4:1 and fails AA outright. The headroom is
+  deliberate: the raster lays a 1-in-3 line of black over everything on the screen.
 **Zeus Notes pages are ordinary documents.** Same sections, same schema, same collaborative editor;
 the only thing that sets one apart is `operations.zeus`, checked two-armed in `page.tsx` (the grant,
 or the legacy `departments.j6` role) and passed to every theme as `canZeus`. Without it the page is
@@ -866,10 +907,10 @@ nothing deletes them.
   the open one's sections nest beneath it as scroll-to buttons with an `IntersectionObserver`
   scroll-spy. The nesting is information, not decoration: "Situation" is *part of* CHQ Orders, not a
   sibling of it, which the old flat document-rail-plus-section-strip pair said otherwise.
-- **`RsvpCell.tsx`** / **`PaperRsvp.tsx`** — the same live cell, drawn by Modern and Cold War
-  respectively. The rules are in **`useRsvpCountdown.ts`**, shared: it polls `live-status` (30s) and
-  ticks its own clock every second in between, and lives in one place so two themes cannot end up
-  disagreeing about the same operation. The old page gave the single most time-critical fact on the
+- **`RsvpCell.tsx`** / **`PaperRsvp.tsx`** / **`ConsoleRsvp.tsx`** — the same live cell, drawn by
+  Modern, Cold War and Sci-Fi respectively. The rules are in **`useRsvpCountdown.ts`**, shared: it
+  polls `live-status` (30s) and ticks its own clock every second in between, and lives in one place
+  so three themes cannot end up disagreeing about the same operation. The old page gave the single most time-critical fact on the
   screen a wide strip at the same weight as everything around it; here it is one cell, and the only
   one carrying the accent.
 
@@ -884,10 +925,16 @@ visitors in both. Public read; `<EditOrdersButton/>` shown to `isHQ`.
 
 #### app/operations/[id]/doc-body.tsx
 Client: renders TipTap ProseMirror JSON as themed HTML (`.op-doc` CSS varies per `pageTheme` —
-`modern` / `oldfashioned` / `scifi` / `coldwar`, the last being **the only light palette on the
-site**, fixed rather than derived from the operation's accent) via `generateHTML` from
-`@tiptap/core`. Used by the single-page view, `PagedView`/`StaffView` and the
-Modern theme.
+`modern` / `oldfashioned` / `scifi`) via `generateHTML` from `@tiptap/core`. Used by the single-page
+view, `PagedView`/`StaffView` and every theme.
+
+**Themes with a page of their own do not use the `pageTheme` prop** — Cold War and Sci-Fi both pass
+nothing (taking the `modern` base) and restate the document's look from their own module with
+`.sheet :global(.op-doc)`. That is not a preference: rules injected from *this* file land at
+`.op-doc`, the same specificity as the base rule in globals.css, so they only win on source order and
+they do not. Invisible while every theme was dark; glaring the moment one was light. The `scifi`
+branch below is consequently dead — `SciFiPage` took that era over — and is kept because this file's
+themes track `ClassicPage`'s, which is still the fallback for any era with no page.
 
 **Its schema is `contentExtensions()` — the editor's own** (`components/editor/content-extensions.ts`),
 and that is not tidiness. This file used to keep a hand-written lookalike beside it, missing

--- a/apps/web/docs/map/g-public-pages.md
+++ b/apps/web/docs/map/g-public-pages.md
@@ -862,11 +862,14 @@ touch. `theme-props.ts` carries the shared `ThemePageProps` (plus `OrdersAttenda
   which is why choosing it used to give you Modern. **`wwii`, `vietnam` and `fantasy` still do** —
   they are offered in the picker and fall through to `ClassicPage`.
 - **`SciFiPage.tsx` + `scifi.module.css` + `ConsoleRail.tsx` + `ConsoleRsvp.tsx`** — the `scifi` era,
-  "**Bridge Console**". The orders as a piece of hardware: a brushed hull, a bezel with screws in it,
-  and behind the bezel a slab of dead-black glass with phosphor burning inside. The whole theme rests
-  on one rule — **the light never leaves the screen**. Glow lives on text and hairlines *inside* the
-  glass; the hull around it is unlit metal, which is the difference between a CRT and a filter laid
-  over a page. Palette **fixed, not the operation's `--acc`**, for Cold War's reason in a different
+  "**Bridge Console**". The orders as a slab of dead-black glass with phosphor burning inside, run to
+  all four edges of the window. The whole theme rests on one rule — **the light never leaves the
+  screen**: glow lives on text and hairlines, never on a frame or a ground, which is the difference
+  between a CRT and a filter laid over a page. It began inside a bezel — brushed hull, rounded
+  corners, screws in each corner — and the frame lost its argument the moment it was seen at size. A
+  bezel is a thing you look *at*; edge to edge the reader is looking *through*. The vignette and the
+  raster carry the tube on their own, and the hardware they were framing only cost the document its
+  width. Palette **fixed, not the operation's `--acc`**, for Cold War's reason in a different
   key: a phosphor tube emits one colour, and an operation themed deep red would leave the page
   glowing in a hue no hardware ever produced. Phosphor green is the tube, amber the second voice for
   times and headings, red appears exactly once — on an order you have not signed, and it is the only


### PR DESCRIPTION
The `scifi` era gets a page of its own instead of `ClassicPage`'s `isSF` variant — the third theme after Modern and Cold War to be rebuilt as its own component rather than a set of ternaries inside a shared one.

**The orders as a slab of dead-black glass with phosphor burning inside**, run to all four edges of the window. One rule holds the whole thing together: *the light never leaves the screen*. Glow lives on text and hairlines, never on a frame or a ground — that's the difference between a CRT and a filter laid over a page, and it's also what keeps a long document readable. Body copy sits on flat near-black at full contrast; only headings, times and alerts emit.

The palette is fixed rather than taking the operation's `--acc`, for Cold War's reason in a different key. A phosphor tube emits one colour — that's what makes it a phosphor tube — and an operation themed deep red would leave the page glowing in a hue no hardware ever produced. Green is the tube, amber the second voice for times and headings, red appears exactly once, on an order you haven't signed, and it's the only thing that pulses.

### Two things it does that Modern doesn't

- **The console outlives the document.** Title, gauges and the two calls sit on the *screen* rather than on the open page, so they stay put when you switch documents in the rail. A console's readout doesn't change because you changed channel.
- **Encryption instead of a locked banner.** Withheld paragraphs render as signal that arrives and fails to resolve, *in place*. Same call Cold War's strikeouts make, and for the same reason: a reader can see how much is held back and where it sits.

### Contrast

Inks measured against the glass rather than eyeballed — 17.8:1, 11.1:1 and 6.1:1, with the phosphor at 13.1:1 and amber at 11.0:1. `--ink-3` is the one that mattered: it's every gauge label and rail header, all small uppercase mono at wide tracking, and it began at `#4d6b60`, which is 3.4:1 and fails AA outright. The headroom is deliberate — the raster lays a line of black over one row in three.

### One shared-code change

`OperationBar` gains a fourth themeable seam, `--tab-glow`: the light the active tab's underline throws. It's read by `tabs.module.css` and **defaults to `transparent`**, so every other theme renders identically — verified on the wire. Custom properties inherit, so a theme sets it through the existing `palette` prop without that file knowing anything about the theme.

It's a background on a pseudo-element rather than a `box-shadow`, and that shape is load-bearing: a box-shadow haloes all four sides, and enough light escaped left and right to draw a hairline down each edge of the tab. It's drawn once by `.tabSlot` rather than once per half, because Orders is a split control and two glows meeting at a seam have no good answer — butted they show a dark hairline, overlapped they stack into a bright one. Hence the single markup change, `tabSlotOn`, which is inert without `--tab-glow`.

### Scope

- **No operation currently uses the era** (496 modern, 1 coldwar), so nothing existing changes.
- `ClassicPage` keeps its `isSF` branches. Nothing routes to them now, but it's still the fallback for `wwii`, `vietnam` and `fantasy`, and deleting a working code path to tidy up is how a fallback stops being one.
- The dispatch in `page.tsx` becomes a lookup rather than a chain of ternaries. Smoke-tested a Modern and the Cold War operation through it — both 200, no regressions.
- `docs/map/g-public-pages.md` updated for the new theme, the bar's seams, and `doc-body`'s now-dead `scifi` branch.

### Checks

`tsc --noEmit` clean, `next lint` clean, 636 tests across 52 files passing. **No local production build** — a dev server was up throughout and `next build` shares its `.next/`; CI covers it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
